### PR TITLE
chore: axios バージョンをピン留めし依存関係を健全化

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -21,7 +21,7 @@
         "@types/react-helmet": "^6.1.11",
         "@types/react-redux": "^7.1.34",
         "@types/react-router-dom": "^5.3.3",
-        "axios": "^0.29.0",
+        "axios": "0.29.0",
         "chart.js": "^3.9.1",
         "class-validator": "^0.14.1",
         "classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -11,5 +11,10 @@
   },
   "devDependencies": {
     "turbo": "^2.8.21"
+  },
+  "pnpm": {
+    "overrides": {
+      "axios": "1.14.0"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  axios: 1.14.0
+
 importers:
 
   .:


### PR DESCRIPTION
## Summary

- `package.json` に `pnpm.overrides` を追加し、workspace 全体の間接依存 axios を `1.14.0` に強制固定（`dbdocs` / `wait-on` 経由の意図しないバージョン混入を防止）
- `client/package.json` の `"^0.29.0"` から `^` を除去し `0.29.0` に直接ピン留め（`client/` は pnpm workspace 外のため個別に対応）

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `package.json` | `pnpm.overrides.axios: "1.14.0"` を追加 |
| `client/package.json` | `"^0.29.0"` → `"0.29.0"` |
| `pnpm-lock.yaml` | overrides 反映によるロックファイル刷新 |

## Test plan

- [x] `pnpm why axios -r` → `axios@1.14.0` のみ、1バージョン確認
- [x] `pnpm build`（@budget/common + @budget/api）→ エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)