### PR TITLE
feature: /expenses/new 専用入力ページと旧Reactアプリ互換UIの新設

### DIFF
--- a/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
@@ -73,6 +73,19 @@ describe('ExpenseCreateForm', () => {
         expect(screen.getByText('登録しました')).toBeInTheDocument()
     })
 
+    it('defaultDate が渡されたとき、日付入力に反映される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseCreateForm userId="user-1" defaultDate="2026-04-13" />)
+
+        const dateInput = screen.getByLabelText('日付') as HTMLInputElement
+        expect(dateInput.defaultValue).toBe('2026-04-13')
+    })
+
     it('isPending=true のとき、ボタンが disabled になる', () => {
         vi.mocked(React.useActionState).mockReturnValue([
             { error: null, success: false },

--- a/apps/web/src/__tests__/components/ExpenseNewForm.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseNewForm.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { ExpenseNewForm } from '../../components/expense/ExpenseNewForm'
+
+// Server Actionをモック
+vi.mock('@/lib/actions/expense', () => ({
+    createExpenseAction: vi.fn(),
+}))
+
+// ESM環境ではvi.spyOnは不可。vi.mockでuseActionStateをモックする
+vi.mock('react', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react')>()
+    return {
+        ...actual,
+        useActionState: vi.fn(),
+    }
+})
+
+describe('ExpenseNewForm', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('初期表示: フォームが描画される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        expect(screen.getByLabelText('金額')).toBeInTheDocument()
+        expect(screen.getByLabelText('日付')).toBeInTheDocument()
+        expect(screen.getByLabelText('内容')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: '追加する' })).toBeInTheDocument()
+    })
+
+    it('初期表示: カテゴリボタングリッドが表示される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        // 支出カテゴリの「食費」が表示される
+        expect(screen.getByRole('button', { name: '食費' })).toBeInTheDocument()
+        // 支出カテゴリの「未分類」が表示される
+        expect(screen.getByRole('button', { name: '未分類' })).toBeInTheDocument()
+    })
+
+    it('スライドタブをクリックすると収入カテゴリに切り替わる', async () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        const tab = screen.getByRole('switch')
+        await userEvent.click(tab)
+
+        // 収入カテゴリの「給料」が表示される
+        expect(screen.getByRole('button', { name: '給料' })).toBeInTheDocument()
+        // 支出カテゴリの「食費」が非表示になる
+        expect(screen.queryByRole('button', { name: '食費' })).not.toBeInTheDocument()
+    })
+
+    it('カテゴリボタンをクリックすると選択状態になる', async () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        const shokuhi = screen.getByRole('button', { name: '食費' })
+        await userEvent.click(shokuhi)
+
+        // 選択されたボタンはブランドカラーのクラスを持つ
+        expect(shokuhi.className).toContain('bg-[var(--color-brand-primary)]')
+    })
+
+    it('fieldErrors.amount があるとき、エラーメッセージを表示する', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false, fieldErrors: { amount: ['金額は1以上の値を入力してください'] } },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        expect(screen.getByText('金額は1以上の値を入力してください')).toBeInTheDocument()
+    })
+
+    it('state.error があるとき、エラーメッセージを表示する', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: 'サーバーエラーが発生しました', success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        expect(screen.getByText('サーバーエラーが発生しました')).toBeInTheDocument()
+    })
+
+    it('state.success=true のとき、成功メッセージを表示する', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: true },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        expect(screen.getByText('登録しました')).toBeInTheDocument()
+    })
+
+    it('defaultDate が渡されたとき、日付入力に反映される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" defaultDate="2026-04-13" />)
+
+        const dateInput = screen.getByLabelText('日付') as HTMLInputElement
+        expect(dateInput.defaultValue).toBe('2026-04-13')
+    })
+
+    it('isPending=true のとき、ボタンが disabled になる', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            true,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseNewForm userId="user-1" />)
+
+        const button = screen.getByRole('button', { name: '登録中...' })
+        expect(button).toBeDisabled()
+    })
+})

--- a/apps/web/src/app/expenses/new/page.tsx
+++ b/apps/web/src/app/expenses/new/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Header } from "@/components/layout/Header";
-import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
+import { ExpenseNewForm } from "@/components/expense/ExpenseNewForm";
 
 export const metadata: Metadata = {
   title: "収支を記録する | 家計管理",
@@ -25,7 +25,7 @@ export default async function ExpenseNewPage({ searchParams }: Props) {
     <div className="flex min-h-screen flex-col bg-[var(--color-surface-subtle)]">
       <Header userName={userId} />
       <main className="mx-auto w-full max-w-lg flex-1 px-4 py-8">
-        <ExpenseCreateForm userId={userId} defaultDate={defaultDate} />
+        <ExpenseNewForm userId={userId} defaultDate={defaultDate} />
       </main>
     </div>
   );

--- a/apps/web/src/app/expenses/new/page.tsx
+++ b/apps/web/src/app/expenses/new/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { Header } from "@/components/layout/Header";
+import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
+
+export const metadata: Metadata = {
+  title: "収支を記録する | 家計管理",
+};
+
+type Props = {
+  searchParams: Promise<{ date?: string }>;
+};
+
+export default async function ExpenseNewPage({ searchParams }: Props) {
+  const cookieStore = await cookies();
+  const userId = cookieStore.get("user_id")?.value;
+  if (!userId) redirect("/login");
+
+  const { date } = await searchParams;
+  // YYYY-MM-DD 形式以外は無視する
+  const defaultDate = date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined;
+
+  return (
+    <div className="flex min-h-screen flex-col bg-[var(--color-surface-subtle)]">
+      <Header userName={userId} />
+      <main className="mx-auto w-full max-w-lg flex-1 px-4 py-8">
+        <ExpenseCreateForm userId={userId} defaultDate={defaultDate} />
+      </main>
+    </div>
+  );
+}

--- a/apps/web/src/components/calendar/MonthlyCalendar.tsx
+++ b/apps/web/src/components/calendar/MonthlyCalendar.tsx
@@ -109,8 +109,8 @@ export function MonthlyCalendar({ expenses }: Props) {
 
   const handleDayClick = (day: DayData) => {
     if (!day.isCurrentMonth) return;
-    // クリックした日付をクエリパラメータで渡してフォームへ
-    router.push(`/?date=${day.dateStr}#form`);
+    // クリックした日付をクエリパラメータで渡して入力ページへ
+    router.push(`/expenses/new?date=${day.dateStr}`);
   };
 
   return (

--- a/apps/web/src/components/expense/ExpenseCreateForm.tsx
+++ b/apps/web/src/components/expense/ExpenseCreateForm.tsx
@@ -8,6 +8,8 @@ import { getCategoriesByType } from "@/lib/constants/categories";
 type Props = {
   /** ログイン中のユーザー ID */
   userId: string;
+  /** 初期表示する日付（YYYY-MM-DD 形式。省略時は今日） */
+  defaultDate?: string;
 };
 
 const initialState: ExpenseActionState = { error: null, success: false };
@@ -19,7 +21,7 @@ function FieldError({ messages }: { messages?: string[] }) {
   );
 }
 
-export function ExpenseCreateForm({ userId }: Props) {
+export function ExpenseCreateForm({ userId, defaultDate }: Props) {
   const [balanceType, setBalanceType] = useState<0 | 1>(0);
   const [state, formAction, isPending] = useActionState(
     createExpenseAction,
@@ -89,7 +91,7 @@ export function ExpenseCreateForm({ userId }: Props) {
               name="date"
               type="date"
               required
-              defaultValue={new Date().toISOString().split("T")[0]}
+              defaultValue={defaultDate ?? new Date().toISOString().split("T")[0]}
               className="flex-1 bg-transparent text-sm outline-none"
             />
             <svg className="h-4 w-4 shrink-0 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">

--- a/apps/web/src/components/expense/ExpenseNewForm.tsx
+++ b/apps/web/src/components/expense/ExpenseNewForm.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { createExpenseAction } from "@/lib/actions/expense";
+import type { ExpenseActionState } from "@/lib/actions/expense";
+import { getCategoriesByType } from "@/lib/constants/categories";
+
+type Props = {
+  /** ログイン中のユーザー ID */
+  userId: string;
+  /** 初期表示する日付（YYYY-MM-DD 形式。省略時は今日） */
+  defaultDate?: string;
+};
+
+const initialState: ExpenseActionState = { error: null, success: false };
+
+function FieldError({ messages }: { messages?: string[] }) {
+  if (!messages?.length) return null;
+  return (
+    <p className="mt-1 text-xs text-[var(--color-expense)]">{messages[0]}</p>
+  );
+}
+
+export function ExpenseNewForm({ userId, defaultDate }: Props) {
+  const [balanceType, setBalanceType] = useState<0 | 1>(0);
+  const [categoryId, setCategoryId] = useState(0);
+  const [state, formAction, isPending] = useActionState(
+    createExpenseAction,
+    initialState,
+  );
+  const categories = getCategoriesByType(balanceType);
+
+  const toggleType = () => {
+    const next: 0 | 1 = balanceType === 0 ? 1 : 0;
+    setBalanceType(next);
+    setCategoryId(0);
+  };
+
+  return (
+    <section className="rounded-xl border border-zinc-100 bg-white p-6 shadow-sm">
+      <h2 className="mb-4 text-center text-sm font-semibold text-zinc-700">
+        収支の入力
+      </h2>
+
+      {/* スライドタブ（支出 / 収入） */}
+      <button
+        type="button"
+        role="switch"
+        aria-checked={balanceType === 1}
+        aria-label={balanceType === 0 ? "支出" : "収入"}
+        onClick={toggleType}
+        className="relative mx-auto mb-8 block h-12 w-[200px] cursor-pointer"
+      >
+        {/* 背景レール */}
+        <span className="absolute inset-0 flex overflow-hidden rounded border border-zinc-300 bg-zinc-100">
+          <span className="flex flex-1 items-center justify-center text-sm text-[var(--color-brand-primary)]">
+            支出
+          </span>
+          <span className="flex flex-1 items-center justify-center text-sm text-[var(--color-brand-primary)]">
+            収入
+          </span>
+        </span>
+        {/* スライドするサークル */}
+        <span
+          className={[
+            "absolute top-[4px] flex h-[calc(100%-8px)] w-[calc(50%-4px)] items-center justify-center rounded bg-[var(--color-brand-primary)] text-sm font-medium text-white transition-all duration-200",
+            balanceType === 0 ? "left-[4px]" : "left-[50%]",
+          ].join(" ")}
+        >
+          {balanceType === 0 ? "支出" : "収入"}
+        </span>
+      </button>
+
+      <form action={formAction}>
+        <input type="hidden" name="userId" value={userId} />
+        <input type="hidden" name="balanceType" value={balanceType} />
+        <input type="hidden" name="categoryId" value={categoryId} />
+
+        {/* 2カラムレイアウト（モバイルは1カラム） */}
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {/* 左カラム: 日付・金額・内容 */}
+          <div>
+            {/* 日付 */}
+            <div className="flex items-center border-b border-zinc-200 py-3">
+              <label
+                htmlFor="date"
+                className="w-12 shrink-0 text-xs text-zinc-500"
+              >
+                日付
+              </label>
+              <input
+                id="date"
+                name="date"
+                type="date"
+                required
+                defaultValue={defaultDate ?? new Date().toISOString().split("T")[0]}
+                className="flex-1 bg-transparent text-sm outline-none"
+              />
+            </div>
+            <FieldError messages={state.fieldErrors?.date} />
+
+            {/* 金額 */}
+            <div className="flex items-center border-b border-zinc-200 py-3">
+              <label
+                htmlFor="amount"
+                className="w-12 shrink-0 text-xs text-zinc-500"
+              >
+                金額
+              </label>
+              <input
+                id="amount"
+                name="amount"
+                type="number"
+                min={1}
+                required
+                placeholder="金額をご入力ください"
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-400"
+              />
+            </div>
+            <FieldError messages={state.fieldErrors?.amount} />
+
+            {/* 内容 */}
+            <div className="flex items-center border-b border-zinc-200 py-3">
+              <label
+                htmlFor="content"
+                className="w-12 shrink-0 text-xs text-zinc-500"
+              >
+                内容
+              </label>
+              <input
+                id="content"
+                name="content"
+                type="text"
+                placeholder="内容をご入力ください（任意）"
+                className="flex-1 bg-transparent text-sm outline-none placeholder:text-zinc-400"
+              />
+            </div>
+          </div>
+
+          {/* 右カラム: カテゴリボタングリッド */}
+          <div>
+            <p className="mb-2 text-xs text-zinc-500">カテゴリ</p>
+            <div className="grid grid-cols-3 gap-2">
+              {categories.map((cat) => (
+                <button
+                  key={cat.id}
+                  type="button"
+                  onClick={() => setCategoryId(cat.id)}
+                  className={[
+                    "rounded border py-3 text-xs font-medium transition-colors",
+                    categoryId === cat.id
+                      ? "border-[var(--color-brand-primary)] bg-[var(--color-brand-primary)] text-white"
+                      : "border-zinc-200 bg-white hover:border-[var(--color-brand-primary)] hover:bg-[var(--color-brand-primary)] hover:text-white",
+                  ].join(" ")}
+                  style={categoryId !== cat.id ? { color: cat.color } : undefined}
+                >
+                  {cat.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {state.error && (
+          <p className="mt-4 rounded-lg bg-[var(--color-expense-light)] px-3 py-2 text-sm text-[var(--color-expense)]">
+            {state.error}
+          </p>
+        )}
+        {state.success && (
+          <p className="mt-4 rounded-lg bg-[var(--color-income-light)] px-3 py-2 text-sm text-[var(--color-income)]">
+            登録しました
+          </p>
+        )}
+
+        <div className="mt-6 flex justify-center">
+          <button
+            type="submit"
+            disabled={isPending}
+            className="w-60 rounded-full bg-[var(--color-brand-primary)] py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+          >
+            {isPending ? "登録中..." : "追加する"}
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -13,7 +13,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: "ホーム", href: "/" },
   { label: "カレンダー", href: "/calendar" },
   { label: "レポート", href: "/report" },
-  { label: "入力", href: "/#form" },
+  { label: "記録する", href: "/expenses/new" },
 ];
 
 type Props = {


### PR DESCRIPTION
## Summary

- カレンダーの日付クリック先を `/?date=...#form` から `/expenses/new?date=...` に変更
- ヘッダーの「入力」リンクを「記録する」→ `/expenses/new` に変更
- `/expenses/new` 専用の `ExpenseNewForm` コンポーネントを新規作成
  - スライドタブ（支出/収入 を CSS transition で切替）
  - 2カラムレイアウト（左列: 日付・金額・内容 / 右列: カテゴリボタングリッド）
  - カテゴリを3列ボタングリッドで表示（選択時はブランドカラー背景）
  - ラベル左固定幅 + 入力右伸縮のフィールドレイアウト（旧Reactアプリ `/edit` と同等）
- ホームページの `ExpenseCreateForm` はクイック入力用として変更なし

## Test plan

- [ ] `pnpm test:unit` — 全50テストパス
- [ ] `/expenses/new` を直接開いて、スライドタブ・カテゴリグリッドが表示されることを確認
- [ ] カレンダーの日付をクリックして `/expenses/new?date=YYYY-MM-DD` に遷移し、日付が反映されることを確認
- [ ] 支出/収入タブを切り替えてカテゴリが変わることを確認
- [ ] フォーム送信が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)