### PR TITLE
feature: AWS インフラ Phase 1 Terraform 構成（VPC/IAM/ECR/SG）

### DIFF
--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,0 +1,26 @@
+# Terraform state
+*.tfstate
+*.tfstate.backup
+*.tfstate.lock.info
+
+# Terraform working directory
+.terraform/
+# .terraform.lock.hcl はコミット対象（プロバイダーバージョン再現性のため）
+
+# 機密値を含む可能性があるため vars ファイルは除外
+# （例外: .example はコミット可）
+*.tfvars
+!*.tfvars.example
+
+# Crash log
+crash.log
+crash.*.log
+
+# Terraform plan output
+*.tfplan
+
+# Override files
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,99 @@
+# infra — Terraform による AWS インフラ構成
+
+budget-management-tool の AWS インフラを Terraform で管理するディレクトリ。
+
+## ディレクトリ構成
+
+```
+infra/
+├── bootstrap/          # 前提リソース（S3 state バケット・DynamoDB ロックテーブル）
+├── modules/            # 再利用可能なモジュール
+│   ├── vpc/            # VPC・サブネット・ルートテーブル
+│   ├── iam/            # OIDC プロバイダー・IAM ロール
+│   ├── ecr/            # ECR リポジトリ・ライフサイクルポリシー
+│   └── sg/             # セキュリティグループ（web/api/rds）
+└── dev/                # dev 環境のルートモジュール
+```
+
+## 設計方針（コスト最小化）
+
+| 非採用リソース | 理由 |
+|--------------|------|
+| ALB | CloudFront + Next.js Rewrites で代替（月 $16 削減） |
+| NAT Gateway | パブリックサブネット構成で代替（月 $35 削減） |
+| Secrets Manager | SSM Parameter Store 無料枠で代替（月 $0.4/secret 削減） |
+
+- Fargate: 0.25 vCPU / 512MB（無料枠 750h/月 に収める）
+- ECR: ライフサイクルポリシーで最新 5 世代のみ保持（無料枠 500MB/月 以内）
+- AWS Budgets: 月 $1 超過時にアラートメール送信
+
+## 認証方式
+
+GitHub Actions から AWS への認証は **OIDC（キーレス認証）** を採用。永続的なアクセスキーは発行しない。
+
+```
+GitHub Actions → OIDC トークン → AssumeRoleWithWebIdentity → GitHubActionsRole
+```
+
+`main` ブランチからの push のみが AssumeRole を許可される（他ブランチは拒否）。
+
+## セキュリティ構成
+
+| ファイル | Git 管理 | 理由 |
+|---------|---------|------|
+| `*.tfvars` | **除外** | メールアドレス・GitHub ユーザー名等を含むため |
+| `*.tfstate` | **除外** | AWS リソース ID 等の実行時情報を含むため |
+| `.terraform.lock.hcl` | **追跡** | プロバイダーバージョンの再現性確保のため |
+| `*.tfvars.example` | **追跡** | 設定項目のテンプレートとして共有 |
+
+## 初回セットアップ手順
+
+### 前提条件
+
+- Terraform >= 1.7.0
+- AWS CLI（`aws configure` 済み、または環境変数で認証設定済み）
+
+### Step 1: Terraform state バックエンドの作成
+
+```bash
+cd infra/bootstrap
+terraform init
+terraform apply
+```
+
+S3 バケット `budget-dev-terraform-state` と DynamoDB テーブル `budget-dev-terraform-locks` が作成される。
+
+### Step 2: tfvars の準備
+
+```bash
+cd infra/dev
+cp terraform.tfvars.example terraform.tfvars
+# terraform.tfvars を編集して実際の値を入力する
+```
+
+### Step 3: dev 環境の適用
+
+```bash
+cd infra/dev
+terraform init
+terraform plan   # 差分を確認してから
+terraform apply
+```
+
+### Step 4: GitHub Actions の設定
+
+`terraform apply` 完了後に出力される値を GitHub リポジトリの Secrets に登録する。
+
+| Secrets 名 | terraform output | 説明 |
+|-----------|-----------------|------|
+| `AWS_ROLE_ARN` | `github_actions_role_arn` | OIDC で assume するロール ARN |
+| `AWS_REGION` | — | `ap-northeast-1` を直接入力 |
+
+ECR push 先 URL は `ecr_repository_urls` output を参照。
+
+## 変更時の注意
+
+- `terraform plan` で差分を必ず確認してから `apply` する
+- RDS の `publicly_accessible = true` は禁止（セキュリティポリシー）
+- `aws_nat_gateway` / `aws_alb` の追加はコスト審査が必要
+- IAM ポリシーの拡張は最小権限原則に従い、追加理由をコメントに記載する

--- a/infra/bootstrap/.terraform.lock.hcl
+++ b/infra/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,63 @@
+# ============================================================
+# Bootstrap: Terraform Remote State バックエンドの初期構築
+#
+# 適用順序:
+#   1. cd infra/bootstrap && terraform init && terraform apply
+#   2. cd infra/dev       && terraform init && terraform apply
+#
+# ⚠️ このモジュール自体は Local State で管理する（鶏卵問題）。
+# ============================================================
+
+locals {
+  bucket_name  = "${var.project}-dev-terraform-state"
+  dynamo_table = "${var.project}-dev-terraform-locks"
+}
+
+# ─── S3: Terraform State ────────────────────────────────────────────────────
+
+resource "aws_s3_bucket" "terraform_state" {
+  bucket = local.bucket_name
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state" {
+  bucket = aws_s3_bucket.terraform_state.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state" {
+  bucket                  = aws_s3_bucket.terraform_state.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ─── DynamoDB: State Locking ──────────────────────────────────────────────────
+
+resource "aws_dynamodb_table" "terraform_locks" {
+  name         = local.dynamo_table
+  billing_mode = "PAY_PER_REQUEST" # 無料枠対象・低頻度アクセスに最適
+  hash_key     = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "state_bucket_name" {
+  description = "Terraform State 用 S3 バケット名（dev/backend.tf に記載）"
+  value       = aws_s3_bucket.terraform_state.bucket
+}
+
+output "lock_table_name" {
+  description = "Terraform State ロック用 DynamoDB テーブル名（dev/backend.tf に記載）"
+  value       = aws_dynamodb_table.terraform_locks.name
+}

--- a/infra/bootstrap/providers.tf
+++ b/infra/bootstrap/providers.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+  # Bootstrap は Local State で管理（鶏卵問題を回避）
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = "shared"
+      ManagedBy   = "terraform"
+      Component   = "bootstrap"
+    }
+  }
+}

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -1,0 +1,11 @@
+variable "project" {
+  description = "プロジェクト名（リソース名前付けに使用）"
+  type        = string
+  default     = "budget"
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}

--- a/infra/dev/.terraform.lock.hcl
+++ b/infra/dev/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infra/dev/backend.tf
+++ b/infra/dev/backend.tf
@@ -1,0 +1,17 @@
+# ============================================================
+# Remote State Backend (S3 + DynamoDB)
+#
+# bootstrap/ で作成したリソースをバックエンドとして使用する。
+# 初回適用前に以下を実行すること:
+#   cd ../bootstrap && terraform apply
+# ============================================================
+
+terraform {
+  backend "s3" {
+    bucket         = "budget-dev-terraform-state"
+    key            = "dev/terraform.tfstate"
+    region         = "ap-northeast-1"
+    dynamodb_table = "budget-dev-terraform-locks"
+    encrypt        = true
+  }
+}

--- a/infra/dev/budgets.tf
+++ b/infra/dev/budgets.tf
@@ -1,0 +1,32 @@
+# ============================================================
+# AWS Budgets: 月次コスト上限アラート
+#
+# 無料枠: AWS Budgets は月 2 件まで無料
+# アラート条件: 実績が上限の 80% / 100% を超えた場合にメール送信
+# ============================================================
+
+resource "aws_budgets_budget" "monthly" {
+  name         = "${local.name_prefix}-monthly-budget"
+  budget_type  = "COST"
+  limit_amount = var.budget_limit_usd
+  limit_unit   = "USD"
+  time_unit    = "MONTHLY"
+
+  # 実績コストが上限の 80% を超えたらアラート
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 80
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
+
+  # 実績コストが上限の 100% を超えたらアラート
+  notification {
+    comparison_operator        = "GREATER_THAN"
+    threshold                  = 100
+    threshold_type             = "PERCENTAGE"
+    notification_type          = "ACTUAL"
+    subscriber_email_addresses = [var.alert_email]
+  }
+}

--- a/infra/dev/locals.tf
+++ b/infra/dev/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  # リソース名プレフィックス: budget-dev
+  name_prefix = "${var.project}-${var.env}"
+}

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -1,0 +1,44 @@
+# ============================================================
+# Root Module: dev
+#
+# フェーズ 1: VPC / IAM / ECR / SG の基盤リソース
+#
+# 適用順:
+#   1. cd ../bootstrap && terraform apply  (初回のみ)
+#   2. terraform init
+#   3. terraform plan
+#   4. terraform apply
+# ============================================================
+
+# ─── フェーズ 1: VPC ─────────────────────────────────────────────────────────
+
+module "vpc" {
+  source      = "../modules/vpc"
+  name_prefix = local.name_prefix
+}
+
+# ─── フェーズ 2: IAM (OIDC + Roles) ──────────────────────────────────────────
+
+module "iam" {
+  source      = "../modules/iam"
+  name_prefix = local.name_prefix
+  aws_region  = var.aws_region
+  github_org  = var.github_org
+  github_repo = var.github_repo
+}
+
+# ─── フェーズ 3: ECR リポジトリ ───────────────────────────────────────────────
+
+module "ecr" {
+  source      = "../modules/ecr"
+  name_prefix = local.name_prefix
+}
+
+# ─── フェーズ 4: セキュリティグループ ────────────────────────────────────────
+
+module "sg" {
+  source      = "../modules/sg"
+  name_prefix = local.name_prefix
+  vpc_id      = module.vpc.vpc_id
+  vpc_cidr    = module.vpc.vpc_cidr
+}

--- a/infra/dev/outputs.tf
+++ b/infra/dev/outputs.tf
@@ -1,0 +1,47 @@
+# ─── VPC ─────────────────────────────────────────────────────────────────────
+
+output "vpc_id" {
+  description = "VPC ID"
+  value       = module.vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "パブリックサブネット ID リスト"
+  value       = module.vpc.public_subnet_ids
+}
+
+# ─── IAM ─────────────────────────────────────────────────────────────────────
+
+output "github_actions_role_arn" {
+  description = "GitHubActionsRole ARN — GitHub Actions Secrets の role-to-assume に設定する"
+  value       = module.iam.github_actions_role_arn
+}
+
+output "ecs_task_execution_role_arn" {
+  description = "EcsTaskExecutionRole ARN — ECS タスク定義の executionRoleArn に設定する"
+  value       = module.iam.ecs_task_execution_role_arn
+}
+
+# ─── ECR ─────────────────────────────────────────────────────────────────────
+
+output "ecr_repository_urls" {
+  description = "ECR リポジトリ URL マップ — docker push 先として使用"
+  value       = module.ecr.repository_urls
+}
+
+# ─── SG ──────────────────────────────────────────────────────────────────────
+
+output "sg_web_id" {
+  description = "sg-web ID"
+  value       = module.sg.web_sg_id
+}
+
+output "sg_api_id" {
+  description = "sg-api ID"
+  value       = module.sg.api_sg_id
+}
+
+output "sg_rds_id" {
+  description = "sg-rds ID"
+  value       = module.sg.rds_sg_id
+}

--- a/infra/dev/providers.tf
+++ b/infra/dev/providers.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.7.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project     = var.project
+      Environment = var.env
+      ManagedBy   = "terraform"
+    }
+  }
+}

--- a/infra/dev/terraform.tfvars.example
+++ b/infra/dev/terraform.tfvars.example
@@ -1,0 +1,21 @@
+# ============================================================
+# terraform.tfvars.example
+#
+# このファイルをコピーして terraform.tfvars を作成し、実際の値を入力すること。
+# terraform.tfvars は .gitignore 対象（リポジトリにコミットしない）。
+#
+#   cp terraform.tfvars.example terraform.tfvars
+# ============================================================
+
+# ─── 基本設定 ─────────────────────────────────────────────────────────────
+project    = "budget"
+env        = "dev"
+aws_region = "ap-northeast-1"
+
+# ─── GitHub 連携 ──────────────────────────────────────────────────────────
+github_org  = "your-github-username"
+github_repo = "budget-management-tool"
+
+# ─── コスト管理 ───────────────────────────────────────────────────────────
+budget_limit_usd = "1"
+alert_email      = "your-email@example.com"

--- a/infra/dev/variables.tf
+++ b/infra/dev/variables.tf
@@ -1,0 +1,38 @@
+variable "project" {
+  description = "プロジェクト名（リソース名前付けプレフィックスに使用）"
+  type        = string
+  default     = "budget"
+}
+
+variable "env" {
+  description = "環境名（dev / stg / prod）"
+  type        = string
+  default     = "dev"
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "github_org" {
+  description = "GitHub 組織名またはユーザー名"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub リポジトリ名"
+  type        = string
+}
+
+variable "budget_limit_usd" {
+  description = "月次コスト上限（USD）。超過時にアラートメールを送信する"
+  type        = string
+  default     = "1"
+}
+
+variable "alert_email" {
+  description = "コスト超過アラートの送信先メールアドレス"
+  type        = string
+}

--- a/infra/modules/ecr/main.tf
+++ b/infra/modules/ecr/main.tf
@@ -1,0 +1,49 @@
+# ============================================================
+# Module: ecr
+#
+# 構成:
+#   - budget-{name_prefix}-{repo} リポジトリを repositories リストから作成
+#   - ライフサイクルポリシー: 最新 max_image_count 世代のみ保持
+#     → 無料枠 500MB/月 を超過させないための制限
+#
+# 禁止事項:
+#   - publicly_accessible = true の設定禁止
+# ============================================================
+
+resource "aws_ecr_repository" "this" {
+  for_each = toset(var.repositories)
+
+  name         = "${var.name_prefix}-${each.key}"
+  force_delete = var.force_delete
+
+  image_scanning_configuration {
+    # プッシュ時に脆弱性スキャンを自動実行（追加コストなし）
+    scan_on_push = true
+  }
+
+  # イメージタグの上書きを許可（latest タグの更新に必要）
+  image_tag_mutability = "MUTABLE"
+}
+
+resource "aws_ecr_lifecycle_policy" "this" {
+  for_each = aws_ecr_repository.this
+
+  repository = each.value.name
+
+  policy = jsonencode({
+    rules = [
+      {
+        rulePriority = 1
+        description  = "最新 ${var.max_image_count} 世代を保持し、古いイメージを自動削除（無料枠超過防止）"
+        selection = {
+          tagStatus   = "any"
+          countType   = "imageCountMoreThan"
+          countNumber = var.max_image_count
+        }
+        action = {
+          type = "expire"
+        }
+      }
+    ]
+  })
+}

--- a/infra/modules/ecr/outputs.tf
+++ b/infra/modules/ecr/outputs.tf
@@ -1,0 +1,9 @@
+output "repository_urls" {
+  description = "リポジトリ名 → URL のマップ（docker push 先として使用）"
+  value       = { for k, v in aws_ecr_repository.this : k => v.repository_url }
+}
+
+output "repository_arns" {
+  description = "リポジトリ名 → ARN のマップ（IAM ポリシーリソース指定に使用）"
+  value       = { for k, v in aws_ecr_repository.this : k => v.arn }
+}

--- a/infra/modules/ecr/variables.tf
+++ b/infra/modules/ecr/variables.tf
@@ -1,0 +1,22 @@
+variable "name_prefix" {
+  description = "リソース名前付けプレフィックス"
+  type        = string
+}
+
+variable "repositories" {
+  description = "作成する ECR リポジトリ名サフィックスのリスト（例: [\"web\", \"api\"]）"
+  type        = list(string)
+  default     = ["web", "api"]
+}
+
+variable "max_image_count" {
+  description = "保持するイメージの最大世代数（無料枠 500MB/月 を超過させないため制限）"
+  type        = number
+  default     = 5
+}
+
+variable "force_delete" {
+  description = "リポジトリ削除時にイメージが残っていても強制削除するか（dev 環境のみ true 推奨）"
+  type        = bool
+  default     = true
+}

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -1,0 +1,183 @@
+# ============================================================
+# Module: iam
+#
+# 構成:
+#   1. GitHub Actions OIDC ID プロバイダー
+#      → 永続的アクセスキー不要のキーレス認証
+#   2. GitHubActionsRole
+#      → main ブランチからのみ AssumeRoleWithWebIdentity を許可
+#      → ECR Push / ECS デプロイ / SSM 読取 の最小権限
+#   3. EcsTaskExecutionRole
+#      → コンテナ起動に必要な標準権限 + SSM Parameter Store 読取
+#
+# 禁止事項:
+#   aws_iam_access_key の発行は行わない（OIDC で代替）
+# ============================================================
+
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id       = data.aws_caller_identity.current.account_id
+  github_oidc_url  = "https://token.actions.githubusercontent.com"
+  ecr_resource_arn = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${var.name_prefix}-*"
+  ssm_resource_arn = "arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter/${var.name_prefix}/*"
+}
+
+# ─── GitHub Actions OIDC ID プロバイダー ────────────────────────────────────
+
+resource "aws_iam_openid_connect_provider" "github" {
+  url             = local.github_oidc_url
+  client_id_list  = ["sts.amazonaws.com"]
+  thumbprint_list = var.github_thumbprints
+}
+
+# ─── GitHubActionsRole ────────────────────────────────────────────────────────
+
+resource "aws_iam_role" "github_actions" {
+  name        = "${var.name_prefix}-github-actions-role"
+  description = "GitHub Actions から OIDC 経由で AssumeRole。ECR Push / ECS Deploy / SSM Read のみ許可。"
+
+  assume_role_policy = data.aws_iam_policy_document.github_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.github.arn]
+    }
+
+    # aud: GitHub が STS に送るオーディエンス
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    # sub: main ブランチからの push のみを許可
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:${var.github_org}/${var.github_repo}:ref:refs/heads/main"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "github_actions" {
+  name   = "${var.name_prefix}-github-actions-policy"
+  role   = aws_iam_role.github_actions.id
+  policy = data.aws_iam_policy_document.github_actions_policy.json
+}
+
+data "aws_iam_policy_document" "github_actions_policy" {
+  # ECR: 認証トークン取得（全リポジトリ対象、リソース指定不可）
+  statement {
+    sid       = "ECRAuth"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+
+  # ECR: budget-* リポジトリへのイメージ Push / Pull
+  statement {
+    sid    = "ECRPush"
+    effect = "Allow"
+    actions = [
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:CompleteLayerUpload",
+      "ecr:InitiateLayerUpload",
+      "ecr:PutImage",
+      "ecr:UploadLayerPart",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = [local.ecr_resource_arn]
+  }
+
+  # ECS: タスク定義更新・サービス更新
+  statement {
+    sid    = "ECSDeployDescribe"
+    effect = "Allow"
+    actions = [
+      "ecs:RegisterTaskDefinition",
+      "ecs:UpdateService",
+      "ecs:DescribeServices",
+      "ecs:DescribeTaskDefinition",
+      "ecs:ListTaskDefinitions",
+      "ecs:ListClusters",
+    ]
+    resources = ["*"]
+  }
+
+  # ECS: タスク定義へ EcsTaskExecutionRole を渡す権限
+  statement {
+    sid     = "ECSPassRole"
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+    resources = [
+      aws_iam_role.ecs_task_execution.arn,
+    ]
+    condition {
+      test     = "StringLike"
+      variable = "iam:PassedToService"
+      values   = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+
+  # SSM Parameter Store: アプリ設定の読取（シークレット含む）
+  statement {
+    sid    = "SSMRead"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+    resources = [local.ssm_resource_arn]
+  }
+}
+
+# ─── EcsTaskExecutionRole ────────────────────────────────────────────────────
+
+resource "aws_iam_role" "ecs_task_execution" {
+  name        = "${var.name_prefix}-ecs-task-execution-role"
+  description = "ECS タスク実行ロール。コンテナ起動時に ECR Pull と CloudWatch Logs 書込みを許可。"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "ecs-tasks.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+}
+
+# ECR Pull + CloudWatch Logs: AWS 管理ポリシーで付与
+resource "aws_iam_role_policy_attachment" "ecs_task_execution_managed" {
+  role       = aws_iam_role.ecs_task_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# SSM Parameter Store: アプリ起動時に環境変数としてシークレットを注入
+resource "aws_iam_role_policy" "ecs_task_execution_ssm" {
+  name   = "${var.name_prefix}-ecs-ssm-read-policy"
+  role   = aws_iam_role.ecs_task_execution.id
+  policy = data.aws_iam_policy_document.ecs_ssm_policy.json
+}
+
+data "aws_iam_policy_document" "ecs_ssm_policy" {
+  statement {
+    sid    = "SSMReadForTaskEnv"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:GetParameters",
+      "ssm:GetParametersByPath",
+    ]
+    resources = [local.ssm_resource_arn]
+  }
+}

--- a/infra/modules/iam/outputs.tf
+++ b/infra/modules/iam/outputs.tf
@@ -1,0 +1,19 @@
+output "github_oidc_provider_arn" {
+  description = "GitHub Actions OIDC ID プロバイダー ARN"
+  value       = aws_iam_openid_connect_provider.github.arn
+}
+
+output "github_actions_role_arn" {
+  description = "GitHubActionsRole ARN（GitHub Actions Secrets の role-to-assume に設定）"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "ecs_task_execution_role_arn" {
+  description = "EcsTaskExecutionRole ARN（ECS タスク定義の executionRoleArn に設定）"
+  value       = aws_iam_role.ecs_task_execution.arn
+}
+
+output "ecs_task_execution_role_name" {
+  description = "EcsTaskExecutionRole 名（ECS サービス定義で参照）"
+  value       = aws_iam_role.ecs_task_execution.name
+}

--- a/infra/modules/iam/variables.tf
+++ b/infra/modules/iam/variables.tf
@@ -1,0 +1,28 @@
+variable "name_prefix" {
+  description = "リソース名前付けプレフィックス"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+}
+
+variable "github_org" {
+  description = "GitHub 組織名またはユーザー名"
+  type        = string
+}
+
+variable "github_repo" {
+  description = "GitHub リポジトリ名"
+  type        = string
+}
+
+variable "github_thumbprints" {
+  description = "GitHub OIDC エンドポイントの TLS 証明書フィンガープリント（証明書ローテーション対応のため複数指定）"
+  type        = list(string)
+  default = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd",
+  ]
+}

--- a/infra/modules/sg/main.tf
+++ b/infra/modules/sg/main.tf
@@ -1,0 +1,105 @@
+# ============================================================
+# Module: sg
+#
+# 構成:
+#   1. sg-web  — CloudFront/インターネットからの HTTP/HTTPS を受け付ける
+#   2. sg-api  — sg-web からのトラフィックのみを受け付ける
+#   3. sg-rds  — sg-api からの MySQL (3306) のみを受け付ける
+#
+# 禁止事項:
+#   - sg-rds への 0.0.0.0/0 ingress は絶対に設定しない
+# ============================================================
+
+# ─── sg-web ──────────────────────────────────────────────────────────────────
+
+resource "aws_security_group" "web" {
+  name        = "${var.name_prefix}-sg-web"
+  description = "CloudFront / Internet → ECS Web (80, 443)"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "HTTP from anywhere"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTPS from anywhere"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-sg-web"
+  }
+}
+
+# ─── sg-api ──────────────────────────────────────────────────────────────────
+
+resource "aws_security_group" "api" {
+  name        = "${var.name_prefix}-sg-api"
+  description = "ECS Web → ECS API (3000)"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "API port from sg-web"
+    from_port       = 3000
+    to_port         = 3000
+    protocol        = "tcp"
+    security_groups = [aws_security_group.web.id]
+  }
+
+  egress {
+    description = "Allow all outbound"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-sg-api"
+  }
+}
+
+# ─── sg-rds ──────────────────────────────────────────────────────────────────
+
+resource "aws_security_group" "rds" {
+  name        = "${var.name_prefix}-sg-rds"
+  description = "ECS API → RDS MySQL (3306) のみ許可。外部からの直接アクセス禁止。"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description     = "MySQL from sg-api only"
+    from_port       = 3306
+    to_port         = 3306
+    protocol        = "tcp"
+    security_groups = [aws_security_group.api.id]
+  }
+
+  # egress はデフォルトで全拒否（RDS から外部への通信は不要）
+  # 明示的に egress を定義しないことで AWS のデフォルト動作（全許可）を避ける
+  egress {
+    description = "Allow all outbound (RDS VPC 内通信用)"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = [var.vpc_cidr]
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-sg-rds"
+  }
+}

--- a/infra/modules/sg/outputs.tf
+++ b/infra/modules/sg/outputs.tf
@@ -1,0 +1,14 @@
+output "web_sg_id" {
+  description = "sg-web ID（ECS Web タスクのネットワーク設定に使用）"
+  value       = aws_security_group.web.id
+}
+
+output "api_sg_id" {
+  description = "sg-api ID（ECS API タスクのネットワーク設定に使用）"
+  value       = aws_security_group.api.id
+}
+
+output "rds_sg_id" {
+  description = "sg-rds ID（RDS インスタンスのセキュリティグループに使用）"
+  value       = aws_security_group.rds.id
+}

--- a/infra/modules/sg/variables.tf
+++ b/infra/modules/sg/variables.tf
@@ -1,0 +1,14 @@
+variable "name_prefix" {
+  description = "リソース名前付けプレフィックス"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "セキュリティグループを作成する VPC ID"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "VPC CIDR ブロック（sg-rds の ingress 制限に使用）"
+  type        = string
+}

--- a/infra/modules/vpc/main.tf
+++ b/infra/modules/vpc/main.tf
@@ -1,0 +1,73 @@
+# ============================================================
+# Module: vpc
+#
+# 構成:
+#   - VPC (10.0.0.0/16)
+#   - パブリックサブネット x2 (AZ: a, c) — RDS Multi-AZ 要件を満たす
+#   - Internet Gateway
+#   - パブリックルートテーブル（0.0.0.0/0 → IGW）
+#
+# 設計方針:
+#   NAT Gateway ($35/月) を不採用。
+#   ECS タスクはパブリックサブネットに配置し、
+#   ECR/SSM などの AWS サービスには直接インターネット経由でアクセス。
+#   RDS へのアクセスは SG で sg-api からのみに制限。
+# ============================================================
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = {
+    Name = "${var.name_prefix}-vpc"
+  }
+}
+
+# ─── Internet Gateway ────────────────────────────────────────────────────────
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+
+  tags = {
+    Name = "${var.name_prefix}-igw"
+  }
+}
+
+# ─── パブリックサブネット（Multi-AZ: a, c）──────────────────────────────────
+
+resource "aws_subnet" "public" {
+  for_each = var.public_subnets
+
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = each.value.cidr
+  availability_zone       = each.value.az
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name = "${var.name_prefix}-pub-${each.key}"
+    Tier = "public"
+  }
+}
+
+# ─── ルートテーブル（IGW 経由で 0.0.0.0/0）─────────────────────────────────
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-rt-public"
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.public.id
+}

--- a/infra/modules/vpc/outputs.tf
+++ b/infra/modules/vpc/outputs.tf
@@ -1,0 +1,24 @@
+output "vpc_id" {
+  description = "VPC ID"
+  value       = aws_vpc.main.id
+}
+
+output "vpc_cidr" {
+  description = "VPC CIDR ブロック"
+  value       = aws_vpc.main.cidr_block
+}
+
+output "public_subnet_ids" {
+  description = "パブリックサブネット ID リスト（RDS SubnetGroup / ECS 配置に使用）"
+  value       = [for s in aws_subnet.public : s.id]
+}
+
+output "public_subnet_map" {
+  description = "AZ識別子 → サブネット ID のマップ"
+  value       = { for k, s in aws_subnet.public : k => s.id }
+}
+
+output "internet_gateway_id" {
+  description = "Internet Gateway ID"
+  value       = aws_internet_gateway.main.id
+}

--- a/infra/modules/vpc/variables.tf
+++ b/infra/modules/vpc/variables.tf
@@ -1,0 +1,22 @@
+variable "name_prefix" {
+  description = "リソース名前付けプレフィックス（例: budget-dev）"
+  type        = string
+}
+
+variable "vpc_cidr" {
+  description = "VPC の CIDR ブロック"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnets" {
+  description = "パブリックサブネット定義（key = AZ識別子、value = cidr + az）"
+  type = map(object({
+    cidr = string
+    az   = string
+  }))
+  default = {
+    a = { cidr = "10.0.1.0/24", az = "ap-northeast-1a" }
+    c = { cidr = "10.0.2.0/24", az = "ap-northeast-1c" }
+  }
+}


### PR DESCRIPTION
## Summary

- **bootstrap**: Terraform remote state 用 S3 バケット・DynamoDB テーブルを作成
- **modules/vpc**: 10.0.0.0/16 VPC、AZ a/c のパブリックサブネット 2 本（NAT Gateway なし、月 $35 削減）
- **modules/iam**: GitHub Actions OIDC 認証（永続アクセスキーなし）、GitHubActionsRole（main ブランチ限定）、EcsTaskExecutionRole
- **modules/ecr**: budget-web/api リポジトリ、ライフサイクルポリシー（最新 5 世代保持、無料枠 500MB/月 以内）
- **modules/sg**: sg-web → sg-api → sg-rds の最小権限チェーン（sg-rds への外部アクセス禁止）
- **dev**: 全モジュールを束ねるルートモジュール、AWS Budgets 月次アラート（$1 上限）
- **infra/README.md**: セットアップ手順・セキュリティ構成・コスト設計方針を記載

## セキュリティ確認

| 項目 | 状態 |
|------|------|
| `terraform.tfvars`（実値） | `.gitignore` 対象、コミットされない |
| `*.tfstate` | `.gitignore` 対象、コミットされない |
| AWS アカウント ID | ハードコードなし（`data.aws_caller_identity` で動的取得） |
| アクセスキー | 発行なし（OIDC で代替） |
| `.terraform.lock.hcl` | コミット対象（プロバイダーバージョン再現性のため） |

## Test plan

- [ ] `cd infra/bootstrap && terraform init && terraform apply` でバックエンドリソース作成確認
- [ ] `cd infra/dev && terraform init && terraform plan` で差分がフリーティアリソースのみであることを確認
- [ ] `terraform apply` 後、`github_actions_role_arn` output の ARN を GitHub Actions Secrets `AWS_ROLE_ARN` に設定
- [ ] `ecr_repository_urls` output の URL で `docker push` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)