### PR TITLE
feature: 収支入力専用ページ /expenses/new を新設

### DIFF
--- a/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
@@ -73,6 +73,19 @@ describe('ExpenseCreateForm', () => {
         expect(screen.getByText('登録しました')).toBeInTheDocument()
     })
 
+    it('defaultDate が渡されたとき、日付入力に反映される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseCreateForm userId="user-1" defaultDate="2026-04-13" />)
+
+        const dateInput = screen.getByLabelText('日付') as HTMLInputElement
+        expect(dateInput.defaultValue).toBe('2026-04-13')
+    })
+
     it('isPending=true のとき、ボタンが disabled になる', () => {
         vi.mocked(React.useActionState).mockReturnValue([
             { error: null, success: false },

--- a/apps/web/src/app/expenses/new/page.tsx
+++ b/apps/web/src/app/expenses/new/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { Header } from "@/components/layout/Header";
+import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
+
+export const metadata: Metadata = {
+  title: "収支を記録する | 家計管理",
+};
+
+type Props = {
+  searchParams: Promise<{ date?: string }>;
+};
+
+export default async function ExpenseNewPage({ searchParams }: Props) {
+  const cookieStore = await cookies();
+  const userId = cookieStore.get("user_id")?.value;
+  if (!userId) redirect("/login");
+
+  const { date } = await searchParams;
+  // YYYY-MM-DD 形式以外は無視する
+  const defaultDate = date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-[var(--color-surface-subtle)]">
+      <Header userName={userId} />
+      <main className="mx-auto w-full max-w-lg flex-1 px-4 py-8">
+        <ExpenseCreateForm userId={userId} defaultDate={defaultDate} />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/MonthlyCalendar.tsx
+++ b/apps/web/src/components/calendar/MonthlyCalendar.tsx
@@ -109,8 +109,8 @@ export function MonthlyCalendar({ expenses }: Props) {
 
   const handleDayClick = (day: DayData) => {
     if (!day.isCurrentMonth) return;
-    // クリックした日付をクエリパラメータで渡してフォームへ
-    router.push(`/?date=${day.dateStr}#form`);
+    // クリックした日付をクエリパラメータで渡して入力ページへ
+    router.push(`/expenses/new?date=${day.dateStr}`);
   };
 
   return (

--- a/apps/web/src/components/expense/ExpenseCreateForm.tsx
+++ b/apps/web/src/components/expense/ExpenseCreateForm.tsx
@@ -8,6 +8,8 @@ import { getCategoriesByType } from "@/lib/constants/categories";
 type Props = {
   /** ログイン中のユーザー ID */
   userId: string;
+  /** 初期表示する日付（YYYY-MM-DD 形式。省略時は今日） */
+  defaultDate?: string;
 };
 
 const initialState: ExpenseActionState = { error: null, success: false };
@@ -19,7 +21,7 @@ function FieldError({ messages }: { messages?: string[] }) {
   );
 }
 
-export function ExpenseCreateForm({ userId }: Props) {
+export function ExpenseCreateForm({ userId, defaultDate }: Props) {
   const [balanceType, setBalanceType] = useState<0 | 1>(0);
   const [state, formAction, isPending] = useActionState(
     createExpenseAction,
@@ -89,7 +91,7 @@ export function ExpenseCreateForm({ userId }: Props) {
               name="date"
               type="date"
               required
-              defaultValue={new Date().toISOString().split("T")[0]}
+              defaultValue={defaultDate ?? new Date().toISOString().split("T")[0]}
               className="flex-1 bg-transparent text-sm outline-none"
             />
             <svg className="h-4 w-4 shrink-0 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: "ホーム", href: "/" },
   { label: "カレンダー", href: "/calendar" },
   { label: "レポート", href: "/report" },
-  { label: "入力", href: "/#form" },
+  { label: "記録する", href: "/expenses/new" },
 ];
 
 type Props = {


### PR DESCRIPTION
## Summary

- カレンダーの日付クリックが `/?date=2026-04-13#form` という非標準URLに遷移していた問題を解消
- ヘッダーの「入力」メニューがホームページのアンカーリンクになっていた問題を解消
- 収支入力専用ページ `/expenses/new` を新設

## 変更内容

| Before | After |
|--------|-------|
| カレンダー日付クリック → `/?date=2026-04-13#form` | → `/expenses/new?date=2026-04-13` |
| ヘッダー「入力」リンク → `/#form` | 「記録する」リンク → `/expenses/new` |

### 新規ファイル
- `apps/web/src/app/expenses/new/page.tsx`: 入力専用ページ（`?date` を受け取り日付を初期セット）

### 変更ファイル
- `ExpenseCreateForm`: `defaultDate` prop 追加
- `MonthlyCalendar`: クリック遷移先を `/expenses/new?date=...` に変更
- `Header`: ナビ「入力」→「記録する」、リンク先を `/expenses/new` に変更

ホームの ExpenseCreateForm はプロダクト・アイデンティティとして維持（即時入力できる設計）

## Test plan
- [ ] カレンダーの日付クリック → `/expenses/new?date=YYYY-MM-DD` に遷移し、日付が入力済みであること
- [ ] ヘッダー「記録する」クリック → `/expenses/new` に遷移すること
- [ ] ホームページの入力フォームが引き続き表示されること
- [ ] 未認証状態で `/expenses/new` にアクセスするとログイン画面にリダイレクトされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)