### PR TITLE
style: Playful Geometric デザインシステム全面適用（Refined Edition）

### DIFF
--- a/apps/web/src/__tests__/components/ExpenseList.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseList.test.tsx
@@ -54,7 +54,8 @@ describe('ExpenseList', () => {
     describe('支出リストの表示', () => {
         it('金額が「¥1,000」形式でフォーマットされて表示される', () => {
             render(<ExpenseList expenses={[buildExpense({ amount: 1000 })]} />);
-            expect(screen.getByText('¥1,000')).toBeInTheDocument();
+            // 支出（balanceType=0）は「-¥」プレフィックス付きで表示される
+            expect(screen.getByText('-¥1,000')).toBeInTheDocument();
         });
 
         it('日付が表示される', () => {
@@ -91,9 +92,10 @@ describe('ExpenseList', () => {
             ];
             render(<ExpenseList expenses={expenses} />);
 
-            expect(screen.getByText('¥500')).toBeInTheDocument();
-            expect(screen.getByText('¥2,000')).toBeInTheDocument();
-            expect(screen.getByText('¥3,000')).toBeInTheDocument();
+            // 支出（balanceType=0）は「-¥」プレフィックス付きで表示される
+            expect(screen.getByText('-¥500')).toBeInTheDocument();
+            expect(screen.getByText('-¥2,000')).toBeInTheDocument();
+            expect(screen.getByText('-¥3,000')).toBeInTheDocument();
         });
     });
 
@@ -116,12 +118,12 @@ describe('ExpenseList', () => {
     describe('エッジケース', () => {
         it('金額が 1 円（最小値）でも正しく表示される', () => {
             render(<ExpenseList expenses={[buildExpense({ amount: 1 })]} />);
-            expect(screen.getByText('¥1')).toBeInTheDocument();
+            expect(screen.getByText('-¥1')).toBeInTheDocument();
         });
 
         it('金額が大きい数値でも桁区切りでフォーマットされる', () => {
             render(<ExpenseList expenses={[buildExpense({ amount: 1000000 })]} />);
-            expect(screen.getByText('¥1,000,000')).toBeInTheDocument();
+            expect(screen.getByText('-¥1,000,000')).toBeInTheDocument();
         });
 
         it('未来日付のエントリも正常に表示される', () => {

--- a/apps/web/src/__tests__/components/PeriodSelector.test.tsx
+++ b/apps/web/src/__tests__/components/PeriodSelector.test.tsx
@@ -41,22 +41,22 @@ describe('PeriodSelector', () => {
         it('period パラメータが未指定のとき「直近7日」がアクティブスタイルになる', () => {
             render(<PeriodSelector />);
             const activeBtn = screen.getByRole('button', { name: '直近7日' });
-            // アクティブスタイルのクラス（bg-zinc-900）が適用されている
-            expect(activeBtn.className).toContain('bg-zinc-900');
+            // アクティブスタイルのクラス（bg-[#f18840]）が適用されている
+            expect(activeBtn.className).toContain('bg-[#f18840]');
         });
 
         it('period=current-month のとき「今月」がアクティブスタイルになる', () => {
             mockSearchParams.set('period', 'current-month');
             render(<PeriodSelector />);
             const activeBtn = screen.getByRole('button', { name: '今月' });
-            expect(activeBtn.className).toContain('bg-zinc-900');
+            expect(activeBtn.className).toContain('bg-[#f18840]');
         });
 
         it('period=last-month のとき「先月」がアクティブスタイルになる', () => {
             mockSearchParams.set('period', 'last-month');
             render(<PeriodSelector />);
             const activeBtn = screen.getByRole('button', { name: '先月' });
-            expect(activeBtn.className).toContain('bg-zinc-900');
+            expect(activeBtn.className).toContain('bg-[#f18840]');
         });
     });
 

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -31,7 +31,7 @@ async function CalendarContent() {
   return (
     <>
       <Header userName={userId} />
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6">
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 bg-[#fffdf5]">
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_3fr]">
           {/* 左カラム：今日のレポート + 入力フォーム */}
           <div className="flex flex-col gap-4">
@@ -49,10 +49,10 @@ async function CalendarContent() {
 
 export default function CalendarPage() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
       <Suspense
         fallback={
-          <div className="flex flex-1 items-center justify-center text-sm text-zinc-400">
+          <div className="flex flex-1 items-center justify-center text-sm font-medium text-[#1c1410]/40">
             読み込み中...
           </div>
         }

--- a/apps/web/src/app/expenses/new/page.tsx
+++ b/apps/web/src/app/expenses/new/page.tsx
@@ -22,7 +22,7 @@ export default async function ExpenseNewPage({ searchParams }: Props) {
   const defaultDate = date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined;
 
   return (
-    <div className="flex min-h-screen flex-col bg-[var(--color-surface-subtle)]">
+    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
       <Header userName={userId} />
       <main className="mx-auto w-full max-w-lg flex-1 px-4 py-8">
         <ExpenseCreateForm userId={userId} defaultDate={defaultDate} />

--- a/apps/web/src/app/expenses/page.tsx
+++ b/apps/web/src/app/expenses/page.tsx
@@ -34,22 +34,31 @@ async function ExpenseListSection() {
     <div className="flex flex-col gap-4">
       {/* サマリー */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">支出合計</p>
-          <p className="mt-1 text-xl font-semibold text-red-600 dark:text-red-400">
+        <div
+          className="rounded-2xl border border-[#1c1410]/12 bg-white p-4"
+          style={{ boxShadow: "var(--shadow-card)" }}
+        >
+          <p className="text-xs font-bold text-[#1c1410]/50">支出合計</p>
+          <p className="mt-1 text-xl font-extrabold tabular-nums" style={{ color: "var(--color-expense)" }}>
             ¥{totalOutgo.toLocaleString()}
           </p>
         </div>
-        <div className="rounded-xl border border-zinc-200 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-800">
-          <p className="text-xs text-zinc-500 dark:text-zinc-400">収入合計</p>
-          <p className="mt-1 text-xl font-semibold text-emerald-600 dark:text-emerald-400">
+        <div
+          className="rounded-2xl border border-[#1c1410]/12 bg-white p-4"
+          style={{ boxShadow: "var(--shadow-card)" }}
+        >
+          <p className="text-xs font-bold text-[#1c1410]/50">収入合計</p>
+          <p className="mt-1 text-xl font-extrabold tabular-nums" style={{ color: "var(--color-income)" }}>
             ¥{totalIncome.toLocaleString()}
           </p>
         </div>
       </div>
 
       {/* 支出リスト */}
-      <div className="rounded-xl border border-zinc-200 bg-white px-4 dark:border-zinc-700 dark:bg-zinc-800">
+      <div
+        className="rounded-2xl border border-[#1c1410]/12 bg-white px-4"
+        style={{ boxShadow: "var(--shadow-card)" }}
+      >
         <ExpenseList expenses={expenses} />
       </div>
     </div>
@@ -61,16 +70,14 @@ export default function ExpensesPage() {
   const userId = "Guest";
 
   return (
-    <div className="mx-auto flex min-h-screen w-full max-w-2xl flex-col gap-6 px-4 py-8">
-      <header className="flex items-center justify-between">
-        <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-          家計管理
+    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
+      <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-8">
+      <header className="flex items-center justify-between mb-6">
+        <h1 className="text-2xl font-extrabold text-[#1c1410]">
+          支出一覧
         </h1>
         <form action={logoutAction}>
-          <button
-            type="submit"
-            className="rounded-full border border-zinc-300 px-4 py-1.5 text-sm text-zinc-600 transition-colors hover:bg-zinc-100 dark:border-zinc-600 dark:text-zinc-400 dark:hover:bg-zinc-700"
-          >
+          <button type="submit" className="btn-ghost text-xs px-3 py-1.5">
             ログアウト
           </button>
         </form>
@@ -82,13 +89,14 @@ export default function ExpensesPage() {
       {/* 支出一覧（Server Component + Suspense でストリーミング） */}
       <Suspense
         fallback={
-          <div className="py-12 text-center text-sm text-zinc-400">
+          <div className="py-12 text-center text-sm font-medium text-[#1c1410]/40">
             読み込み中...
           </div>
         }
       >
         <ExpenseListSection />
       </Suspense>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -13,14 +13,18 @@
 /* @generated:start by scripts/sync-tokens.ts */
 :root {
   /* カラートークン */
-  --color-brand-primary: #f08030;
-  --color-brand-secondary: #e06020;
+  --color-brand-primary: #f18840;
+  --color-brand-secondary: #e07030;
   --color-surface-default: #ffffff;
-  --color-surface-subtle: #fef5ee;
-  --color-expense: #f08030;
-  --color-expense-light: #fff5ec;
-  --color-income: #2bb5a0;
+  --color-surface-subtle: #fffdf5;
+  --color-expense: #f18840;
+  --color-expense-light: #fff6ee;
+  --color-income: #35b5a2;
   --color-income-light: #ecfaf8;
+  --color-playful-coral: #f87171;
+  --color-playful-coral-light: #fee2e2;
+  --color-playful-amber: #fbbf24;
+  --color-playful-amber-light: #fef3c7;
   /* スペーシングトークン */
   --spacing-xs: 4px;
   --spacing-sm: 8px;
@@ -29,17 +33,37 @@
   --spacing-xl: 32px;
   /* ボーダー半径トークン */
   --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-card: 12px;
+  --radius-md: 12px;
+  --radius-card: 16px;
+  --radius-lg: 20px;
+  --radius-xl: 24px;
   --radius-full: 9999px;
 }
 /* @generated:end */
 
 /* ── 手動管理: @generated に含まれない静的トークン ──────────────── */
 :root {
-  /* スクリーンショットのウォームベージュ背景 */
-  --background: #fef5ee;
-  --foreground: #1a1a1a;
+  /* ベースカラー（ウォームクリーム背景 / ディープウォームブラウン前景） */
+  --background: #fffdf5;
+  --foreground: #1c1410;
+
+  /* ボーダー */
+  --border-default: #e8c8b0;
+  --border-strong: #1c1410;
+
+  /* Soft Pop シャドウ（Refined Edition）
+   *  高優先UI（ボタン・モーダル）: 2px offset hard shadow
+   *  中優先カード: subtle soft shadow のみ
+   *  低優先ブロック: シャドウなし（bg差のみ）
+   */
+  --shadow-pop-sm: 1px 1px 0px 0px #1c1410;
+  --shadow-pop:    2px 2px 0px 0px #1c1410;
+  --shadow-pop-lg: 3px 3px 0px 0px #1c1410;
+  --shadow-card:   0 1px 4px 0 rgba(28, 20, 16, 0.07), 0 0 0 1px rgba(28, 20, 16, 0.06);
+  --shadow-card-hover: 0 4px 12px 0 rgba(28, 20, 16, 0.10), 0 0 0 1px rgba(28, 20, 16, 0.08);
+
+  /* モーションイージング（Material You: Emphasized） */
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
 }
 
 /* ── ダークモード オーバーライド ────────────────────────────────── */
@@ -48,16 +72,30 @@
     --background: #1a1008;
     --foreground: #f0ebe5;
 
-    --color-brand-primary: #f09050;
-    --color-brand-secondary: #e07040;
+    --border-default: #4a3020;
+    --border-strong: #f0ebe5;
+
+    --shadow-pop-sm: 1px 1px 0px 0px #f0ebe5;
+    --shadow-pop:    2px 2px 0px 0px #f0ebe5;
+    --shadow-pop-lg: 3px 3px 0px 0px #f0ebe5;
+    --shadow-card:   0 1px 4px 0 rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.06);
+    --shadow-card-hover: 0 4px 12px 0 rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.08);
+
+    --color-brand-primary: #f29050;
+    --color-brand-secondary: #e07840;
 
     --color-surface-default: #241a10;
     --color-surface-subtle: #2e2418;
 
-    --color-expense: #f09050;
+    --color-expense: #f29050;
     --color-expense-light: #3a1a08;
     --color-income: #3dc8b4;
     --color-income-light: #082e28;
+
+    --color-playful-coral: #f87171;
+    --color-playful-coral-light: #3a1010;
+    --color-playful-amber: #fbbf24;
+    --color-playful-amber-light: #3a2a00;
   }
 }
 
@@ -79,12 +117,79 @@
   --color-income: var(--color-income);
   --color-income-light: var(--color-income-light);
 
-  --font-sans: var(--font-geist-sans);
+  --color-playful-coral: var(--color-playful-coral);
+  --color-playful-coral-light: var(--color-playful-coral-light);
+  --color-playful-amber: var(--color-playful-amber);
+  --color-playful-amber-light: var(--color-playful-amber-light);
+
+  --font-sans: var(--font-outfit);
+  --font-display: var(--font-outfit);
   --font-mono: var(--font-geist-mono);
+}
+
+/* ── Refined Geometric コンポーネントパターン ────────────────────
+ *
+ *  情報優先度による使い分け:
+ *  高（メインボタン）: .btn-candy  — オレンジ + 2px ハードシャドウ
+ *  中（カード）      : .card-pop   — soft shadow + 1px ボーダー
+ *  低（背景要素）    : トーン差のみ（ボーダー・シャドウなし）
+ *
+   ──────────────────────────────────────────────────────────── */
+@layer components {
+  /* 中優先カード — soft shadow + 1px ボーダー（pop offset なし） */
+  .card-pop {
+    @apply bg-white rounded-2xl p-6;
+    border: 1px solid rgba(28, 20, 16, 0.12);
+    box-shadow: var(--shadow-card);
+    transition: box-shadow 0.2s var(--ease-standard);
+  }
+  .card-pop:hover {
+    box-shadow: var(--shadow-card-hover);
+  }
+
+  /* 高優先プライマリボタン — オレンジ + 2px ハードシャドウ */
+  .btn-candy {
+    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm text-white bg-[#f18840] border-2 border-[#1c1410] cursor-pointer select-none;
+    box-shadow: var(--shadow-pop);
+    transition: transform 0.2s var(--ease-standard), box-shadow 0.2s var(--ease-standard);
+  }
+  .btn-candy:hover {
+    transform: translate(-1px, -1px);
+    box-shadow: var(--shadow-pop-lg);
+  }
+  .btn-candy:active {
+    transform: translate(1px, 1px);
+    box-shadow: none;
+  }
+
+  /* セカンダリボタン — 1px ボーダー + ホバーでbg変化（シャドウなし） */
+  .btn-ghost {
+    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm bg-white cursor-pointer select-none text-[#1c1410];
+    border: 1px solid rgba(28, 20, 16, 0.25);
+    transition: background-color 0.2s var(--ease-standard), border-color 0.2s var(--ease-standard);
+  }
+  .btn-ghost:hover {
+    background-color: #fff6ee;
+    border-color: rgba(28, 20, 16, 0.40);
+  }
+  .btn-ghost:active {
+    background-color: #fff6ee;
+  }
+
+  /* 入力フィールド — フォーカス時にオレンジリング */
+  .input-pop {
+    @apply w-full rounded-xl bg-white px-3 py-2 text-sm outline-none;
+    border: 1px solid rgba(28, 20, 16, 0.18);
+    transition: border-color 0.2s var(--ease-standard), box-shadow 0.2s var(--ease-standard);
+  }
+  .input-pop:focus {
+    border-color: #f18840;
+    box-shadow: 0 0 0 3px rgba(241, 136, 64, 0.14);
+  }
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-outfit), "Outfit", sans-serif;
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Outfit } from "next/font/google";
+import { Geist_Mono } from "next/font/google";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const outfit = Outfit({
+  variable: "--font-outfit",
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700", "800"],
 });
 
 const geistMono = Geist_Mono({
@@ -28,7 +30,7 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${outfit.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">{children}</body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -72,7 +72,7 @@ async function DashboardContent() {
   return (
     <>
       <Header userName={userId} />
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6">
+      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 bg-[#fffdf5]">
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_3fr]">
           {/* 左カラム：Xデーパネル + 今日のレポート + 入力フォーム */}
           <div className="flex flex-col gap-4">
@@ -97,10 +97,10 @@ async function DashboardContent() {
 
 export default function HomePage() {
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
       <Suspense
         fallback={
-          <div className="flex flex-1 items-center justify-center text-sm text-zinc-400">
+          <div className="flex flex-1 items-center justify-center text-sm font-medium text-[#1c1410]/40">
             読み込み中...
           </div>
         }

--- a/apps/web/src/app/report/page.tsx
+++ b/apps/web/src/app/report/page.tsx
@@ -78,7 +78,7 @@ async function ReportSection({ period }: { period: Period }) {
 
   if (budgets.length === 0) {
     return (
-      <p className="py-12 text-center text-sm text-zinc-400">
+      <p className="py-12 text-center text-sm font-medium text-[#1c1410]/40">
         この期間のデータはありません
       </p>
     );
@@ -91,18 +91,24 @@ async function ReportSection({ period }: { period: Period }) {
   const sortedDates = Object.keys(grouped).sort((a, b) => b.localeCompare(a));
 
   return (
-    <div className="flex flex-col gap-8">
+    <div className="flex flex-col gap-6">
       {/* サマリー */}
       <div className="grid grid-cols-2 gap-3">
-        <div className="rounded-xl border border-zinc-100 bg-white p-4">
-          <p className="text-xs text-zinc-500">支出合計</p>
-          <p className="mt-1 text-xl font-semibold" style={{ color: "var(--color-expense)" }}>
+        <div
+          className="rounded-2xl border border-[#1c1410]/12 bg-white p-4"
+          style={{ boxShadow: "var(--shadow-card)" }}
+        >
+          <p className="text-xs font-bold text-[#1c1410]/50">支出合計</p>
+          <p className="mt-1 text-xl font-extrabold tabular-nums" style={{ color: "var(--color-expense)" }}>
             ¥{totalOutgo.toLocaleString()}
           </p>
         </div>
-        <div className="rounded-xl border border-zinc-100 bg-white p-4">
-          <p className="text-xs text-zinc-500">収入合計</p>
-          <p className="mt-1 text-xl font-semibold" style={{ color: "var(--color-income)" }}>
+        <div
+          className="rounded-2xl border border-[#1c1410]/12 bg-white p-4"
+          style={{ boxShadow: "var(--shadow-card)" }}
+        >
+          <p className="text-xs font-bold text-[#1c1410]/50">収入合計</p>
+          <p className="mt-1 text-xl font-extrabold tabular-nums" style={{ color: "var(--color-income)" }}>
             ¥{totalIncome.toLocaleString()}
           </p>
         </div>
@@ -111,27 +117,30 @@ async function ReportSection({ period }: { period: Period }) {
       {/* カテゴリ別バーチャート（支出） */}
       {categoryBreakdown.length > 0 && (
         <section>
-          <h2 className="mb-3 text-sm font-semibold text-zinc-700">
+          <h2 className="mb-3 text-sm font-extrabold text-[#1c1410]">
             支出カテゴリ内訳
           </h2>
-          <div className="flex flex-col gap-2 rounded-xl border border-zinc-100 bg-white p-4">
+          <div
+            className="flex flex-col gap-3 rounded-2xl border border-[#1c1410]/12 bg-white p-4"
+            style={{ boxShadow: "var(--shadow-card)" }}
+          >
             {categoryBreakdown.map((cat) => (
-              <div key={cat.name} className="flex flex-col gap-1">
+              <div key={cat.name} className="flex flex-col gap-1.5">
                 <div className="flex justify-between text-sm">
                   <span className="flex items-center gap-1.5">
                     <span
-                      className="inline-block h-2.5 w-2.5 rounded-full"
+                      className="inline-block h-3 w-3 rounded-full border border-[#1c1410]/10"
                       style={{ backgroundColor: cat.color }}
                     />
-                    <span className="text-zinc-700">{cat.name}</span>
+                    <span className="font-bold text-[#1c1410]">{cat.name}</span>
                   </span>
-                  <span className="text-zinc-500">
+                  <span className="font-bold text-[#1c1410]/60">
                     ¥{cat.amount.toLocaleString()} ({cat.pct}%)
                   </span>
                 </div>
-                <div className="h-2 w-full overflow-hidden rounded-full bg-zinc-100">
+                <div className="h-2.5 w-full overflow-hidden rounded-full border border-[#e8c8b0] bg-[#fffdf5]">
                   <div
-                    className="h-2 rounded-full transition-all"
+                    className="h-full rounded-full transition-all"
                     style={{ width: `${cat.pct}%`, backgroundColor: cat.color }}
                   />
                 </div>
@@ -143,7 +152,7 @@ async function ReportSection({ period }: { period: Period }) {
 
       {/* 日付別明細 */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold text-zinc-700">
+        <h2 className="mb-3 text-sm font-extrabold text-[#1c1410]">
           明細
         </h2>
         <div className="flex flex-col gap-4">
@@ -155,10 +164,10 @@ async function ReportSection({ period }: { period: Period }) {
             return (
               <section key={date}>
                 <div className="mb-2 flex items-center justify-between">
-                  <span className="text-sm font-medium text-zinc-600">
+                  <span className="text-sm font-extrabold text-[#1c1410]">
                     {date}
                   </span>
-                  <div className="flex gap-3 text-sm">
+                  <div className="flex gap-3 text-sm font-bold">
                     {income > 0 && (
                       <span style={{ color: "var(--color-income)" }}>
                         +¥{income.toLocaleString()}
@@ -171,7 +180,10 @@ async function ReportSection({ period }: { period: Period }) {
                     )}
                   </div>
                 </div>
-                <ul className="divide-y divide-zinc-100 rounded-xl border border-zinc-100 bg-white">
+                <ul
+                  className="divide-y divide-[#e8c8b0] rounded-2xl border border-[#1c1410]/12 bg-white overflow-hidden"
+                  style={{ boxShadow: "var(--shadow-card)" }}
+                >
                   {items.map((item) => {
                     const category = getCategoryById(item.balanceType, item.categoryId);
                     const deleteAction = deleteBudgetAction.bind(null, item.id);
@@ -184,22 +196,22 @@ async function ReportSection({ period }: { period: Period }) {
                         <div className="flex items-center gap-2">
                           {category && (
                             <span
-                              className="h-2.5 w-2.5 flex-shrink-0 rounded-full"
+                              className="h-3 w-3 flex-shrink-0 rounded-full border border-[#1c1410]/10"
                               style={{ backgroundColor: category.color }}
                             />
                           )}
                           <div className="flex flex-col">
-                            <span className="text-sm text-zinc-700">
+                            <span className="text-sm font-bold text-[#1c1410]">
                               {category?.name ?? "未分類"}
                             </span>
                             {item.content && (
-                              <span className="text-xs text-zinc-400">{item.content}</span>
+                              <span className="text-xs font-medium text-[#1c1410]/40">{item.content}</span>
                             )}
                           </div>
                         </div>
                         <div className="flex items-center gap-3">
                           <span
-                            className="text-sm font-semibold"
+                            className="text-sm font-extrabold tabular-nums"
                             style={{ color: isIncome ? "var(--color-income)" : "var(--color-expense)" }}
                           >
                             {isIncome ? "+" : "-"}¥{item.amount.toLocaleString()}
@@ -208,9 +220,9 @@ async function ReportSection({ period }: { period: Period }) {
                             <button
                               type="submit"
                               aria-label="削除"
-                              className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-zinc-100 hover:text-zinc-600"
+                              className="flex h-7 w-7 items-center justify-center rounded-full border border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f87171] hover:bg-[#fee2e2] hover:text-[#f87171]"
                             >
-                              <X size={14} />
+                              <X size={12} />
                             </button>
                           </form>
                         </div>
@@ -242,11 +254,11 @@ export default async function ReportPage({
   const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
       <Header userName={userId} />
       <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
         <div className="mb-6 flex items-center justify-between">
-          <h1 className="text-xl font-bold text-zinc-800">
+          <h1 className="text-2xl font-extrabold text-[#1c1410]">
             レポート
           </h1>
           <PeriodSelector />
@@ -257,7 +269,7 @@ export default async function ReportPage({
               {[...Array(3)].map((_, i) => (
                 <div
                   key={i}
-                  className="h-24 animate-pulse rounded-xl bg-zinc-100"
+                  className="h-24 animate-pulse rounded-2xl border border-[#e8c8b0] bg-white"
                 />
               ))}
             </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,15 +1,21 @@
 import type { Metadata } from "next";
 import { DataExportSection } from "@/components/settings/DataExportSection";
+import { Header } from "@/components/layout/Header";
+import { cookies } from "next/headers";
 
-export const metadata: Metadata = { title: "設定 | 家計管理ツール" };
+export const metadata: Metadata = { title: "設定 | 家計管理" };
 
-export default function SettingsPage() {
+export default async function SettingsPage() {
+    const cookieStore = await cookies();
+    const userId = cookieStore.get("user_id")?.value ?? "Guest";
+
     return (
-        <div className="min-h-screen bg-zinc-50 dark:bg-zinc-900 py-12">
-            <div className="mx-auto max-w-xl px-4 space-y-6">
-                <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">設定</h1>
+        <div className="flex min-h-screen flex-col bg-[#fffdf5]">
+            <Header userName={userId} />
+            <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
+                <h1 className="mb-6 text-2xl font-extrabold text-[#1c1410]">設定</h1>
                 <DataExportSection />
-            </div>
+            </main>
         </div>
     );
 }

--- a/apps/web/src/components/calendar/MonthlyCalendar.tsx
+++ b/apps/web/src/components/calendar/MonthlyCalendar.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import type { ExpenseResponse } from "@/lib/api/types";
 import { useRouter } from "next/navigation";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 
 type Props = {
   expenses: ExpenseResponse[];
@@ -26,7 +27,6 @@ function buildCalendarDays(year: number, month: number, expenses: ExpenseRespons
   const firstDay = new Date(year, month, 1);
   const lastDay = new Date(year, month + 1, 0);
 
-  // 前月の日付でカレンダーの先頭を埋める
   const startPad = firstDay.getDay();
   const days: DayData[] = [];
 
@@ -42,7 +42,6 @@ function buildCalendarDays(year: number, month: number, expenses: ExpenseRespons
     });
   }
 
-  // 当月の日付
   for (let day = 1; day <= lastDay.getDate(); day++) {
     const d = new Date(year, month, day);
     const dateStr = d.toISOString().split("T")[0];
@@ -64,7 +63,6 @@ function buildCalendarDays(year: number, month: number, expenses: ExpenseRespons
     });
   }
 
-  // 次月の日付でカレンダーの末尾を埋める（6行になるよう）
   const remaining = 42 - days.length;
   for (let i = 1; i <= remaining; i++) {
     const d = new Date(year, month + 1, i);
@@ -109,43 +107,45 @@ export function MonthlyCalendar({ expenses }: Props) {
 
   const handleDayClick = (day: DayData) => {
     if (!day.isCurrentMonth) return;
-    // クリックした日付をクエリパラメータで渡して入力ページへ
     router.push(`/expenses/new?date=${day.dateStr}`);
   };
 
   return (
-    <section className="flex h-full flex-col rounded-xl border border-zinc-100 bg-white shadow-sm">
+    <section
+      className="flex h-full flex-col rounded-2xl border-2 border-[#1c1410] bg-white overflow-hidden"
+      style={{ boxShadow: "var(--shadow-pop)" }}
+    >
       {/* カレンダーヘッダー */}
-      <div className="flex items-center justify-between rounded-t-xl bg-[var(--color-brand-primary)] px-4 py-3 text-white">
+      <div className="flex items-center justify-between border-b-2 border-[#1c1410] bg-[#f18840] px-4 py-3 text-white">
         <button
           type="button"
           onClick={prevMonth}
-          className="flex h-7 w-7 items-center justify-center rounded-full hover:bg-white/20"
+          className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-white/40 bg-white/10 hover:bg-white/20 transition-colors"
           aria-label="前月"
         >
-          ‹
+          <ChevronLeft size={14} />
         </button>
-        <h2 className="text-sm font-semibold">
-          {year}年{month + 1}月1日 – {new Date(year, month + 1, 0).getDate()}日
+        <h2 className="text-sm font-extrabold">
+          {year}年{month + 1}月
         </h2>
         <button
           type="button"
           onClick={nextMonth}
-          className="flex h-7 w-7 items-center justify-center rounded-full hover:bg-white/20"
+          className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-white/40 bg-white/10 hover:bg-white/20 transition-colors"
           aria-label="翌月"
         >
-          ›
+          <ChevronRight size={14} />
         </button>
       </div>
 
       {/* 曜日ヘッダー */}
-      <div className="grid grid-cols-7 border-b border-zinc-100">
+      <div className="grid grid-cols-7 border-b border-[#e8c8b0] bg-[#fffdf5]">
         {WEEK_DAYS.map((day, i) => (
           <div
             key={day}
             className={[
-              "py-2 text-center text-xs font-medium",
-              i === 0 ? "text-red-500" : i === 6 ? "text-blue-500" : "text-zinc-500",
+              "py-2 text-center text-xs font-extrabold",
+              i === 0 ? "text-[#f87171]" : i === 6 ? "text-[#35b5a2]" : "text-[#1c1410]/50",
             ].join(" ")}
           >
             {day}
@@ -162,29 +162,32 @@ export function MonthlyCalendar({ expenses }: Props) {
             onClick={() => handleDayClick(day)}
             disabled={!day.isCurrentMonth}
             className={[
-              "relative flex flex-col items-start border-b border-r border-zinc-100 p-1 text-left text-xs transition-colors",
+              "relative flex flex-col items-start border-b border-r border-[#e8c8b0] p-1 text-left text-xs transition-colors",
               day.isCurrentMonth
-                ? "hover:bg-[var(--color-surface-subtle)] cursor-pointer"
+                ? "hover:bg-[#fff6ee] cursor-pointer"
                 : "cursor-default",
-              day.isToday ? "bg-amber-50" : "",
+              day.isToday ? "bg-[#fff5ec]" : "",
             ].join(" ")}
           >
             {/* 日付数字 */}
             <span
               className={[
-                "mb-0.5 text-xs",
-                !day.isCurrentMonth ? "text-zinc-300" : day.isToday ? "font-bold text-[var(--color-brand-primary)]" : "text-zinc-600",
+                "mb-0.5 text-xs font-bold",
+                !day.isCurrentMonth
+                  ? "text-[#1c1410]/20"
+                  : day.isToday
+                  ? "rounded-full bg-[#f18840] px-1 text-white"
+                  : "text-[#1c1410]",
               ].join(" ")}
             >
-              {day.date.getDate()}日
+              {day.date.getDate()}
             </span>
 
             {/* 支出 */}
             {day.outgo > 0 && (
               <div className="flex items-center gap-0.5">
-                <span className="h-2.5 w-2.5 rounded-full bg-[var(--color-expense)] text-[8px]">
-                </span>
-                <span className="text-[10px] text-zinc-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-[#f18840]" />
+                <span className="text-[9px] font-bold text-[#1c1410]/60">
                   {day.outgo >= 1000
                     ? `${Math.floor(day.outgo / 1000)}k`
                     : day.outgo}
@@ -195,9 +198,8 @@ export function MonthlyCalendar({ expenses }: Props) {
             {/* 収入 */}
             {day.income > 0 && (
               <div className="flex items-center gap-0.5">
-                <span className="h-2.5 w-2.5 rounded-full bg-[var(--color-income)] text-[8px]">
-                </span>
-                <span className="text-[10px] text-zinc-700">
+                <span className="h-1.5 w-1.5 rounded-full bg-[#35b5a2]" />
+                <span className="text-[9px] font-bold text-[#1c1410]/60">
                   {day.income >= 1000
                     ? `${Math.floor(day.income / 1000)}k`
                     : day.income}

--- a/apps/web/src/components/common/SecurityBadges.tsx
+++ b/apps/web/src/components/common/SecurityBadges.tsx
@@ -11,7 +11,7 @@ export function SecurityBadges() {
             <Tooltip
                 content={
                     <span className="space-y-1 block">
-                        <strong className="font-medium text-zinc-800 dark:text-zinc-100">
+                        <strong className="font-bold text-[#1c1410]">
                             データ保護について
                         </strong>
                         <p className="leading-relaxed">
@@ -20,8 +20,8 @@ export function SecurityBadges() {
                     </span>
                 }
             >
-                <span className="inline-flex cursor-default items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs font-medium text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400">
-                    <ShieldCheck size={12} strokeWidth={2} className="text-zinc-400 dark:text-zinc-500" />
+                <span className="inline-flex cursor-default items-center gap-1.5 rounded-full border border-[#e8c8b0] bg-[#fffdf5] px-2.5 py-1 text-xs font-bold text-[#1c1410]/60">
+                    <ShieldCheck size={12} strokeWidth={2} className="text-[#35b5a2]" />
                     暗号化通信
                 </span>
             </Tooltip>
@@ -29,7 +29,7 @@ export function SecurityBadges() {
             <Tooltip
                 content={
                     <span className="space-y-1 block">
-                        <strong className="font-medium text-zinc-800 dark:text-zinc-100">
+                        <strong className="font-bold text-[#1c1410]">
                             プライバシー配慮
                         </strong>
                         <p className="leading-relaxed">
@@ -38,8 +38,8 @@ export function SecurityBadges() {
                     </span>
                 }
             >
-                <span className="inline-flex cursor-default items-center gap-1.5 rounded-full border border-zinc-200 bg-zinc-50 px-2.5 py-1 text-xs font-medium text-zinc-500 dark:border-zinc-700 dark:bg-zinc-800/60 dark:text-zinc-400">
-                    <UserRound size={12} strokeWidth={2} className="text-zinc-400 dark:text-zinc-500" />
+                <span className="inline-flex cursor-default items-center gap-1.5 rounded-full border border-[#e8c8b0] bg-[#fffdf5] px-2.5 py-1 text-xs font-bold text-[#1c1410]/60">
+                    <UserRound size={12} strokeWidth={2} className="text-[#f18840]" />
                     匿名利用可
                 </span>
             </Tooltip>

--- a/apps/web/src/components/dashboard/SetupModal.tsx
+++ b/apps/web/src/components/dashboard/SetupModal.tsx
@@ -26,36 +26,47 @@ export function SetupModal({ onSave, defaultAssets, defaultIncome, onClose }: Pr
 
     return (
         <div
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-blur-sm"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-[#1c1410]/50"
             onClick={onClose}
         >
-            { }
             <div
-                className="relative mx-4 w-full max-w-md rounded-[var(--radius-card)] border border-orange-200 bg-[var(--color-surface-subtle)] p-8 shadow-xl"
+                className="relative mx-4 w-full max-w-md rounded-2xl border-2 border-[#1c1410] bg-[#fffdf5] p-8"
+                style={{ boxShadow: "var(--shadow-pop)" }}
                 onClick={e => e.stopPropagation()}
             >
+                {/* 幾何学デコレーション */}
+                <div
+                    className="pointer-events-none absolute right-16 top-4 h-6 w-6 rounded-full border border-[#f18840]/20 bg-[#fff6ee]"
+                    aria-hidden="true"
+                />
+                <div
+                    className="pointer-events-none absolute left-6 bottom-6 h-4 w-4 rotate-12 rounded-sm border border-[#35b5a2]/20 bg-[#ecfaf8]"
+                    aria-hidden="true"
+                />
+
                 {/* 閉じるボタン（再設定時のみ表示） */}
                 {onClose && (
                     <button
                         type="button"
                         onClick={onClose}
                         aria-label="閉じる"
-                        className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-orange-100 hover:text-zinc-600"
+                        className="absolute right-4 top-4 flex h-8 w-8 items-center justify-center rounded-full border-2 border-[#1c1410] bg-white text-[#1c1410] transition-colors hover:bg-[#fff6ee]"
+                        style={{ boxShadow: "var(--shadow-pop-sm)" }}
                     >
-                        <X size={16} />
+                        <X size={14} />
                     </button>
                 )}
 
-                <p className="mb-1 text-xs font-medium text-zinc-400">
-                    {isReconfigure ? "家計の寿命 — 設定の更新" : "家計の寿命 — はじめに"}
+                <p className="mb-1 text-xs font-bold text-[#1c1410]/40 uppercase tracking-wider">
+                    {isReconfigure ? "設定の更新" : "はじめに"}
                 </p>
-                <h1 className="mb-2 text-xl font-bold text-zinc-800">
-                    {isReconfigure ? "資産データを更新する" : "あなたの家計の寿命を計算します"}
+                <h1 className="mb-2 text-xl font-extrabold text-[#1c1410]">
+                    {isReconfigure ? "資産データを更新する" : "家計の寿命を計算します"}
                 </h1>
                 {!isReconfigure && (
-                    <p className="mb-6 text-sm text-zinc-500">
+                    <p className="mb-6 text-sm text-[#1c1410]/60">
                         現在の資産と収入を入力すると、今のペースで
-                        <span className="font-medium text-[var(--color-brand-primary)]">
+                        <span className="font-bold text-[#f18840]">
                             あと何年・何ヶ月 自由に暮らせるか
                         </span>
                         がわかります。
@@ -64,7 +75,7 @@ export function SetupModal({ onSave, defaultAssets, defaultIncome, onClose }: Pr
 
                 <form onSubmit={handleSubmit} className={isReconfigure ? "mt-4 flex flex-col gap-5" : "flex flex-col gap-5"}>
                     <div className="flex flex-col gap-1.5">
-                        <label className="text-sm font-medium text-zinc-700" htmlFor="totalAssets">
+                        <label className="text-sm font-bold text-[#1c1410]" htmlFor="totalAssets">
                             現在の総資産（円）
                         </label>
                         <input
@@ -75,16 +86,17 @@ export function SetupModal({ onSave, defaultAssets, defaultIncome, onClose }: Pr
                             min={0}
                             defaultValue={defaultAssets}
                             placeholder="5,000,000"
-                            className="rounded-[var(--radius-md)] border border-orange-200 bg-white px-3 py-2.5 text-sm text-zinc-800 outline-none placeholder:text-zinc-300 focus:border-[var(--color-brand-primary)] focus:ring-2 focus:ring-orange-100"
+                            className="input-pop"
                         />
-                        <p className="text-xs text-zinc-400">
+                        <p className="text-xs text-[#1c1410]/40">
                             貯金・投資・現金の合計額を入力してください。
                         </p>
                     </div>
 
                     <div className="flex flex-col gap-1.5">
-                        <label className="text-sm font-medium text-zinc-700" htmlFor="monthlyIncome">
-                            月次の固定収入（円）— 任意
+                        <label className="text-sm font-bold text-[#1c1410]" htmlFor="monthlyIncome">
+                            月次の固定収入（円）
+                            <span className="ml-1 font-normal text-[#1c1410]/40">— 任意</span>
                         </label>
                         <input
                             id="monthlyIncome"
@@ -93,18 +105,15 @@ export function SetupModal({ onSave, defaultAssets, defaultIncome, onClose }: Pr
                             min={0}
                             defaultValue={defaultIncome ?? 0}
                             placeholder="0"
-                            className="rounded-[var(--radius-md)] border border-orange-200 bg-white px-3 py-2.5 text-sm text-zinc-800 outline-none placeholder:text-zinc-300 focus:border-[var(--color-brand-primary)] focus:ring-2 focus:ring-orange-100"
+                            className="input-pop"
                         />
-                        <p className="text-xs text-zinc-400">
+                        <p className="text-xs text-[#1c1410]/40">
                             確定している収入のみ入力してください。不明な場合は 0 のままで構いません。
                         </p>
                     </div>
 
-                    <button
-                        type="submit"
-                        className="rounded-[var(--radius-md)] bg-[var(--color-brand-primary)] px-4 py-3 text-sm font-bold text-white transition-colors hover:bg-[var(--color-brand-secondary)] active:opacity-80"
-                    >
-                        {isReconfigure ? "更新する →" : "家計の寿命を計算する →"}
+                    <button type="submit" className="btn-candy w-full py-3">
+                        {isReconfigure ? "更新する" : "家計の寿命を計算する"}
                     </button>
                 </form>
             </div>

--- a/apps/web/src/components/dashboard/XDayDisplay.tsx
+++ b/apps/web/src/components/dashboard/XDayDisplay.tsx
@@ -19,7 +19,6 @@ const STORAGE_KEY_INCOME = "hkl_monthly_income";
  * これにより hydration 時はサーバーと一致し、マウント後に localStorage 値へ遷移する。
  */
 function subscribeStorage(callback: () => void): () => void {
-    // storage イベント（他タブ書き込み）にも対応
     window.addEventListener("storage", callback);
     return () => window.removeEventListener("storage", callback);
 }
@@ -57,7 +56,7 @@ function formatLifespan(daysRemaining: number | null): { main: string; sub: stri
     const days = daysRemaining % 30;
 
     if (years >= 10) {
-        return { main: `${years}年`, sub: `余裕のある家計を維持しています` };
+        return { main: `${years}年`, sub: "余裕のある家計を維持しています" };
     }
     if (years >= 1) {
         return {
@@ -79,12 +78,11 @@ function getLifespanStatus(daysRemaining: number | null): "infinite" | "long" | 
     return "short";
 }
 
-/** ステータスに対応するオレンジグラデーション色 */
 const STATUS_COLORS = {
-    infinite: "var(--color-income)",       // teal（∞ = 最良）
-    long:     "var(--color-income)",       // teal（10年超）
-    medium:   "var(--color-brand-primary)", // オレンジ（2〜10年）
-    short:    "var(--color-brand-secondary)", // 濃いオレンジ（2年未満）
+    infinite: "var(--color-income)",
+    long:     "var(--color-income)",
+    medium:   "var(--color-brand-primary)",
+    short:    "var(--color-brand-secondary)",
 } as const;
 
 /** 信頼度インジケーターのバー幅（%） */
@@ -97,13 +95,13 @@ function TrustBar({ value }: { value: number }) {
         : "var(--color-brand-secondary)";
     return (
         <div className="flex items-center gap-2">
-            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-zinc-100">
+            <div className="h-2 flex-1 overflow-hidden rounded-full border border-[#e8c8b0] bg-[#fffdf5]">
                 <div
                     className="h-full rounded-full transition-all duration-500"
                     style={{ width: `${pct}%`, backgroundColor: color }}
                 />
             </div>
-            <span className="text-xs text-zinc-500 tabular-nums">{pct}%</span>
+            <span className="text-xs font-bold text-[#1c1410]/40 tabular-nums">{pct}%</span>
         </div>
     );
 }
@@ -115,29 +113,22 @@ export function XDayDisplay({
     avgDailyExpense,
     recordedDays,
 }: Props) {
-    // useSyncExternalStore: サーバー = null、クライアントマウント後 = localStorage 値
-    // → hydration 時は必ずサーバーと一致する
     const totalAssets = useSyncExternalStore(subscribeStorage, readAssetsSnapshot, () => SERVER_ASSETS);
     const monthlyIncome = useSyncExternalStore(subscribeStorage, readIncomeSnapshot, () => SERVER_INCOME);
 
-    // リアルタイム更新値（setInterval で更新。静止時は null のまま → 後述の導出値を使う）
     const [rtAssets, setRtAssets] = useState<number | null>(null);
     const [rtDays, setRtDays] = useState<number | null>(null);
     const [snapshotAt] = useMemo(() => [new Date()], []);
 
-    // 再設定モーダルの表示フラグ（localStorageは消さず、モーダルを重ねて表示）
     const [showSetup, setShowSetup] = useState(false);
 
-    /** localStorage に書き込み、storage イベントを dispatch して useSyncExternalStore を更新 */
     const handleSetup = useCallback((assets: number, income: number) => {
         localStorage.setItem(STORAGE_KEY_ASSETS, String(assets));
         localStorage.setItem(STORAGE_KEY_INCOME, String(income));
-        // storage イベントは同一タブでは発火しないため手動 dispatch
         window.dispatchEvent(new Event("storage"));
         setShowSetup(false);
     }, []);
 
-    // Xデーをクライアント側で算出
     const xdayResult = totalAssets !== null
         ? calculateXDay({
               totalAssets,
@@ -153,11 +144,9 @@ export function XDayDisplay({
     const minutesPerYen = xdayResult?.minutesPerYen ?? 0;
     const trustWeight = xdayResult?.trustWeight ?? 0;
 
-    // 静止状態（収入>支出、または資産未設定）では静的導出値を使う
     const realtimeAssets = netDailyExpense > 0 ? rtAssets : totalAssets;
     const daysRemaining = netDailyExpense > 0 ? rtDays : (xdayResult?.daysRemaining ?? null);
 
-    // 1秒ごとにリアルタイム資産を更新（侵食がある場合のみ）
     useEffect(() => {
         if (totalAssets === null || netDailyExpense <= 0) return;
 
@@ -173,12 +162,10 @@ export function XDayDisplay({
         return () => clearInterval(id);
     }, [totalAssets, netDailyExpense, snapshotAt]);
 
-    // 初回（未設定）の場合はセットアップモーダルを表示
     if (totalAssets === null) {
         return <SetupModal onSave={handleSetup} />;
     }
 
-    // 再設定モーダル（既存値を初期セット、×ボタンで閉じられる）
     if (showSetup) {
         return (
             <SetupModal
@@ -199,44 +186,47 @@ export function XDayDisplay({
         : null;
 
     return (
-        <section className="rounded-xl border border-zinc-100 bg-white p-5 shadow-sm">
-            {/* タイトル（他ウィジットと統一） */}
-            <h2 className="mb-4 text-center text-sm font-semibold text-zinc-700">家計の寿命</h2>
+        <section
+            className="rounded-2xl border-2 border-[#1c1410] bg-white p-5"
+            style={{ boxShadow: "var(--shadow-pop)" }}
+        >
+            <h2 className="mb-4 text-center text-sm font-extrabold text-[#1c1410] tracking-wide uppercase">
+                家計の寿命
+            </h2>
 
             {/* メイン：残り期間 */}
-            <div className="mb-3 rounded-lg border border-zinc-100 p-3 text-center">
+            <div className="mb-3 rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-4 text-center">
                 <p
-                    className="text-2xl font-bold tabular-nums leading-tight transition-colors duration-1000"
+                    className="text-3xl font-extrabold tabular-nums leading-tight transition-colors duration-1000"
                     style={{ color: statusColor }}
                 >
                     あと {lifespan.main}
                 </p>
-                <p className="mt-1 text-xs text-zinc-500">{lifespan.sub}</p>
+                <p className="mt-1 text-xs font-medium text-[#1c1410]/50">{lifespan.sub}</p>
             </div>
 
             {/* 資産情報グリッド */}
             <div className="mb-3 grid grid-cols-2 gap-2">
-                <div className="rounded-lg border border-zinc-100 p-3">
-                    <p className="text-xs text-zinc-500">残存資産</p>
-                    <p className="mt-1 text-base font-semibold tabular-nums text-zinc-800">
+                <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-3">
+                    <p className="text-xs font-bold text-[#1c1410]/50">残存資産</p>
+                    <p className="mt-1 text-sm font-extrabold tabular-nums text-[#1c1410]">
                         {realtimeAssets !== null
-                            ? `¥ ${Math.floor(realtimeAssets).toLocaleString("ja-JP")}`
+                            ? `¥${Math.floor(realtimeAssets).toLocaleString("ja-JP")}`
                             : "---"}
                     </p>
                 </div>
-                <div className="rounded-lg border border-zinc-100 p-3">
-                    <p className="text-xs text-zinc-500">1日あたりの支出</p>
-                    <p className="mt-1 text-base font-semibold tabular-nums text-zinc-800">
+                <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-3">
+                    <p className="text-xs font-bold text-[#1c1410]/50">1日あたり</p>
+                    <p className="mt-1 text-sm font-extrabold tabular-nums text-[#1c1410]">
                         ¥{Math.round(netDailyExpense).toLocaleString()}
-                        <span className="ml-1 text-xs font-normal text-zinc-400">/ 日</span>
+                        <span className="ml-1 text-xs font-normal text-[#1c1410]/40">/ 日</span>
                     </p>
                     {minutesPerYen > 0 && (
-                        <p className="mt-0.5 text-xs text-zinc-400">
+                        <p className="mt-0.5 text-xs text-[#1c1410]/40">
                             1,000円 ={" "}
                             {minutesPerYen >= 1
                                 ? `${(minutesPerYen * 1000 / 60).toFixed(1)}時間`
                                 : `${Math.round(minutesPerYen * 1000)}秒`}
-                            分
                         </p>
                     )}
                 </div>
@@ -244,21 +234,21 @@ export function XDayDisplay({
 
             {/* 今日・昨日 */}
             <div className="mb-3 grid grid-cols-2 gap-2">
-                <div className="rounded-lg border border-zinc-100 p-3">
-                    <p className="text-xs text-zinc-500">今日</p>
+                <div className="rounded-xl bg-[#fff6ee] p-3">
+                    <p className="text-xs font-bold text-[#f18840]/70">今日</p>
                     <p
-                        className="mt-1 text-base font-semibold tabular-nums"
+                        className="mt-1 text-sm font-extrabold tabular-nums"
                         style={{ color: todayExpense === 0 ? "var(--color-income)" : "var(--color-expense)" }}
                     >
                         {todayExpense === 0 ? "¥0" : `¥${todayExpense.toLocaleString()}`}
                     </p>
                     {impactLabel && (
-                        <p className="mt-0.5 text-xs text-zinc-400">影響 -{impactLabel}</p>
+                        <p className="mt-0.5 text-xs text-[#1c1410]/40">影響 -{impactLabel}</p>
                     )}
                 </div>
-                <div className="rounded-lg border border-zinc-100 p-3">
-                    <p className="text-xs text-zinc-500">昨日</p>
-                    <p className="mt-1 text-base font-semibold tabular-nums text-zinc-800">
+                <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-3">
+                    <p className="text-xs font-bold text-[#1c1410]/50">昨日</p>
+                    <p className="mt-1 text-sm font-extrabold tabular-nums text-[#1c1410]">
                         ¥{yesterdayExpense.toLocaleString()}
                     </p>
                 </div>
@@ -266,7 +256,7 @@ export function XDayDisplay({
 
             {/* 信頼度バー */}
             <div className="mb-3">
-                <div className="mb-1.5 flex items-center justify-between text-xs text-zinc-500">
+                <div className="mb-1.5 flex items-center justify-between text-xs font-bold text-[#1c1410]/40">
                     <span>予測の精度</span>
                     <span>{recordedDays}日分の実績</span>
                 </div>
@@ -275,26 +265,12 @@ export function XDayDisplay({
 
             {/* 積み上げメッセージ */}
             {zeroStreakDays >= 2 && (
-                <p
-                    className="mb-3 rounded-lg border p-3 text-xs font-medium"
-                    style={{
-                        color: "var(--color-income)",
-                        borderColor: "var(--color-income-light)",
-                        backgroundColor: "var(--color-income-light)",
-                    }}
-                >
+                <p className="mb-3 rounded-xl bg-[#ecfaf8] p-3 text-xs font-bold text-[#35b5a2]">
                     {zeroStreakDays}日連続で支出ゼロ — 着実に余裕が積み上がっています
                 </p>
             )}
             {todayExpense === 0 && zeroStreakDays < 2 && (
-                <p
-                    className="mb-3 rounded-lg border p-3 text-xs font-medium"
-                    style={{
-                        color: "var(--color-income)",
-                        borderColor: "var(--color-income-light)",
-                        backgroundColor: "var(--color-income-light)",
-                    }}
-                >
+                <p className="mb-3 rounded-xl bg-[#ecfaf8] p-3 text-xs font-bold text-[#35b5a2]">
                     今日は支出ゼロ — 余裕が1日分増えました
                 </p>
             )}
@@ -304,7 +280,7 @@ export function XDayDisplay({
                 <button
                     type="button"
                     onClick={() => setShowSetup(true)}
-                    className="text-xs text-zinc-400 underline underline-offset-2 hover:text-zinc-600"
+                    className="text-xs font-bold text-[#1c1410]/40 underline underline-offset-2 hover:text-[#f18840] transition-colors"
                 >
                     資産データを更新
                 </button>

--- a/apps/web/src/components/expense/ExpenseCreateForm.tsx
+++ b/apps/web/src/components/expense/ExpenseCreateForm.tsx
@@ -17,7 +17,7 @@ const initialState: ExpenseActionState = { error: null, success: false };
 function FieldError({ messages }: { messages?: string[] }) {
   if (!messages?.length) return null;
   return (
-    <p className="mt-1 text-xs text-[var(--color-expense)]">{messages[0]}</p>
+    <p className="mt-1 text-xs font-medium text-[#f87171]">{messages[0]}</p>
   );
 }
 
@@ -30,21 +30,25 @@ export function ExpenseCreateForm({ userId, defaultDate }: Props) {
   const categories = getCategoriesByType(balanceType);
 
   return (
-    <section id="form" className="rounded-xl border border-zinc-100 bg-white p-5 shadow-sm">
-      <h2 className="mb-4 text-center text-sm font-semibold text-zinc-700">
+    <section
+      id="form"
+      className="rounded-2xl border-2 border-[#1c1410] bg-white p-5"
+      style={{ boxShadow: "var(--shadow-pop)" }}
+    >
+      <h2 className="mb-4 text-center text-sm font-extrabold text-[#1c1410] tracking-wide uppercase">
         収支の入力
       </h2>
 
       {/* 収支タブ */}
-      <div className="mb-4 flex gap-2">
+      <div className="mb-4 flex rounded-xl border-2 border-[#1c1410] overflow-hidden" style={{ boxShadow: "var(--shadow-pop-sm)" }}>
         <button
           type="button"
           onClick={() => setBalanceType(0)}
           className={[
-            "flex-1 rounded-full py-2 text-sm font-medium transition-colors",
+            "flex-1 py-2 text-sm font-bold transition-colors",
             balanceType === 0
-              ? "bg-[var(--color-brand-primary)] text-white"
-              : "border border-[var(--color-brand-primary)] text-[var(--color-brand-primary)] hover:bg-[var(--color-expense-light)]",
+              ? "bg-[#f18840] text-white"
+              : "bg-white text-[#1c1410]/50 hover:bg-[#fff6ee]",
           ].join(" ")}
         >
           支出
@@ -53,10 +57,10 @@ export function ExpenseCreateForm({ userId, defaultDate }: Props) {
           type="button"
           onClick={() => setBalanceType(1)}
           className={[
-            "flex-1 rounded-full py-2 text-sm font-medium transition-colors",
+            "flex-1 py-2 text-sm font-bold transition-colors",
             balanceType === 1
-              ? "bg-[var(--color-income)] text-white"
-              : "border border-[var(--color-income)] text-[var(--color-income)] hover:bg-[var(--color-income-light)]",
+              ? "bg-[#35b5a2] text-white"
+              : "bg-white text-[#1c1410]/50 hover:bg-[#ecfaf8]",
           ].join(" ")}
         >
           収入
@@ -69,7 +73,7 @@ export function ExpenseCreateForm({ userId, defaultDate }: Props) {
 
         {/* 金額 */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="amount" className="text-xs text-zinc-500">金額</label>
+          <label htmlFor="amount" className="text-xs font-bold text-[#1c1410]/50">金額</label>
           <input
             id="amount"
             name="amount"
@@ -77,69 +81,59 @@ export function ExpenseCreateForm({ userId, defaultDate }: Props) {
             min={1}
             required
             placeholder="金額をご入力ください"
-            className="border-b border-zinc-300 bg-transparent py-2 text-sm outline-none placeholder:text-zinc-400 focus:border-[var(--color-brand-primary)]"
+            className="input-pop"
           />
           <FieldError messages={state.fieldErrors?.amount} />
         </div>
 
         {/* 日付 */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="date" className="text-xs text-zinc-500">日付</label>
-          <div className="flex items-center gap-2 border-b border-zinc-300 py-2 focus-within:border-[var(--color-brand-primary)]">
-            <input
-              id="date"
-              name="date"
-              type="date"
-              required
-              defaultValue={defaultDate ?? new Date().toISOString().split("T")[0]}
-              className="flex-1 bg-transparent text-sm outline-none"
-            />
-            <svg className="h-4 w-4 shrink-0 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-            </svg>
-          </div>
+          <label htmlFor="date" className="text-xs font-bold text-[#1c1410]/50">日付</label>
+          <input
+            id="date"
+            name="date"
+            type="date"
+            required
+            defaultValue={defaultDate ?? new Date().toISOString().split("T")[0]}
+            className="input-pop"
+          />
           <FieldError messages={state.fieldErrors?.date} />
         </div>
 
         {/* カテゴリ */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="categoryId" className="text-xs text-zinc-500">カテゴリ</label>
-          <div className="relative border-b border-zinc-300 focus-within:border-[var(--color-brand-primary)]">
-            <select
-              id="categoryId"
-              name="categoryId"
-              defaultValue={0}
-              className="w-full appearance-none bg-transparent py-2 text-sm text-zinc-700 outline-none"
-            >
-              {categories.map((cat) => (
-                <option key={cat.id} value={cat.id}>{cat.name}</option>
-              ))}
-            </select>
-            <svg className="pointer-events-none absolute right-0 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-            </svg>
-          </div>
+          <label htmlFor="categoryId" className="text-xs font-bold text-[#1c1410]/50">カテゴリ</label>
+          <select
+            id="categoryId"
+            name="categoryId"
+            defaultValue={0}
+            className="input-pop"
+          >
+            {categories.map((cat) => (
+              <option key={cat.id} value={cat.id}>{cat.name}</option>
+            ))}
+          </select>
         </div>
 
         {/* 内容 */}
         <div className="flex flex-col gap-1">
-          <label htmlFor="content" className="text-xs text-zinc-500">内容</label>
+          <label htmlFor="content" className="text-xs font-bold text-[#1c1410]/50">内容</label>
           <input
             id="content"
             name="content"
             type="text"
             placeholder="内容をご入力ください（任意）"
-            className="border-b border-zinc-300 bg-transparent py-2 text-sm outline-none placeholder:text-zinc-400 focus:border-[var(--color-brand-primary)]"
+            className="input-pop"
           />
         </div>
 
         {state.error && (
-          <p className="rounded-lg bg-[var(--color-expense-light)] px-3 py-2 text-sm text-[var(--color-expense)]">
+          <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
             {state.error}
           </p>
         )}
         {state.success && (
-          <p className="rounded-lg bg-[var(--color-income-light)] px-3 py-2 text-sm text-[var(--color-income)]">
+          <p className="rounded-xl border border-[#35b5a2]/40 bg-[#ecfaf8] px-3 py-2 text-sm font-bold text-[#35b5a2]">
             登録しました
           </p>
         )}
@@ -147,7 +141,7 @@ export function ExpenseCreateForm({ userId, defaultDate }: Props) {
         <button
           type="submit"
           disabled={isPending}
-          className="mt-2 rounded-full bg-[var(--color-brand-primary)] py-2.5 text-sm font-medium text-white transition-opacity hover:opacity-90 disabled:opacity-50"
+          className="btn-candy w-full mt-2 disabled:opacity-50"
         >
           {isPending ? "登録中..." : "追加する"}
         </button>

--- a/apps/web/src/components/expense/ExpenseList.tsx
+++ b/apps/web/src/components/expense/ExpenseList.tsx
@@ -1,11 +1,6 @@
 import { deleteExpenseAction } from "@/lib/actions/expense";
 import type { ExpenseResponse } from "@/lib/api/types";
-
-/** 収支区分のラベルと色 */
-const BALANCE_TYPE_MAP = {
-  0: { label: "支出", className: "text-red-600 dark:text-red-400" },
-  1: { label: "収入", className: "text-emerald-600 dark:text-emerald-400" },
-} as const;
+import { X } from "lucide-react";
 
 type Props = {
   expenses: ExpenseResponse[];
@@ -14,45 +9,51 @@ type Props = {
 export function ExpenseList({ expenses }: Props) {
   if (expenses.length === 0) {
     return (
-      <p className="py-12 text-center text-sm text-zinc-400">
+      <p className="py-12 text-center text-sm font-medium text-[#1c1410]/40">
         まだ支出が登録されていません
       </p>
     );
   }
 
   return (
-    <ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
+    <ul className="divide-y divide-[#e8c8b0]">
       {expenses.map((expense) => {
-        const typeInfo = BALANCE_TYPE_MAP[expense.balanceType];
+        const isOutgo = expense.balanceType === 0;
         const deleteAction = deleteExpenseAction.bind(null, expense.id);
         return (
           <li key={expense.id} className="flex items-center justify-between gap-4 py-3">
             <div className="flex flex-col gap-0.5">
-              <span className="text-sm text-zinc-500 dark:text-zinc-400">
+              <span className="text-xs font-bold text-[#1c1410]/40">
                 {expense.date}
               </span>
               {expense.content && (
-                <span className="text-sm text-zinc-700 dark:text-zinc-300">
+                <span className="text-sm font-medium text-[#1c1410]">
                   {expense.content}
                 </span>
               )}
             </div>
             <div className="flex items-center gap-3">
               <div className="flex flex-col items-end gap-0.5">
-                <span className={`text-sm font-medium ${typeInfo.className}`}>
-                  {typeInfo.label}
+                <span
+                  className="text-xs font-bold"
+                  style={{ color: isOutgo ? "var(--color-expense)" : "var(--color-income)" }}
+                >
+                  {isOutgo ? "支出" : "収入"}
                 </span>
-                <span className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
-                  ¥{expense.amount.toLocaleString()}
+                <span
+                  className="text-base font-extrabold tabular-nums"
+                  style={{ color: isOutgo ? "var(--color-expense)" : "var(--color-income)" }}
+                >
+                  {isOutgo ? "-" : "+"}¥{expense.amount.toLocaleString()}
                 </span>
               </div>
               <form action={deleteAction}>
                 <button
                   type="submit"
                   aria-label="削除"
-                  className="rounded-lg p-1.5 text-zinc-400 transition-colors hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30 dark:hover:text-red-400"
+                  className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f87171] hover:bg-[#fee2e2] hover:text-[#f87171]"
                 >
-                  ✕
+                  <X size={12} />
                 </button>
               </form>
             </div>

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -24,17 +24,19 @@ export function Header({ userName }: Props) {
   const pathname = usePathname();
 
   return (
-    <header className="sticky top-0 z-10 border-b border-[var(--color-brand-primary)]/20 bg-white shadow-sm">
+    <header className="sticky top-0 z-10 border-b border-[#1c1410]/10 bg-[#fffdf5]">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
         {/* ロゴ */}
-        <Link
-          href="/"
-          className="flex items-center gap-2 text-base font-bold text-zinc-800"
-        >
-          <span className="flex h-7 w-7 items-center justify-center rounded bg-[var(--color-brand-primary)] text-xs font-bold text-white">
+        <Link href="/" className="flex items-center gap-2">
+          <span
+            className="flex h-8 w-8 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-sm font-extrabold text-white"
+            style={{ boxShadow: "var(--shadow-pop-sm)" }}
+          >
             B
           </span>
-          家計簿管理ツール
+          <span className="text-base font-bold text-[#1c1410]">
+            家計簿
+          </span>
         </Link>
 
         {/* ナビゲーション */}
@@ -49,15 +51,15 @@ export function Header({ userName }: Props) {
                 key={item.href}
                 href={item.href}
                 className={[
-                  "relative px-4 py-4 text-sm font-medium transition-colors",
+                  "relative px-3 py-2 text-sm font-semibold transition-colors rounded-lg",
                   isActive
-                    ? "text-[var(--color-brand-primary)]"
-                    : "text-zinc-600 hover:text-[var(--color-brand-primary)]",
+                    ? "text-[#f18840] bg-[#fff6ee]"
+                    : "text-[#1c1410] hover:text-[#f18840] hover:bg-[#fff6ee]",
                 ].join(" ")}
               >
                 {item.label}
                 {isActive && (
-                  <span className="absolute bottom-0 left-0 right-0 h-0.5 bg-[var(--color-brand-primary)]" />
+                  <span className="absolute -bottom-0.5 left-3 right-3 h-0.5 rounded-full bg-[#f18840]" />
                 )}
               </Link>
             );
@@ -67,13 +69,12 @@ export function Header({ userName }: Props) {
         {/* ユーザー情報 + ログアウト */}
         <div className="flex items-center gap-3">
           {userName && (
-            <span className="text-sm text-zinc-600">{userName}さん</span>
+            <span className="text-sm font-medium text-[#1c1410]/50">
+              {userName}さん
+            </span>
           )}
           <form action={logoutAction}>
-            <button
-              type="submit"
-              className="rounded-full bg-[var(--color-brand-primary)] px-4 py-1.5 text-sm font-medium text-white transition-opacity hover:opacity-90"
-            >
+            <button type="submit" className="btn-ghost text-xs px-3 py-1.5">
               ログアウト
             </button>
           </form>

--- a/apps/web/src/components/login/LoginForm.tsx
+++ b/apps/web/src/components/login/LoginForm.tsx
@@ -10,29 +10,27 @@ import { SecurityBadges } from "@/components/common/SecurityBadges";
 
 const initialState: LoginState = { error: null };
 
-/** フィールドエラーを表示するヘルパー */
 function FieldError({ messages }: { messages?: string[] }) {
   if (!messages?.length) return null;
   return (
-    <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+    <p className="mt-1 text-xs font-medium text-[#f87171]">
       {messages[0]}
     </p>
   );
 }
 
-/** クエリパラメータに応じた通知バナー */
 function NotificationBanner() {
   const params = useSearchParams();
   if (params.get("registered") === "1") {
     return (
-      <p className="mb-4 rounded-lg bg-green-50 px-3 py-2 text-sm text-green-700 dark:bg-green-900/30 dark:text-green-400">
+      <p className="mb-4 rounded-xl border border-[#35b5a2]/40 bg-[#ecfaf8] px-3 py-2 text-sm font-medium text-[#1c1410]">
         アカウントを作成しました。ログインしてください。
       </p>
     );
   }
   if (params.get("reset") === "1") {
     return (
-      <p className="mb-4 rounded-lg bg-green-50 px-3 py-2 text-sm text-green-700 dark:bg-green-900/30 dark:text-green-400">
+      <p className="mb-4 rounded-xl border border-[#35b5a2]/40 bg-[#ecfaf8] px-3 py-2 text-sm font-medium text-[#1c1410]">
         パスワードを再設定しました。新しいパスワードでログインしてください。
       </p>
     );
@@ -44,11 +42,40 @@ export function LoginForm() {
   const [state, formAction, isPending] = useActionState(loginAction, initialState);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
-      <section className="w-full max-w-sm rounded-xl bg-white p-8 shadow dark:bg-zinc-800">
-        <h1 className="mb-6 text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-          ログイン
-        </h1>
+    <div className="flex min-h-screen items-center justify-center bg-[#fffdf5] px-4">
+      {/* 背景の幾何学デコレーション（控えめなサイズ） */}
+      <div
+        className="pointer-events-none fixed left-8 top-20 h-16 w-16 rounded-full border border-[#f18840]/20 bg-[#fff6ee]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none fixed right-12 bottom-24 h-10 w-10 rotate-12 rounded-md border border-[#35b5a2]/20 bg-[#ecfaf8]"
+        aria-hidden="true"
+      />
+      <div
+        className="pointer-events-none fixed left-1/4 bottom-16 h-7 w-7 rounded-sm border border-[#fbbf24]/30 bg-[#fef3c7]"
+        aria-hidden="true"
+      />
+
+      <section
+        className="w-full max-w-sm rounded-2xl border-2 border-[#1c1410] bg-white p-8"
+        style={{ boxShadow: "var(--shadow-pop)" }}
+      >
+        {/* ヘッダー */}
+        <div className="mb-6 flex items-center gap-3">
+          <span
+            className="flex h-10 w-10 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-base font-extrabold text-white"
+            style={{ boxShadow: "var(--shadow-pop-sm)" }}
+          >
+            B
+          </span>
+          <div>
+            <h1 className="text-xl font-bold text-[#1c1410] leading-tight">
+              ログイン
+            </h1>
+            <p className="text-xs text-[#1c1410]/50">家計を整えよう</p>
+          </div>
+        </div>
 
         <Suspense>
           <NotificationBanner />
@@ -56,7 +83,7 @@ export function LoginForm() {
 
         <form action={formAction} className="flex flex-col gap-4">
           <div className="flex flex-col gap-1">
-            <label htmlFor="userId" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+            <label htmlFor="userId" className="text-sm font-semibold text-[#1c1410]">
               ユーザー名
             </label>
             <input
@@ -66,21 +93,21 @@ export function LoginForm() {
               required
               autoComplete="username"
               placeholder="ユーザー名を入力"
-              className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+              className="input-pop"
             />
             <FieldError messages={state.fieldErrors?.userId} />
           </div>
 
           <div className="flex flex-col gap-1">
             <div className="flex items-center justify-between">
-              <label htmlFor="password" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+              <label htmlFor="password" className="text-sm font-semibold text-[#1c1410]">
                 パスワード
               </label>
               <Link
                 href="/forgot-password"
-                className="text-xs text-zinc-500 dark:text-zinc-400 underline underline-offset-2 hover:text-zinc-700 dark:hover:text-zinc-200"
+                className="text-xs text-[#1c1410]/50 underline underline-offset-2 hover:text-[#f18840] transition-colors"
               >
-                パスワードを忘れた場合
+                忘れた場合
               </Link>
             </div>
             <input
@@ -90,13 +117,13 @@ export function LoginForm() {
               required
               autoComplete="current-password"
               placeholder="パスワードを入力"
-              className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+              className="input-pop"
             />
             <FieldError messages={state.fieldErrors?.password} />
           </div>
 
           {state.error && (
-            <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/30 dark:text-red-400">
+            <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
               {state.error}
             </p>
           )}
@@ -104,28 +131,27 @@ export function LoginForm() {
           <button
             type="submit"
             disabled={isPending}
-            className="mt-2 rounded-full bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+            className="btn-candy w-full mt-2 disabled:opacity-50"
           >
             {isPending ? "ログイン中..." : "ログインする"}
           </button>
         </form>
 
-        <div className="mt-4 border-t border-zinc-200 pt-4 dark:border-zinc-700 space-y-3">
+        <div className="mt-4 border-t border-[#e8c8b0] pt-4 space-y-3">
           <form action={guestLoginAction}>
-            <button
-              type="submit"
-              className="w-full rounded-full border border-zinc-300 px-4 py-2.5 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-700"
-            >
+            <button type="submit" className="btn-ghost w-full">
               ゲストユーザーでログイン
             </button>
           </form>
-          <p className="text-center text-sm text-zinc-500 dark:text-zinc-400">
+          <p className="text-center text-sm text-[#1c1410]/60">
             アカウントをお持ちでない方は{" "}
-            <Link href="/register" className="text-zinc-800 dark:text-zinc-200 underline underline-offset-2">
+            <Link
+              href="/register"
+              className="font-semibold text-[#f18840] underline underline-offset-2 hover:text-[#e07030] transition-colors"
+            >
               新規登録
             </Link>
           </p>
-          {/* セキュリティバッジ: ホバーでツールチップ表示 */}
           <div className="flex justify-center pt-1">
             <SecurityBadges />
           </div>

--- a/apps/web/src/components/recovery/ForgotPasswordFlow.tsx
+++ b/apps/web/src/components/recovery/ForgotPasswordFlow.tsx
@@ -28,11 +28,11 @@ function LookupStep({ onNext }: { onNext: (userId: string, questionText: string)
 
     return (
         <form action={formAction} className="flex flex-col gap-4">
-            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            <p className="text-sm font-medium text-[#1c1410]/60">
                 登録時に設定したユーザー名を入力してください。秘密の質問でパスワードを再設定できます。
             </p>
             <div className="flex flex-col gap-1">
-                <label htmlFor="userId" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                <label htmlFor="userId" className="text-sm font-bold text-[#1c1410]">
                     ユーザー名
                 </label>
                 <input
@@ -41,19 +41,15 @@ function LookupStep({ onNext }: { onNext: (userId: string, questionText: string)
                     type="text"
                     autoComplete="username"
                     placeholder="ユーザー名を入力"
-                    className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                    className="input-pop"
                 />
             </div>
             {state.error && (
-                <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/30 dark:text-red-400">
+                <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
                     {state.error}
                 </p>
             )}
-            <button
-                type="submit"
-                disabled={isPending}
-                className="rounded-full bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900"
-            >
+            <button type="submit" disabled={isPending} className="btn-candy w-full disabled:opacity-50">
                 {isPending ? "確認中..." : "次へ"}
             </button>
         </form>
@@ -86,13 +82,13 @@ function VerifyStep({
         <form action={formAction} className="flex flex-col gap-4">
             <input type="hidden" name="userId" value={userId} />
 
-            <div className="rounded-lg bg-zinc-100 dark:bg-zinc-700/50 px-4 py-3">
-                <p className="text-xs font-medium text-zinc-500 dark:text-zinc-400 mb-1">秘密の質問</p>
-                <p className="text-sm font-medium text-zinc-800 dark:text-zinc-200">{questionText}</p>
+            <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] px-4 py-3">
+                <p className="text-xs font-bold text-[#1c1410]/40 mb-1">秘密の質問</p>
+                <p className="text-sm font-bold text-[#1c1410]">{questionText}</p>
             </div>
 
             <div className="flex flex-col gap-1">
-                <label htmlFor="answer" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                <label htmlFor="answer" className="text-sm font-bold text-[#1c1410]">
                     回答
                 </label>
                 <input
@@ -101,21 +97,17 @@ function VerifyStep({
                     type="text"
                     autoComplete="off"
                     placeholder="回答を入力（大文字・小文字は区別されません）"
-                    className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                    className="input-pop"
                 />
             </div>
 
             {state.error && (
-                <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/30 dark:text-red-400">
+                <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
                     {state.error}
                 </p>
             )}
 
-            <button
-                type="submit"
-                disabled={isPending}
-                className="rounded-full bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900"
-            >
+            <button type="submit" disabled={isPending} className="btn-candy w-full disabled:opacity-50">
                 {isPending ? "照合中..." : "回答を確認する"}
             </button>
         </form>
@@ -135,12 +127,12 @@ function ResetStep({ resetToken }: { resetToken: string }) {
         <form action={formAction} className="flex flex-col gap-4">
             <input type="hidden" name="resetToken" value={resetToken} />
 
-            <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            <p className="text-sm font-medium text-[#1c1410]/60">
                 新しいパスワードを設定してください。
             </p>
 
             <div className="flex flex-col gap-1">
-                <label htmlFor="newPassword" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                <label htmlFor="newPassword" className="text-sm font-bold text-[#1c1410]">
                     新しいパスワード
                 </label>
                 <input
@@ -151,22 +143,18 @@ function ResetStep({ resetToken }: { resetToken: string }) {
                     onChange={(e) => setNewPassword(e.target.value)}
                     autoComplete="new-password"
                     placeholder="8文字以上"
-                    className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                    className="input-pop"
                 />
                 <PasswordStrengthMeter password={newPassword} />
             </div>
 
             {state.error && (
-                <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/30 dark:text-red-400">
+                <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
                     {state.error}
                 </p>
             )}
 
-            <button
-                type="submit"
-                disabled={isPending}
-                className="rounded-full bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900"
-            >
+            <button type="submit" disabled={isPending} className="btn-candy w-full disabled:opacity-50">
                 {isPending ? "設定中..." : "パスワードを設定する"}
             </button>
         </form>
@@ -176,10 +164,12 @@ function ResetStep({ resetToken }: { resetToken: string }) {
 // ─── メインコンポーネント ─────────────────────────────────────────
 
 const STEP_LABELS: Record<Step, string> = {
-    lookup: "① ユーザー名を入力",
-    verify: "② 秘密の質問に回答",
-    reset: "③ 新しいパスワードを設定",
+    lookup: "STEP 1 — ユーザー名を入力",
+    verify: "STEP 2 — 秘密の質問に回答",
+    reset: "STEP 3 — 新しいパスワードを設定",
 };
+
+const STEPS: Step[] = ["lookup", "verify", "reset"];
 
 export function ForgotPasswordFlow() {
     const [step, setStep] = useState<Step>("lookup");
@@ -187,28 +177,38 @@ export function ForgotPasswordFlow() {
     const [questionText, setQuestionText] = useState("");
     const [resetToken, setResetToken] = useState("");
 
+    const currentIdx = STEPS.indexOf(step);
+
     return (
-        <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900">
-            <section className="w-full max-w-sm rounded-xl bg-white p-8 shadow dark:bg-zinc-800">
-                <h1 className="mb-1 text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-                    パスワードを忘れた場合
-                </h1>
-                <p className="mb-5 text-xs text-zinc-500 dark:text-zinc-400">
+        <div className="flex min-h-screen items-center justify-center bg-[#fffdf5] px-4">
+            <section
+                className="w-full max-w-sm rounded-2xl border-2 border-[#1c1410] bg-white p-8"
+                style={{ boxShadow: "var(--shadow-pop)" }}
+            >
+                <div className="mb-2 flex items-center gap-3">
+                    <span
+                        className="flex h-8 w-8 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-xs font-extrabold text-white"
+                        style={{ boxShadow: "var(--shadow-pop-sm)" }}
+                    >
+                        B
+                    </span>
+                    <h1 className="text-lg font-extrabold text-[#1c1410]">
+                        パスワードを忘れた場合
+                    </h1>
+                </div>
+                <p className="mb-5 text-xs font-bold text-[#1c1410]/40 uppercase tracking-wider">
                     {STEP_LABELS[step]}
                 </p>
 
                 {/* ステップインジケーター */}
                 <div className="flex gap-2 mb-6">
-                    {(["lookup", "verify", "reset"] as Step[]).map((s, i) => (
+                    {STEPS.map((s, i) => (
                         <div
                             key={s}
-                            className={`h-1 flex-1 rounded-full ${
-                                step === s
-                                    ? "bg-zinc-800 dark:bg-zinc-200"
-                                    : i < (["lookup", "verify", "reset"] as Step[]).indexOf(step)
-                                    ? "bg-zinc-400"
-                                    : "bg-zinc-200 dark:bg-zinc-700"
-                            }`}
+                            className="h-2 flex-1 rounded-full border border-[#1c1410]/10"
+                            style={{
+                                backgroundColor: i <= currentIdx ? "#f18840" : "#e8c8b0",
+                            }}
                         />
                     ))}
                 </div>
@@ -234,8 +234,11 @@ export function ForgotPasswordFlow() {
                 )}
                 {step === "reset" && <ResetStep resetToken={resetToken} />}
 
-                <div className="mt-6 border-t border-zinc-200 pt-4 dark:border-zinc-700 text-center">
-                    <Link href="/login" className="text-sm text-zinc-500 dark:text-zinc-400 underline underline-offset-2">
+                <div className="mt-6 border-t border-[#e8c8b0] pt-4 text-center">
+                    <Link
+                        href="/login"
+                        className="text-sm font-semibold text-[#1c1410]/40 underline underline-offset-2 hover:text-[#f18840] transition-colors"
+                    >
                         ログイン画面に戻る
                     </Link>
                 </div>

--- a/apps/web/src/components/register/RegisterForm.tsx
+++ b/apps/web/src/components/register/RegisterForm.tsx
@@ -16,7 +16,7 @@ interface SecurityQuestion {
 
 function FieldError({ messages }: { messages?: string[] }) {
     if (!messages?.length) return null;
-    return <p className="mt-1 text-xs text-red-600 dark:text-red-400">{messages[0]}</p>;
+    return <p className="mt-1 text-xs font-medium text-[#f87171]">{messages[0]}</p>;
 }
 
 export function RegisterForm() {
@@ -30,7 +30,6 @@ export function RegisterForm() {
     const [questions, setQuestions] = useState<SecurityQuestion[]>([]);
     const [questionsError, setQuestionsError] = useState(false);
 
-    // 秘密の質問一覧をロード
     useEffect(() => {
         publicFetch<{ questions: SecurityQuestion[] }>("/security-questions")
             .then((res) => setQuestions(res.questions))
@@ -38,13 +37,36 @@ export function RegisterForm() {
     }, []);
 
     return (
-        <div className="flex min-h-screen items-center justify-center bg-zinc-50 dark:bg-zinc-900 py-12">
-            <section className="w-full max-w-md rounded-xl bg-white p-8 shadow dark:bg-zinc-800">
+        <div className="flex min-h-screen items-center justify-center bg-[#fffdf5] px-4 py-12">
+            {/* 背景の幾何学デコレーション */}
+            <div
+                className="pointer-events-none fixed left-8 top-20 h-16 w-16 rounded-full border border-[#f18840]/20 bg-[#fff6ee]"
+                aria-hidden="true"
+            />
+            <div
+                className="pointer-events-none fixed right-12 bottom-24 h-10 w-10 rotate-12 rounded-md border border-[#35b5a2]/20 bg-[#ecfaf8]"
+                aria-hidden="true"
+            />
+
+            <section
+                className="w-full max-w-md rounded-2xl border-2 border-[#1c1410] bg-white p-8"
+                style={{ boxShadow: "var(--shadow-pop)" }}
+            >
                 <div className="mb-6 flex items-start justify-between gap-4">
-                    <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-50">
-                        アカウント登録
-                    </h1>
-                    {/* セキュリティバッジ: ホバーでツールチップ表示 */}
+                    <div className="flex items-center gap-3">
+                        <span
+                            className="flex h-10 w-10 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-base font-extrabold text-white"
+                            style={{ boxShadow: "var(--shadow-pop-sm)" }}
+                        >
+                            B
+                        </span>
+                        <div>
+                            <h1 className="text-xl font-extrabold text-[#1c1410] leading-tight">
+                                アカウント登録
+                            </h1>
+                            <p className="text-xs text-[#1c1410]/50">まず無料ではじめよう</p>
+                        </div>
+                    </div>
                     <SecurityBadges />
                 </div>
 
@@ -56,13 +78,13 @@ export function RegisterForm() {
                         error={state.fieldErrors?.userId?.[0]}
                         disabled={isPending}
                     />
-                    {/* フォームの hidden フィールドとして値を渡す */}
                     <input type="hidden" name="userId" value={userId} />
 
                     {/* 表示名 */}
                     <div className="flex flex-col gap-1">
-                        <label htmlFor="displayName" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
-                            表示名 <span className="text-zinc-400 font-normal">（省略可・後から変更可）</span>
+                        <label htmlFor="displayName" className="text-sm font-semibold text-[#1c1410]">
+                            表示名{" "}
+                            <span className="font-normal text-[#1c1410]/40">（省略可・後から変更可）</span>
                         </label>
                         <input
                             id="displayName"
@@ -70,14 +92,14 @@ export function RegisterForm() {
                             type="text"
                             autoComplete="name"
                             placeholder="ニックネームなど（省略時はユーザー名と同じ）"
-                            className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                            className="input-pop"
                         />
                         <FieldError messages={state.fieldErrors?.displayName} />
                     </div>
 
                     {/* パスワード（強度メーター付き） */}
                     <div className="flex flex-col gap-1">
-                        <label htmlFor="password" className="text-sm font-medium text-zinc-700 dark:text-zinc-300">
+                        <label htmlFor="password" className="text-sm font-semibold text-[#1c1410]">
                             パスワード
                         </label>
                         <input
@@ -88,27 +110,27 @@ export function RegisterForm() {
                             onChange={(e) => setPassword(e.target.value)}
                             autoComplete="new-password"
                             placeholder="8文字以上"
-                            className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                            className="input-pop"
                         />
                         <PasswordStrengthMeter password={password} />
                         <FieldError messages={state.fieldErrors?.password} />
                     </div>
 
                     {/* 秘密の質問 */}
-                    <div className="rounded-lg border border-zinc-200 dark:border-zinc-700 p-4 space-y-3">
-                        <p className="text-sm font-medium text-zinc-800 dark:text-zinc-200">
+                    <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-4 space-y-3">
+                        <p className="text-sm font-extrabold text-[#1c1410]">
                             秘密の質問
                         </p>
-                        <p className="text-xs text-zinc-500 dark:text-zinc-400">
+                        <p className="text-xs text-[#1c1410]/50">
                             万が一パスワードを忘れても、この質問があれば安心して再設定できます
                         </p>
 
                         <div className="flex flex-col gap-1">
-                            <label htmlFor="securityQuestionId" className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
+                            <label htmlFor="securityQuestionId" className="text-xs font-bold text-[#1c1410]/60">
                                 質問を選択
                             </label>
                             {questionsError ? (
-                                <p className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-600 dark:bg-red-900/30 dark:text-red-400">
+                                <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-xs font-medium text-[#1c1410]">
                                     質問の読み込みに失敗しました。APIサーバーが起動しているか確認してください。
                                 </p>
                             ) : (
@@ -116,7 +138,7 @@ export function RegisterForm() {
                                     id="securityQuestionId"
                                     name="securityQuestionId"
                                     disabled={questions.length === 0}
-                                    className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 disabled:opacity-50 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                                    className="input-pop disabled:opacity-50"
                                 >
                                     <option value="">
                                         {questions.length === 0 ? "読み込み中..." : "-- 質問を選んでください --"}
@@ -130,7 +152,7 @@ export function RegisterForm() {
                         </div>
 
                         <div className="flex flex-col gap-1">
-                            <label htmlFor="securityAnswer" className="text-xs font-medium text-zinc-600 dark:text-zinc-400">
+                            <label htmlFor="securityAnswer" className="text-xs font-bold text-[#1c1410]/60">
                                 回答
                             </label>
                             <input
@@ -139,14 +161,14 @@ export function RegisterForm() {
                                 type="text"
                                 autoComplete="off"
                                 placeholder="回答を入力（大文字・小文字は区別されません）"
-                                className="rounded-lg border border-zinc-300 px-3 py-2 text-sm outline-none focus:border-zinc-500 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-50"
+                                className="input-pop"
                             />
                             <FieldError messages={state.fieldErrors?.securityAnswer} />
                         </div>
                     </div>
 
                     {state.error && (
-                        <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/30 dark:text-red-400">
+                        <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
                             {state.error}
                         </p>
                     )}
@@ -154,16 +176,19 @@ export function RegisterForm() {
                     <button
                         type="submit"
                         disabled={isPending}
-                        className="mt-2 rounded-full bg-zinc-900 px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                        className="btn-candy w-full mt-2 disabled:opacity-50"
                     >
                         {isPending ? "登録中..." : "アカウントを作成する"}
                     </button>
                 </form>
 
-                <div className="mt-4 border-t border-zinc-200 pt-4 dark:border-zinc-700 text-center">
-                    <p className="text-sm text-zinc-500 dark:text-zinc-400">
+                <div className="mt-4 border-t border-[#e8c8b0] pt-4 text-center">
+                    <p className="text-sm text-[#1c1410]/60">
                         すでにアカウントをお持ちですか？{" "}
-                        <Link href="/login" className="text-zinc-800 dark:text-zinc-200 underline underline-offset-2">
+                        <Link
+                            href="/login"
+                            className="font-semibold text-[#f18840] underline underline-offset-2 hover:text-[#e07030] transition-colors"
+                        >
                             ログイン
                         </Link>
                     </p>

--- a/apps/web/src/components/report/PeriodSelector.tsx
+++ b/apps/web/src/components/report/PeriodSelector.tsx
@@ -24,17 +24,19 @@ export function PeriodSelector() {
   }
 
   return (
-    <div className="flex gap-2">
+    <div className="flex gap-1.5">
       {PERIODS.map((period) => (
         <button
           key={period}
           type="button"
           onClick={() => select(period)}
-          className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+          className={[
+            "rounded-full px-3 py-1 text-xs font-bold transition-colors border-2",
             current === period
-              ? "bg-zinc-900 text-white dark:bg-zinc-50 dark:text-zinc-900"
-              : "border border-zinc-300 text-zinc-600 hover:bg-zinc-50 dark:border-zinc-600 dark:text-zinc-300 dark:hover:bg-zinc-700"
-          }`}
+              ? "bg-[#f18840] text-white border-[#1c1410]"
+              : "border-[#e8c8b0] bg-white text-[#1c1410]/60 hover:border-[#1c1410] hover:text-[#1c1410]",
+          ].join(" ")}
+          style={current === period ? { boxShadow: "2px 2px 0px 0px #1c1410" } : undefined}
         >
           {PERIOD_LABELS[period]}
         </button>

--- a/apps/web/src/components/report/RecentGraph.tsx
+++ b/apps/web/src/components/report/RecentGraph.tsx
@@ -49,7 +49,6 @@ function LineChart({
     100,
   );
 
-  // Y軸目盛り（5段階）
   const yTicks = Array.from({ length: 6 }, (_, i) =>
     Math.round((maxVal / 5) * i),
   );
@@ -79,15 +78,17 @@ function LineChart({
             y1={toY(tick)}
             x2={W - PAD.right}
             y2={toY(tick)}
-            stroke="#e5e7eb"
+            stroke="#e8c8b0"
             strokeWidth="1"
+            strokeDasharray="4 2"
           />
           <text
             x={PAD.left - 6}
             y={toY(tick) + 4}
             textAnchor="end"
             fontSize="10"
-            fill="#9ca3af"
+            fill="#1c1410"
+            opacity="0.4"
           >
             {tick >= 1000 ? `${Math.round(tick / 100) * 100}円` : `${tick}円`}
           </text>
@@ -102,7 +103,9 @@ function LineChart({
           y={H - 4}
           textAnchor="middle"
           fontSize="10"
-          fill="#9ca3af"
+          fontWeight="700"
+          fill="#1c1410"
+          opacity="0.4"
         >
           {d.label}
         </text>
@@ -113,8 +116,9 @@ function LineChart({
         d={pathD("outgo")}
         fill="none"
         stroke="var(--color-expense)"
-        strokeWidth="2"
+        strokeWidth="2.5"
         strokeLinejoin="round"
+        strokeLinecap="round"
       />
 
       {/* 収入ライン */}
@@ -122,8 +126,9 @@ function LineChart({
         d={pathD("income")}
         fill="none"
         stroke="var(--color-income)"
-        strokeWidth="2"
+        strokeWidth="2.5"
         strokeLinejoin="round"
+        strokeLinecap="round"
       />
 
       {/* 支出ドット */}
@@ -132,8 +137,10 @@ function LineChart({
           key={`outgo-${d.date}`}
           cx={toX(i)}
           cy={toY(d.outgo)}
-          r="4"
-          fill="var(--color-expense)"
+          r="5"
+          fill="white"
+          stroke="var(--color-expense)"
+          strokeWidth="2.5"
         />
       ))}
 
@@ -143,8 +150,10 @@ function LineChart({
           key={`income-${d.date}`}
           cx={toX(i)}
           cy={toY(d.income)}
-          r="4"
-          fill="var(--color-income)"
+          r="5"
+          fill="white"
+          stroke="var(--color-income)"
+          strokeWidth="2.5"
         />
       ))}
     </svg>
@@ -160,7 +169,7 @@ function RecentList({ expenses }: { expenses: ExpenseResponse[] }) {
   if (recent.length === 0) return null;
 
   return (
-    <ul className="mt-2 divide-y divide-zinc-100">
+    <ul className="mt-2 divide-y divide-[#e8c8b0]">
       {recent.map((expense) => {
         const category: Category | undefined = getCategoryById(
           expense.balanceType,
@@ -169,28 +178,26 @@ function RecentList({ expenses }: { expenses: ExpenseResponse[] }) {
         const isOutgo = expense.balanceType === 0;
 
         return (
-          <li key={expense.id} className="flex items-center justify-between py-2">
+          <li key={expense.id} className="flex items-center justify-between py-2.5">
             <div className="flex items-center gap-2">
               {category && (
                 <span
-                  className="rounded-full px-2 py-0.5 text-xs text-white"
+                  className="rounded-full border border-[#1c1410]/10 px-2 py-0.5 text-xs font-bold text-white"
                   style={{ backgroundColor: category.color }}
                 >
                   {category.name}
                 </span>
               )}
               {expense.content && (
-                <span className="text-xs text-zinc-500">{expense.content}</span>
+                <span className="text-xs font-medium text-[#1c1410]/50">{expense.content}</span>
               )}
             </div>
             <div className="flex items-center gap-2">
               <span
-                className={[
-                  "text-sm font-semibold",
-                  isOutgo
-                    ? "text-[var(--color-expense)]"
-                    : "text-[var(--color-income)]",
-                ].join(" ")}
+                className="text-sm font-extrabold tabular-nums"
+                style={{
+                  color: isOutgo ? "var(--color-expense)" : "var(--color-income)",
+                }}
               >
                 {isOutgo ? "-" : "+"}¥{expense.amount.toLocaleString()}
               </span>
@@ -207,23 +214,26 @@ export function RecentGraph({ expenses }: Props) {
   const data = buildGraphData(expenses);
 
   return (
-    <section className="flex h-full flex-col rounded-xl border border-zinc-100 bg-white p-5 shadow-sm">
-      <h2 className="mb-4 text-center text-sm font-semibold text-zinc-700">
+    <section
+      className="flex h-full flex-col rounded-2xl border-2 border-[#1c1410] bg-white p-5"
+      style={{ boxShadow: "var(--shadow-pop)" }}
+    >
+      <h2 className="mb-4 text-center text-sm font-extrabold text-[#1c1410] tracking-wide uppercase">
         直近のレポート
       </h2>
 
       {/* 凡例 */}
-      <div className="mb-3 flex items-center justify-center gap-4 text-xs text-zinc-500">
-        <span className="flex items-center gap-1">
+      <div className="mb-3 flex items-center justify-center gap-4 text-xs font-bold text-[#1c1410]/50">
+        <span className="flex items-center gap-1.5">
           <span
-            className="inline-block h-3 w-6 rounded"
+            className="inline-block h-2.5 w-5 rounded-full"
             style={{ backgroundColor: "var(--color-expense)" }}
           />
           支出
         </span>
-        <span className="flex items-center gap-1">
+        <span className="flex items-center gap-1.5">
           <span
-            className="inline-block h-3 w-6 rounded"
+            className="inline-block h-2.5 w-5 rounded-full"
             style={{ backgroundColor: "var(--color-income)" }}
           />
           収入

--- a/apps/web/src/components/report/TodayReport.tsx
+++ b/apps/web/src/components/report/TodayReport.tsx
@@ -18,41 +18,41 @@ export function TodayReport({ expenses }: Props) {
   const balance = income - outgo;
 
   return (
-    <section className="rounded-xl border border-zinc-100 bg-white p-5 shadow-sm">
-      <h2 className="mb-4 text-center text-sm font-semibold text-zinc-700">
+    <section
+      className="rounded-2xl border-2 border-[#1c1410] bg-white p-5"
+      style={{ boxShadow: "var(--shadow-pop)" }}
+    >
+      <h2 className="mb-4 text-center text-sm font-extrabold text-[#1c1410] tracking-wide uppercase">
         本日のレポート
       </h2>
 
       {/* 収支合計 */}
-      <div className="mb-3 rounded-lg border border-zinc-100 p-3 text-center">
-        <div className="flex items-center justify-center gap-3">
-          <span className="text-sm text-zinc-500">収支</span>
+      <div className="mb-3 rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-3 text-center">
+        <div className="flex items-center justify-center gap-2">
+          <span className="text-xs font-bold text-[#1c1410]/50">収支</span>
           <span
-            className={[
-              "text-lg font-semibold",
-              balance >= 0
-                ? "text-[var(--color-income)]"
-                : "text-[var(--color-expense)]",
-            ].join(" ")}
+            className="text-xl font-extrabold tabular-nums"
+            style={{
+              color: balance >= 0 ? "var(--color-income)" : "var(--color-expense)",
+            }}
           >
-            ¥ {balance >= 0 ? "" : ""}
-            {balance.toLocaleString()}
+            {balance >= 0 ? "+" : ""}¥{balance.toLocaleString()}
           </span>
         </div>
       </div>
 
       {/* 支出・収入内訳 */}
       <div className="grid grid-cols-2 gap-2">
-        <div className="rounded-lg border border-zinc-100 p-3">
-          <p className="text-xs text-[var(--color-expense)]">支出</p>
-          <p className="mt-1 text-base font-semibold text-zinc-800">
-            ¥ {outgo.toLocaleString()}
+        <div className="rounded-xl bg-[#fff6ee] p-3">
+          <p className="text-xs font-bold text-[#f18840]">支出</p>
+          <p className="mt-1 text-base font-extrabold tabular-nums text-[#1c1410]">
+            ¥{outgo.toLocaleString()}
           </p>
         </div>
-        <div className="rounded-lg border border-zinc-100 p-3">
-          <p className="text-xs text-[var(--color-income)]">収入</p>
-          <p className="mt-1 text-base font-semibold text-zinc-800">
-            ¥ {income.toLocaleString()}
+        <div className="rounded-xl bg-[#ecfaf8] p-3">
+          <p className="text-xs font-bold text-[#35b5a2]">収入</p>
+          <p className="mt-1 text-base font-extrabold tabular-nums text-[#1c1410]">
+            ¥{income.toLocaleString()}
           </p>
         </div>
       </div>

--- a/apps/web/src/components/settings/DataExportSection.tsx
+++ b/apps/web/src/components/settings/DataExportSection.tsx
@@ -42,12 +42,15 @@ export function DataExportSection() {
     }
 
     return (
-        <div className="rounded-xl border border-zinc-200 dark:border-zinc-700 p-6 space-y-4">
+        <div
+            className="rounded-2xl border-2 border-[#1c1410] bg-white p-6 space-y-4"
+            style={{ boxShadow: "var(--shadow-pop)" }}
+        >
             <div>
-                <h2 className="text-base font-semibold text-zinc-900 dark:text-zinc-50">
+                <h2 className="text-base font-extrabold text-[#1c1410]">
                     全データのバックアップ
                 </h2>
-                <p className="mt-1 text-sm text-zinc-500 dark:text-zinc-400">
+                <p className="mt-1 text-sm font-medium text-[#1c1410]/60">
                     いつでもデータを持ち出し可能です。サービスへの依存を気にせずご利用いただけます。
                 </p>
             </div>
@@ -62,20 +65,20 @@ export function DataExportSection() {
                             value={f}
                             checked={format === f}
                             onChange={() => setFormat(f)}
-                            className="accent-zinc-800 dark:accent-zinc-200"
+                            className="accent-[#f18840]"
                         />
-                        <span className="text-sm text-zinc-700 dark:text-zinc-300 uppercase font-mono">{f}</span>
+                        <span className="text-sm font-bold text-[#1c1410] uppercase font-mono">{f}</span>
                     </label>
                 ))}
             </div>
 
-            <div className="text-xs text-zinc-400 dark:text-zinc-500 space-y-0.5">
+            <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] px-3 py-2 text-xs font-medium text-[#1c1410]/60">
                 {format === "json" && <p>JSON 形式: 構造化データ。他ツールへのインポートやプログラムでの加工に最適</p>}
                 {format === "csv" && <p>CSV 形式: Excel / Google スプレッドシートで直接開けます</p>}
             </div>
 
             {error && (
-                <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-900/30 dark:text-red-400">
+                <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
                     {error}
                 </p>
             )}
@@ -84,7 +87,7 @@ export function DataExportSection() {
                 type="button"
                 onClick={handleExport}
                 disabled={isLoading}
-                className="rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white transition-colors hover:bg-zinc-700 disabled:opacity-50 dark:bg-zinc-50 dark:text-zinc-900 dark:hover:bg-zinc-200"
+                className="btn-candy disabled:opacity-50"
             >
                 {isLoading ? "準備中..." : `${format.toUpperCase()} でダウンロード`}
             </button>

--- a/docs/design/figma-tokens.json
+++ b/docs/design/figma-tokens.json
@@ -1,16 +1,20 @@
 {
   "_comment": "Figma Variables のエクスポートJSON。Figma Plugin（例: Variables Import/Export）でエクスポートし、このファイルを上書きしてください。",
   "_usage": "pnpm run sync:tokens でこのファイルから globals.css のCSS変数を自動更新します。",
-  "_source": "スクリーンショット解析による初期値（2026-04-12）",
+  "_source": "Playful Geometric デザインシステム適用（2026-04-15）— オレンジ#f08030/ティール#2bb5a0 を既存踏襲",
   "colors": {
-    "brand/primary": { "value": "#f08030", "type": "color" },
-    "brand/secondary": { "value": "#e06020", "type": "color" },
+    "brand/primary": { "value": "#f18840", "type": "color" },
+    "brand/secondary": { "value": "#e07030", "type": "color" },
     "surface/default": { "value": "#ffffff", "type": "color" },
-    "surface/subtle": { "value": "#fef5ee", "type": "color" },
-    "expense": { "value": "#f08030", "type": "color" },
-    "expense/light": { "value": "#fff5ec", "type": "color" },
-    "income": { "value": "#2bb5a0", "type": "color" },
-    "income/light": { "value": "#ecfaf8", "type": "color" }
+    "surface/subtle": { "value": "#fffdf5", "type": "color" },
+    "expense": { "value": "#f18840", "type": "color" },
+    "expense/light": { "value": "#fff6ee", "type": "color" },
+    "income": { "value": "#35b5a2", "type": "color" },
+    "income/light": { "value": "#ecfaf8", "type": "color" },
+    "playful/coral": { "value": "#f87171", "type": "color" },
+    "playful/coral-light": { "value": "#fee2e2", "type": "color" },
+    "playful/amber": { "value": "#fbbf24", "type": "color" },
+    "playful/amber-light": { "value": "#fef3c7", "type": "color" }
   },
   "spacing": {
     "xs": { "value": "4", "type": "dimension", "unit": "px" },
@@ -21,8 +25,10 @@
   },
   "borderRadius": {
     "sm": { "value": "4", "type": "dimension", "unit": "px" },
-    "md": { "value": "8", "type": "dimension", "unit": "px" },
-    "card": { "value": "12", "type": "dimension", "unit": "px" },
+    "md": { "value": "12", "type": "dimension", "unit": "px" },
+    "card": { "value": "16", "type": "dimension", "unit": "px" },
+    "lg": { "value": "20", "type": "dimension", "unit": "px" },
+    "xl": { "value": "24", "type": "dimension", "unit": "px" },
     "full": { "value": "9999", "type": "dimension", "unit": "px" }
   }
 }


### PR DESCRIPTION
## Summary

- **Playful Geometric デザインシステム**を全ページ・全コンポーネントに適用
- フォント: Geist → **Outfit**（400〜800weight）
- カラー: 彩度約5%低減・明度微増（`#f08030` → `#f18840`、`#2bb5a0` → `#35b5a2`）
- 情報優先度に基づく **3段階ビジュアル階層** を実装

## 情報優先度ルール

| 優先度 | 対象 | スタイル |
|--------|------|---------|
| 高 | フォーム・モーダル・主要ボタン | `border-2 border-[#1c1410]` + 2px ハードシャドウ |
| 中 | 情報カード・リスト | `border border-[#1c1410]/12` + soft shadow |
| 低 | 背景要素・デコレーション | ボーダーなし、背景トーン差のみ |

## 変更ファイル

- `docs/design/figma-tokens.json` — カラートークン更新
- `apps/web/src/app/globals.css` — Soft Pop シャドウ、Material You イージング、コンポーネントクラス定義
- `apps/web/src/app/layout.tsx` — Outfit フォント
- 15コンポーネント — Playful Geometric スタイル適用
- `__tests__/components/PeriodSelector.test.tsx` — アクティブ色アサーション更新
- `__tests__/components/ExpenseList.test.tsx` — 収支プレフィックス表示対応

## Test plan

- [x] `pnpm test:unit` — 全41テスト通過
- [x] `pnpm -F web build` — ビルド成功
- [x] pre-commit hooks（lint / type-check / format / unit-test）通過
- [x] pre-push hooks（integration-test）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)