### PR TITLE
fix: レポートページにHeaderを追加・middleware認証漏れを修正

### DIFF
--- a/apps/web/src/app/report/page.tsx
+++ b/apps/web/src/app/report/page.tsx
@@ -1,9 +1,12 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { X } from "lucide-react";
 import { getBudgets } from "@/lib/api/budget";
 import { deleteBudgetAction } from "@/lib/actions/budget";
 import { getCategoryById, OUTGO_CATEGORIES } from "@/lib/constants/categories";
 import { PeriodSelector } from "@/components/report/PeriodSelector";
+import { Header } from "@/components/layout/Header";
 import type { BudgetResponse } from "@/lib/api/budget";
 
 export const metadata: Metadata = {
@@ -91,15 +94,15 @@ async function ReportSection({ period }: { period: Period }) {
     <div className="flex flex-col gap-8">
       {/* サマリー */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">支出合計</p>
-          <p className="mt-1 text-xl font-semibold text-red-600 dark:text-red-400">
+        <div className="rounded-xl border border-zinc-100 bg-white p-4">
+          <p className="text-xs text-zinc-500">支出合計</p>
+          <p className="mt-1 text-xl font-semibold" style={{ color: "var(--color-expense)" }}>
             ¥{totalOutgo.toLocaleString()}
           </p>
         </div>
-        <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">収入合計</p>
-          <p className="mt-1 text-xl font-semibold text-emerald-600 dark:text-emerald-400">
+        <div className="rounded-xl border border-zinc-100 bg-white p-4">
+          <p className="text-xs text-zinc-500">収入合計</p>
+          <p className="mt-1 text-xl font-semibold" style={{ color: "var(--color-income)" }}>
             ¥{totalIncome.toLocaleString()}
           </p>
         </div>
@@ -108,10 +111,10 @@ async function ReportSection({ period }: { period: Period }) {
       {/* カテゴリ別バーチャート（支出） */}
       {categoryBreakdown.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+          <h2 className="mb-3 text-sm font-semibold text-zinc-700">
             支出カテゴリ内訳
           </h2>
-          <div className="flex flex-col gap-2 rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
+          <div className="flex flex-col gap-2 rounded-xl border border-zinc-100 bg-white p-4">
             {categoryBreakdown.map((cat) => (
               <div key={cat.name} className="flex flex-col gap-1">
                 <div className="flex justify-between text-sm">
@@ -120,13 +123,13 @@ async function ReportSection({ period }: { period: Period }) {
                       className="inline-block h-2.5 w-2.5 rounded-full"
                       style={{ backgroundColor: cat.color }}
                     />
-                    <span className="text-zinc-700 dark:text-zinc-300">{cat.name}</span>
+                    <span className="text-zinc-700">{cat.name}</span>
                   </span>
-                  <span className="text-zinc-500 dark:text-zinc-400">
+                  <span className="text-zinc-500">
                     ¥{cat.amount.toLocaleString()} ({cat.pct}%)
                   </span>
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-100 dark:bg-zinc-700">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-100">
                   <div
                     className="h-2 rounded-full transition-all"
                     style={{ width: `${cat.pct}%`, backgroundColor: cat.color }}
@@ -140,7 +143,7 @@ async function ReportSection({ period }: { period: Period }) {
 
       {/* 日付別明細 */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold text-zinc-700 dark:text-zinc-300">
+        <h2 className="mb-3 text-sm font-semibold text-zinc-700">
           明細
         </h2>
         <div className="flex flex-col gap-4">
@@ -152,23 +155,23 @@ async function ReportSection({ period }: { period: Period }) {
             return (
               <section key={date}>
                 <div className="mb-2 flex items-center justify-between">
-                  <span className="text-sm font-medium text-zinc-600 dark:text-zinc-400">
+                  <span className="text-sm font-medium text-zinc-600">
                     {date}
                   </span>
                   <div className="flex gap-3 text-sm">
                     {income > 0 && (
-                      <span className="text-emerald-600 dark:text-emerald-400">
+                      <span style={{ color: "var(--color-income)" }}>
                         +¥{income.toLocaleString()}
                       </span>
                     )}
                     {outgo > 0 && (
-                      <span className="text-red-600 dark:text-red-400">
+                      <span style={{ color: "var(--color-expense)" }}>
                         -¥{outgo.toLocaleString()}
                       </span>
                     )}
                   </div>
                 </div>
-                <ul className="divide-y divide-zinc-100 rounded-xl border border-zinc-200 bg-white dark:divide-zinc-800 dark:border-zinc-700 dark:bg-zinc-800">
+                <ul className="divide-y divide-zinc-100 rounded-xl border border-zinc-100 bg-white">
                   {items.map((item) => {
                     const category = getCategoryById(item.balanceType, item.categoryId);
                     const deleteAction = deleteBudgetAction.bind(null, item.id);
@@ -186,7 +189,7 @@ async function ReportSection({ period }: { period: Period }) {
                             />
                           )}
                           <div className="flex flex-col">
-                            <span className="text-sm text-zinc-700 dark:text-zinc-300">
+                            <span className="text-sm text-zinc-700">
                               {category?.name ?? "未分類"}
                             </span>
                             {item.content && (
@@ -196,11 +199,8 @@ async function ReportSection({ period }: { period: Period }) {
                         </div>
                         <div className="flex items-center gap-3">
                           <span
-                            className={`text-sm font-semibold ${
-                              isIncome
-                                ? "text-emerald-600 dark:text-emerald-400"
-                                : "text-red-600 dark:text-red-400"
-                            }`}
+                            className="text-sm font-semibold"
+                            style={{ color: isIncome ? "var(--color-income)" : "var(--color-expense)" }}
                           >
                             {isIncome ? "+" : "-"}¥{item.amount.toLocaleString()}
                           </span>
@@ -208,9 +208,9 @@ async function ReportSection({ period }: { period: Period }) {
                             <button
                               type="submit"
                               aria-label="削除"
-                              className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+                              className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
                             >
-                              ✕
+                              <X size={14} />
                             </button>
                           </form>
                         </div>
@@ -238,28 +238,34 @@ export default async function ReportPage({
       ? rawPeriod
       : "7days";
 
+  const cookieStore = await cookies();
+  const userId = cookieStore.get("user_id")?.value ?? "Guest";
+
   return (
-    <main className="mx-auto max-w-xl px-4 py-8">
-      <div className="mb-6 flex items-center justify-between">
-        <h1 className="text-xl font-bold text-zinc-900 dark:text-zinc-50">
-          レポート
-        </h1>
-        <PeriodSelector />
-      </div>
-      <Suspense
-        fallback={
-          <div className="space-y-4">
-            {[...Array(3)].map((_, i) => (
-              <div
-                key={i}
-                className="h-24 animate-pulse rounded-xl bg-zinc-100 dark:bg-zinc-800"
-              />
-            ))}
-          </div>
-        }
-      >
-        <ReportSection period={period} />
-      </Suspense>
-    </main>
+    <div className="flex min-h-screen flex-col">
+      <Header userName={userId} />
+      <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
+        <div className="mb-6 flex items-center justify-between">
+          <h1 className="text-xl font-bold text-zinc-800">
+            レポート
+          </h1>
+          <PeriodSelector />
+        </div>
+        <Suspense
+          fallback={
+            <div className="flex flex-col gap-4">
+              {[...Array(3)].map((_, i) => (
+                <div
+                  key={i}
+                  className="h-24 animate-pulse rounded-xl bg-zinc-100"
+                />
+              ))}
+            </div>
+          }
+        >
+          <ReportSection period={period} />
+        </Suspense>
+      </main>
+    </div>
   );
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -81,5 +81,5 @@ export async function middleware(request: NextRequest) {
 export const config = {
   // /register, /forgot-password は公開ルートのため除外
   // /settings は認証が必要なため含める
-  matcher: ["/expenses/:path*", "/report/:path*", "/settings", "/settings/:path*", "/analysis", "/analysis/:path*"],
+  matcher: ["/expenses/:path*", "/report", "/report/:path*", "/settings", "/settings/:path*", "/analysis", "/analysis/:path*"],
 };


### PR DESCRIPTION
## 問題

`/report`（日付ごとのレポート一覧）ページは実装済みでHeaderのナビにもリンクが存在していたが、3つの不具合により正常に利用できない状態だった。

## 修正内容

### 1. レポートページにHeaderが存在しない（主要因）
`report/page.tsx` は `<main>` のみ返しており、`<Header>` を含んでいなかった。ホームページから "レポート" リンクをクリックすると遷移はできるが、ナビゲーションバーが消えてしまい、ユーザーが迷子になる状態だった。

→ ホームページと同じパターンで `<Header>` を組み込んだ

### 2. middleware の matcher から `/report` が漏れていた（認証バグ）
`/report/:path*`（サブパス）は含まれていたが `/report`（ルートパス）が未指定だったため、`/report` への直接アクセスで認証チェックが動作しなかった。

→ `/report` を matcher に追加

### 3. デザイン規約違反
- 削除ボタンが `✕` 文字を使用（lucide-react 必須ルール違反）→ `<X size={14} />` に変更
- カラーが `text-red-600` / `text-emerald-600` の直書き → `var(--color-expense)` / `var(--color-income)` に統一
- `dark:` クラス（ダークモード未対応のプロジェクトで不要）を削除

## Test plan

- [ ] ホームページのHeaderで「レポート」をクリックすると `/report` に遷移し、Headerナビが表示される
- [ ] 未ログイン状態で `/report` にアクセスするとログインページにリダイレクトされる
- [ ] 直近7日 / 今月 / 先月の期間切り替えが正しく動作する
- [ ] 日付ごとのグループと金額が正しく表示される
- [ ] 削除ボタン（X アイコン）をクリックするとレコードが削除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)