### PR TITLE
feature: コンテナデプロイ自動化と ALB レスルーティングの構築

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,287 @@
+# ============================================================
+# deploy.yml — main ブランチへのプッシュで ECS へ自動デプロイ
+#
+# フロー:
+#   1. 変更検出    — apps/web / apps/api の差分を検出し、不要なビルドをスキップ
+#   2. Build & Push — ECR へイメージをプッシュ
+#   3. DB Migration — ECS Run Task で prisma migrate deploy を実行
+#   4. ECS Deploy   — タスク定義を更新しサービスをローリングアップデート
+#   5. CF Update    — ECS タスクの Public IP を CloudFront オリジンに反映
+#
+# 必須 GitHub Secrets:
+#   AWS_ROLE_ARN          — terraform output github_actions_role_arn の値
+#   AWS_REGION            — ap-northeast-1
+#   ECR_REGISTRY          — <account-id>.dkr.ecr.ap-northeast-1.amazonaws.com
+#   ECS_CLUSTER           — budget-dev-cluster
+#   ECS_SERVICE_WEB       — budget-dev-web
+#   ECS_SERVICE_API       — budget-dev-api
+#   ECS_TASK_FAMILY_WEB   — budget-dev-web
+#   ECS_TASK_FAMILY_API   — budget-dev-api
+#   CLOUDFRONT_DIST_ID    — terraform output cloudfront_distribution_id の値
+#   SSM_PREFIX            — /budget/dev
+# ============================================================
+
+name: Deploy to ECS
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write  # OIDC トークン取得に必要
+  contents: read
+
+jobs:
+  # ─── 変更ファイルの検出 ──────────────────────────────────────────────────────
+  detect-changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      web: ${{ steps.filter.outputs.web }}
+      api: ${{ steps.filter.outputs.api }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Filter changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            web:
+              - 'apps/web/**'
+              - 'packages/common/**'
+              - 'packages/api-client/**'
+            api:
+              - 'apps/api/**'
+              - 'packages/common/**'
+
+  # ─── ECR へイメージをビルド & プッシュ ───────────────────────────────────────
+  build-and-push:
+    name: Build & Push
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.web == 'true' || needs.detect-changes.outputs.api == 'true'
+    outputs:
+      web-image: ${{ steps.web-image.outputs.image }}
+      api-image: ${{ steps.api-image.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to ECR
+        id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & push web image
+        id: web-image
+        if: needs.detect-changes.outputs.web == 'true'
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE="${ECR_REGISTRY}/budget-dev-web:${IMAGE_TAG}"
+          docker buildx build \
+            --file apps/web/Dockerfile \
+            --tag "${IMAGE}" \
+            --tag "${ECR_REGISTRY}/budget-dev-web:latest" \
+            --cache-from type=registry,ref="${ECR_REGISTRY}/budget-dev-web:latest" \
+            --cache-to type=inline \
+            --push \
+            .
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push api image
+        id: api-image
+        if: needs.detect-changes.outputs.api == 'true'
+        env:
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          IMAGE="${ECR_REGISTRY}/budget-dev-api:${IMAGE_TAG}"
+          docker buildx build \
+            --file apps/api/Dockerfile \
+            --tag "${IMAGE}" \
+            --tag "${ECR_REGISTRY}/budget-dev-api:latest" \
+            --cache-from type=registry,ref="${ECR_REGISTRY}/budget-dev-api:latest" \
+            --cache-to type=inline \
+            --push \
+            .
+          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+
+  # ─── DB マイグレーション ─────────────────────────────────────────────────────
+  db-migrate:
+    name: DB Migration
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: needs.build-and-push.outputs.api-image != ''
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Run prisma migrate deploy via ECS Run Task
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_API }}
+          SUBNETS: ${{ secrets.ECS_SUBNETS }}
+          SG_API: ${{ secrets.SG_API_ID }}
+        run: |
+          # 最新タスク定義 ARN を取得
+          TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "${TASK_FAMILY}" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+
+          # マイグレーション専用タスクを実行（コマンド上書き）
+          TASK_ARN=$(aws ecs run-task \
+            --cluster "${CLUSTER}" \
+            --task-definition "${TASK_DEF}" \
+            --launch-type FARGATE \
+            --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SG_API}],assignPublicIp=ENABLED}" \
+            --overrides '{"containerOverrides":[{"name":"api","command":["node","build/index.js","--migrate"]}]}' \
+            --query 'tasks[0].taskArn' \
+            --output text)
+
+          echo "Migration task ARN: ${TASK_ARN}"
+
+          # タスク完了を待機
+          aws ecs wait tasks-stopped \
+            --cluster "${CLUSTER}" \
+            --tasks "${TASK_ARN}"
+
+          # 終了コードを確認
+          EXIT_CODE=$(aws ecs describe-tasks \
+            --cluster "${CLUSTER}" \
+            --tasks "${TASK_ARN}" \
+            --query 'tasks[0].containers[0].exitCode' \
+            --output text)
+
+          if [ "${EXIT_CODE}" != "0" ]; then
+            echo "Migration failed with exit code ${EXIT_CODE}"
+            exit 1
+          fi
+
+          echo "Migration completed successfully"
+
+  # ─── ECS サービス更新 ────────────────────────────────────────────────────────
+  deploy-ecs:
+    name: Deploy ECS
+    runs-on: ubuntu-latest
+    needs: [build-and-push, db-migrate]
+    # db-migrate がスキップ（API 変更なし）の場合も実行する
+    if: |
+      always() &&
+      needs.build-and-push.result == 'success' &&
+      (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped')
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy web service
+        if: needs.build-and-push.outputs.web-image != ''
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE: ${{ secrets.ECS_SERVICE_WEB }}
+          TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_WEB }}
+          NEW_IMAGE: ${{ needs.build-and-push.outputs.web-image }}
+        run: |
+          # 現在のタスク定義を取得して image を差し替え
+          TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "${TASK_FAMILY}" \
+            --query 'taskDefinition' \
+            --output json)
+
+          NEW_TASK_DEF=$(echo "${TASK_DEF}" | \
+            jq --arg IMAGE "${NEW_IMAGE}" \
+            '.containerDefinitions[0].image = $IMAGE |
+             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .placementConstraints, .compatibilities, .registeredAt, .registeredBy)')
+
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "${NEW_TASK_DEF}" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+
+          aws ecs update-service \
+            --cluster "${CLUSTER}" \
+            --service "${SERVICE}" \
+            --task-definition "${NEW_TASK_DEF_ARN}" \
+            --force-new-deployment
+
+          echo "web-task-def=${NEW_TASK_DEF_ARN}" >> "$GITHUB_ENV"
+
+      - name: Deploy api service
+        if: needs.build-and-push.outputs.api-image != ''
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE: ${{ secrets.ECS_SERVICE_API }}
+          TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_API }}
+          NEW_IMAGE: ${{ needs.build-and-push.outputs.api-image }}
+        run: |
+          TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "${TASK_FAMILY}" \
+            --query 'taskDefinition' \
+            --output json)
+
+          NEW_TASK_DEF=$(echo "${TASK_DEF}" | \
+            jq --arg IMAGE "${NEW_IMAGE}" \
+            '.containerDefinitions[0].image = $IMAGE |
+             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .placementConstraints, .compatibilities, .registeredAt, .registeredBy)')
+
+          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+            --cli-input-json "${NEW_TASK_DEF}" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text)
+
+          aws ecs update-service \
+            --cluster "${CLUSTER}" \
+            --service "${SERVICE}" \
+            --task-definition "${NEW_TASK_DEF_ARN}" \
+            --force-new-deployment
+
+      - name: Wait for web service stability
+        if: needs.build-and-push.outputs.web-image != ''
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE: ${{ secrets.ECS_SERVICE_WEB }}
+        run: |
+          aws ecs wait services-stable \
+            --cluster "${CLUSTER}" \
+            --services "${SERVICE}"
+
+  # ─── CloudFront オリジン更新 ─────────────────────────────────────────────────
+  update-cloudfront:
+    name: Update CloudFront Origin
+    runs-on: ubuntu-latest
+    needs: deploy-ecs
+    if: needs.deploy-ecs.result == 'success'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Update CloudFront origin and invalidate cache
+        env:
+          CLUSTER: ${{ secrets.ECS_CLUSTER }}
+          SERVICE: ${{ secrets.ECS_SERVICE_WEB }}
+          CLOUDFRONT_DIST_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
+        run: bash scripts/update-cloudfront-origin.sh

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,66 @@
+# ============================================================
+# apps/api/Dockerfile — Hono API マルチステージビルド
+#
+# ステージ:
+#   1. base    — pnpm セットアップ
+#   2. deps    — 依存関係インストール（workspace 対応）
+#   3. builder — TypeScript コンパイル
+#   4. runner  — 最小ランタイムイメージ
+# ============================================================
+
+FROM node:20-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+# ─── deps: workspace の依存関係をインストール ────────────────────────────────
+FROM base AS deps
+WORKDIR /repo
+
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/common/package.json ./packages/common/
+
+RUN pnpm install --frozen-lockfile
+
+# ─── builder: TypeScript コンパイル + Prisma クライアント生成 ─────────────────
+FROM base AS builder
+WORKDIR /repo
+
+COPY --from=deps /repo/node_modules ./node_modules
+COPY --from=deps /repo/apps/api/node_modules ./apps/api/node_modules
+COPY --from=deps /repo/packages/common/node_modules ./packages/common/node_modules 2>/dev/null || true
+
+COPY packages/common ./packages/common
+COPY apps/api ./apps/api
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+
+# common をビルド
+RUN pnpm --filter @budget/common build
+
+# Prisma クライアント生成
+RUN pnpm --filter @budget/api exec prisma generate
+
+# TypeScript ビルド
+RUN pnpm --filter @budget/api build
+
+# ─── runner: 最小ランタイム ───────────────────────────────────────────────────
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 honoapi
+
+# ビルド成果物のみコピー（ソースは含めない）
+COPY --from=builder /repo/apps/api/build ./build
+COPY --from=builder /repo/apps/api/node_modules ./node_modules
+COPY --from=builder /repo/apps/api/prisma ./prisma
+# Prisma クライアントは node_modules に含まれるが、スキーマファイルが必要
+COPY --from=builder /repo/packages/common/dist ./packages/common/dist
+
+USER honoapi
+
+EXPOSE 3001
+ENV PORT=3001
+
+CMD ["node", "build/index.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,72 @@
+# ============================================================
+# apps/web/Dockerfile — Next.js (standalone) マルチステージビルド
+#
+# ステージ:
+#   1. base    — pnpm セットアップ
+#   2. deps    — 依存関係インストール（workspace 対応）
+#   3. builder — Next.js ビルド（standalone 出力）
+#   4. runner  — 最小ランタイムイメージ
+# ============================================================
+
+FROM node:20-alpine AS base
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
+
+# ─── deps: workspace の依存関係をインストール ────────────────────────────────
+FROM base AS deps
+WORKDIR /repo
+
+# pnpm workspace 解決に必要なファイルを先にコピーしてキャッシュを活用
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/common/package.json ./packages/common/
+COPY packages/api-client/package.json ./packages/api-client/
+
+# 本番依存のみインストール（devDependencies はビルド用に全部必要なので --frozen-lockfile）
+RUN pnpm install --frozen-lockfile
+
+# ─── builder: Next.js ビルド ──────────────────────────────────────────────────
+FROM base AS builder
+WORKDIR /repo
+
+COPY --from=deps /repo/node_modules ./node_modules
+COPY --from=deps /repo/apps/web/node_modules ./apps/web/node_modules
+COPY --from=deps /repo/packages/common/node_modules ./packages/common/node_modules 2>/dev/null || true
+COPY --from=deps /repo/packages/api-client/node_modules ./packages/api-client/node_modules 2>/dev/null || true
+
+# ソースをコピー
+COPY packages/common ./packages/common
+COPY packages/api-client ./packages/api-client
+COPY apps/web ./apps/web
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+
+# common / api-client をビルド（web が依存）
+RUN pnpm --filter @budget/common build
+RUN pnpm --filter @budget/api-client build
+
+# Next.js ビルド
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm --filter web build
+
+# ─── runner: 最小ランタイム ───────────────────────────────────────────────────
+FROM node:20-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+# セキュリティ: 非 root ユーザーで実行
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+# standalone 出力をコピー
+COPY --from=builder /repo/apps/web/.next/standalone ./
+COPY --from=builder /repo/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder /repo/apps/web/public ./apps/web/public
+
+USER nextjs
+
+EXPOSE 3000
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
+
+CMD ["node", "apps/web/server.js"]

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,7 +3,9 @@ import type { NextConfig } from "next";
 const API_URL = process.env.API_URL ?? "http://localhost:3001";
 
 const nextConfig: NextConfig = {
-  /** 開発時に /api/* を Express バックエンドへプロキシする */
+  // コンテナデプロイ用: standalone モードで最小ランタイムを出力
+  output: "standalone",
+  /** /api/* を Hono バックエンドへプロキシする（開発: localhost:3001、本番: ECS API タスク） */
   async rewrites() {
     return [
       {

--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -2,6 +2,8 @@
 # Root Module: dev
 #
 # フェーズ 1: VPC / IAM / ECR / SG の基盤リソース
+# フェーズ 2: ECS クラスター / タスク定義 / サービス
+# フェーズ 3: CloudFront ディストリビューション
 #
 # 適用順:
 #   1. cd ../bootstrap && terraform apply  (初回のみ)
@@ -41,4 +43,35 @@ module "sg" {
   name_prefix = local.name_prefix
   vpc_id      = module.vpc.vpc_id
   vpc_cidr    = module.vpc.vpc_cidr
+}
+
+# ─── フェーズ 5: ECS クラスター・タスク定義・サービス ──────────────────────────
+
+module "ecs" {
+  source      = "../modules/ecs"
+  name_prefix = local.name_prefix
+  aws_region  = var.aws_region
+  vpc_id      = module.vpc.vpc_id
+  subnet_ids  = module.vpc.public_subnet_ids
+
+  web_sg_id               = module.sg.web_sg_id
+  api_sg_id               = module.sg.api_sg_id
+  task_execution_role_arn = module.iam.ecs_task_execution_role_arn
+
+  # 初期イメージは ECR にプッシュ後に更新（初回は placeholder）
+  web_image = "${module.ecr.repository_urls["web"]}:latest"
+  api_image = "${module.ecr.repository_urls["api"]}:latest"
+
+  ssm_prefix = var.ssm_prefix
+}
+
+# ─── フェーズ 6: CloudFront ディストリビューション ───────────────────────────
+
+module "cloudfront" {
+  source      = "../modules/cloudfront"
+  name_prefix = local.name_prefix
+
+  # ECS タスク起動後に scripts/update-cloudfront-origin.sh で自動更新
+  # 初回 apply 時は placeholder（terraform apply 後に手動で初回デプロイを実行）
+  web_origin_domain = var.initial_web_origin_ip
 }

--- a/infra/dev/outputs.tf
+++ b/infra/dev/outputs.tf
@@ -45,3 +45,42 @@ output "sg_rds_id" {
   description = "sg-rds ID"
   value       = module.sg.rds_sg_id
 }
+
+# ─── ECS ─────────────────────────────────────────────────────────────────────
+
+output "ecs_cluster_name" {
+  description = "ECS クラスター名 — GitHub Actions Secrets: ECS_CLUSTER"
+  value       = module.ecs.cluster_name
+}
+
+output "ecs_web_service_name" {
+  description = "ECS web サービス名 — GitHub Actions Secrets: ECS_SERVICE_WEB"
+  value       = module.ecs.web_service_name
+}
+
+output "ecs_api_service_name" {
+  description = "ECS api サービス名 — GitHub Actions Secrets: ECS_SERVICE_API"
+  value       = module.ecs.api_service_name
+}
+
+output "ecs_web_task_family" {
+  description = "ECS web タスクファミリー — GitHub Actions Secrets: ECS_TASK_FAMILY_WEB"
+  value       = module.ecs.web_task_family
+}
+
+output "ecs_api_task_family" {
+  description = "ECS api タスクファミリー — GitHub Actions Secrets: ECS_TASK_FAMILY_API"
+  value       = module.ecs.api_task_family
+}
+
+# ─── CloudFront ───────────────────────────────────────────────────────────────
+
+output "cloudfront_distribution_id" {
+  description = "CloudFront ディストリビューション ID — GitHub Actions Secrets: CLOUDFRONT_DIST_ID"
+  value       = module.cloudfront.distribution_id
+}
+
+output "cloudfront_domain_name" {
+  description = "CloudFront ドメイン名（アクセス URL）"
+  value       = "https://${module.cloudfront.distribution_domain_name}"
+}

--- a/infra/dev/terraform.tfvars.example
+++ b/infra/dev/terraform.tfvars.example
@@ -19,3 +19,8 @@ github_repo = "budget-management-tool"
 # ─── コスト管理 ───────────────────────────────────────────────────────────
 budget_limit_usd = "1"
 alert_email      = "your-email@example.com"
+
+# ─── ECS / CloudFront ─────────────────────────────────────────────────────────
+ssm_prefix = "/budget/dev"
+# initial_web_origin_ip は初回 apply 後に自動更新されるため通常は変更不要
+# initial_web_origin_ip = "127.0.0.1"

--- a/infra/dev/variables.tf
+++ b/infra/dev/variables.tf
@@ -36,3 +36,15 @@ variable "alert_email" {
   description = "コスト超過アラートの送信先メールアドレス"
   type        = string
 }
+
+variable "ssm_prefix" {
+  description = "SSM Parameter Store のパスプレフィックス（例: /budget/dev）"
+  type        = string
+  default     = "/budget/dev"
+}
+
+variable "initial_web_origin_ip" {
+  description = "CloudFront オリジンの初期 IP（terraform apply 後に scripts/update-cloudfront-origin.sh で自動更新）"
+  type        = string
+  default     = "127.0.0.1" # placeholder: 初回デプロイ後に自動更新される
+}

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -1,0 +1,132 @@
+# ============================================================
+# Module: cloudfront
+#
+# 構成:
+#   - CloudFront ディストリビューション（HTTPS 終端）
+#   - オリジン: ECS web タスクの Public IP（scripts/update-cloudfront-origin.sh で自動更新）
+#   - キャッシュポリシー:
+#     - /_next/static/*: 長期キャッシュ（イミュータブルアセット）
+#     - /api/*: キャッシュ無効化（バックエンド API は常に通過）
+#     - /*: デフォルト（TTL 0、SSR レスポンス対応）
+#
+# ALB を使わない理由:
+#   ALB は月 $16〜 かかるため、CloudFront → ECS Public IP の直接接続で代替。
+#   IP は ECS タスク再起動のたびに変わるため、デプロイパイプラインで自動更新する。
+# ============================================================
+
+locals {
+  origin_id = "${var.name_prefix}-web-origin"
+}
+
+resource "aws_cloudfront_distribution" "main" {
+  enabled             = true
+  is_ipv6_enabled     = true
+  comment             = "${var.name_prefix} — ALBレス CloudFront 直接配信"
+  price_class         = var.price_class
+  default_root_object = ""
+
+  # ─── オリジン設定 ────────────────────────────────────────────────────────────
+  origin {
+    origin_id   = local.origin_id
+    domain_name = var.web_origin_domain
+
+    custom_origin_config {
+      http_port              = 3000
+      https_port             = 443
+      origin_protocol_policy = "http-only" # ECS タスクへは HTTP で接続（CloudFront が HTTPS 終端）
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  # ─── デフォルトキャッシュ（SSR ページ） ───────────────────────────────────────
+  default_cache_behavior {
+    target_origin_id       = local.origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    forwarded_values {
+      # SSR: クエリパラメータ・Cookie をオリジンに転送
+      query_string = true
+      cookies {
+        forward = "all"
+      }
+      headers = ["Host", "CloudFront-Forwarded-Proto"]
+    }
+
+    # SSR レスポンスはキャッシュしない（TTL = 0）
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  # ─── /_next/static/*: 長期キャッシュ（イミュータブル） ───────────────────────
+  ordered_cache_behavior {
+    path_pattern           = "/_next/static/*"
+    target_origin_id       = local.origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+
+    # Next.js static assets はコンテンツハッシュ付きのため長期キャッシュ可能
+    min_ttl     = 0
+    default_ttl = 86400    # 1日
+    max_ttl     = 31536000 # 1年
+  }
+
+  # ─── /api/*: キャッシュ無効（Hono API は常にオリジンへ通過） ──────────────────
+  ordered_cache_behavior {
+    path_pattern           = "/api/*"
+    target_origin_id       = local.origin_id
+    viewer_protocol_policy = "redirect-to-https"
+    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+    cached_methods         = ["GET", "HEAD"]
+    compress               = true
+
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "all"
+      }
+      headers = ["Authorization", "Content-Type", "Accept"]
+    }
+
+    # API は常にオリジンへ通過
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+  }
+
+  # ─── HTTPS 設定 ───────────────────────────────────────────────────────────────
+  dynamic "viewer_certificate" {
+    for_each = var.acm_certificate_arn != null ? [1] : []
+    content {
+      acm_certificate_arn      = var.acm_certificate_arn
+      ssl_support_method       = "sni-only"
+      minimum_protocol_version = "TLSv1.2_2021"
+    }
+  }
+
+  dynamic "viewer_certificate" {
+    for_each = var.acm_certificate_arn == null ? [1] : []
+    content {
+      # ACM 証明書なしの場合は CloudFront デフォルト証明書（*.cloudfront.net）を使用
+      cloudfront_default_certificate = true
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+}

--- a/infra/modules/cloudfront/outputs.tf
+++ b/infra/modules/cloudfront/outputs.tf
@@ -1,0 +1,14 @@
+output "distribution_id" {
+  description = "CloudFront ディストリビューション ID（GitHub Actions Secrets の CLOUDFRONT_DIST_ID に設定）"
+  value       = aws_cloudfront_distribution.main.id
+}
+
+output "distribution_domain_name" {
+  description = "CloudFront ドメイン名（例: d1234abcd.cloudfront.net）"
+  value       = aws_cloudfront_distribution.main.domain_name
+}
+
+output "distribution_arn" {
+  description = "CloudFront ディストリビューション ARN"
+  value       = aws_cloudfront_distribution.main.arn
+}

--- a/infra/modules/cloudfront/variables.tf
+++ b/infra/modules/cloudfront/variables.tf
@@ -1,0 +1,21 @@
+variable "name_prefix" {
+  description = "リソース名前付けプレフィックス"
+  type        = string
+}
+
+variable "web_origin_domain" {
+  description = "CloudFront オリジンドメイン（ECS web タスクの Public IP または DNS）"
+  type        = string
+}
+
+variable "acm_certificate_arn" {
+  description = "ACM 証明書 ARN（us-east-1 リージョンで発行したもの）。null の場合は HTTP のみ"
+  type        = string
+  default     = null
+}
+
+variable "price_class" {
+  description = "CloudFront 価格クラス（PriceClass_100: 北米+欧州のみで最安）"
+  type        = string
+  default     = "PriceClass_100"
+}

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -1,0 +1,209 @@
+# ============================================================
+# Module: ecs
+#
+# 構成:
+#   1. ECS クラスター（Fargate、Container Insights 無効で無料枠維持）
+#   2. CloudWatch ロググループ（web / api 各サービス用）
+#   3. ECS タスク定義（web / api）
+#      - 0.25 vCPU / 512MB（無料枠 750h/月）
+#      - 環境変数は SSM Parameter Store から注入（ハードコード禁止）
+#   4. ECS サービス（web / api）
+#      - Fargate、パブリックサブネット直接配置（NAT GW 不要）
+#      - desired_count = 1（停止時は 0 に変更して無料枠節約可）
+#
+# 禁止事項:
+#   - タスク定義への DATABASE_URL 等の直書き
+#   - ALB / NAT Gateway の使用
+# ============================================================
+
+# ─── ECS クラスター ───────────────────────────────────────────────────────────
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.name_prefix}-cluster"
+
+  setting {
+    # Container Insights は有料のため無効化
+    name  = "containerInsights"
+    value = "disabled"
+  }
+}
+
+# ─── CloudWatch ロググループ ──────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "web" {
+  name              = "/ecs/${var.name_prefix}/web"
+  retention_in_days = 7 # 無料枠 5GB/月 を超えないよう短期保持
+}
+
+resource "aws_cloudwatch_log_group" "api" {
+  name              = "/ecs/${var.name_prefix}/api"
+  retention_in_days = 7
+}
+
+# ─── タスク定義: web ─────────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "web" {
+  family                   = "${var.name_prefix}-web"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "web"
+      image     = var.web_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 3000
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        # API_URL は VPC 内部の api タスク IP を指定（デプロイ後に更新）
+        # 初期値は placeholder。ECS Service Connect または手動更新で解決
+        {
+          name  = "NODE_ENV"
+          value = "production"
+        }
+      ]
+
+      # SSM から環境変数を注入（ハードコード禁止）
+      secrets = [
+        {
+          name      = "NEXT_PUBLIC_API_URL"
+          valueFrom = "${var.ssm_prefix}/api_url"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.web.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+}
+
+# ─── タスク定義: api ─────────────────────────────────────────────────────────
+
+resource "aws_ecs_task_definition" "api" {
+  family                   = "${var.name_prefix}-api"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.cpu
+  memory                   = var.memory
+  execution_role_arn       = var.task_execution_role_arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "api"
+      image     = var.api_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 3001
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "NODE_ENV"
+          value = "production"
+        },
+        {
+          name  = "PORT"
+          value = "3001"
+        }
+      ]
+
+      # SSM から DATABASE_URL 等のシークレットを注入
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${var.ssm_prefix}/database_url"
+        },
+        {
+          name      = "JWT_SECRET"
+          valueFrom = "${var.ssm_prefix}/jwt_secret"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.api.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:3001/api/health || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+}
+
+# ─── ECS サービス: web ───────────────────────────────────────────────────────
+
+resource "aws_ecs_service" "web" {
+  name            = "${var.name_prefix}-web"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.web.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [var.web_sg_id]
+    # NAT GW なしで ECR / SSM へアクセスするためパブリック IP を付与
+    assign_public_ip = true
+  }
+
+  # タスク定義の変更はデプロイパイプラインが管理するため、Terraform では無視
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+}
+
+# ─── ECS サービス: api ───────────────────────────────────────────────────────
+
+resource "aws_ecs_service" "api" {
+  name            = "${var.name_prefix}-api"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.api.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.subnet_ids
+    security_groups  = [var.api_sg_id]
+    assign_public_ip = true
+  }
+
+  lifecycle {
+    ignore_changes = [task_definition, desired_count]
+  }
+}

--- a/infra/modules/ecs/outputs.tf
+++ b/infra/modules/ecs/outputs.tf
@@ -1,0 +1,29 @@
+output "cluster_name" {
+  description = "ECS クラスター名（GitHub Actions Secrets の ECS_CLUSTER に設定）"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "cluster_arn" {
+  description = "ECS クラスター ARN"
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "web_service_name" {
+  description = "ECS web サービス名（GitHub Actions Secrets の ECS_SERVICE_WEB に設定）"
+  value       = aws_ecs_service.web.name
+}
+
+output "api_service_name" {
+  description = "ECS api サービス名（GitHub Actions Secrets の ECS_SERVICE_API に設定）"
+  value       = aws_ecs_service.api.name
+}
+
+output "web_task_family" {
+  description = "web タスク定義ファミリー名（GitHub Actions Secrets の ECS_TASK_FAMILY_WEB に設定）"
+  value       = aws_ecs_task_definition.web.family
+}
+
+output "api_task_family" {
+  description = "api タスク定義ファミリー名（GitHub Actions Secrets の ECS_TASK_FAMILY_API に設定）"
+  value       = aws_ecs_task_definition.api.family
+}

--- a/infra/modules/ecs/variables.tf
+++ b/infra/modules/ecs/variables.tf
@@ -1,0 +1,67 @@
+variable "name_prefix" {
+  description = "リソース名前付けプレフィックス"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWSリージョン"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ECS サービスを配置する VPC ID"
+  type        = string
+}
+
+variable "subnet_ids" {
+  description = "ECS タスクを配置するサブネット ID リスト（パブリックサブネット）"
+  type        = list(string)
+}
+
+variable "web_sg_id" {
+  description = "sg-web セキュリティグループ ID"
+  type        = string
+}
+
+variable "api_sg_id" {
+  description = "sg-api セキュリティグループ ID"
+  type        = string
+}
+
+variable "task_execution_role_arn" {
+  description = "EcsTaskExecutionRole ARN"
+  type        = string
+}
+
+variable "web_image" {
+  description = "web コンテナイメージ URI（初期値。デプロイ後は GitHub Actions が更新）"
+  type        = string
+}
+
+variable "api_image" {
+  description = "api コンテナイメージ URI（初期値。デプロイ後は GitHub Actions が更新）"
+  type        = string
+}
+
+variable "ssm_prefix" {
+  description = "SSM Parameter Store のパスプレフィックス（例: /budget/dev）"
+  type        = string
+}
+
+variable "cpu" {
+  description = "タスク CPU ユニット（無料枠: 256 = 0.25 vCPU）"
+  type        = number
+  default     = 256
+}
+
+variable "memory" {
+  description = "タスクメモリ MB（無料枠: 512MB）"
+  type        = number
+  default     = 512
+}
+
+variable "desired_count" {
+  description = "サービスのタスク起動数（開発時は 0 にして無料枠を節約できる）"
+  type        = number
+  default     = 1
+}

--- a/scripts/update-cloudfront-origin.sh
+++ b/scripts/update-cloudfront-origin.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# ============================================================
+# update-cloudfront-origin.sh
+#
+# ECS Fargate タスクに割り当てられた Public IP を取得し、
+# CloudFront のオリジン設定を書き換えてキャッシュを無効化する。
+#
+# 前提:
+#   - AWS CLI v2 がインストール・認証済みであること
+#   - jq がインストールされていること
+#
+# 環境変数:
+#   CLUSTER             — ECS クラスター名（例: budget-dev-cluster）
+#   SERVICE             — ECS サービス名（例: budget-dev-web）
+#   CLOUDFRONT_DIST_ID  — CloudFront ディストリビューション ID
+# ============================================================
+
+set -euo pipefail
+
+# ─── 引数バリデーション ───────────────────────────────────────────────────────
+
+: "${CLUSTER:?環境変数 CLUSTER が未設定です}"
+: "${SERVICE:?環境変数 SERVICE が未設定です}"
+: "${CLOUDFRONT_DIST_ID:?環境変数 CLOUDFRONT_DIST_ID が未設定です}"
+
+# ─── ECS タスクの Public IP を取得 ───────────────────────────────────────────
+
+echo "ECS サービス '${SERVICE}' の実行中タスクを取得中..."
+
+TASK_ARN=$(aws ecs list-tasks \
+  --cluster "${CLUSTER}" \
+  --service-name "${SERVICE}" \
+  --desired-status RUNNING \
+  --query 'taskArns[0]' \
+  --output text)
+
+if [ -z "${TASK_ARN}" ] || [ "${TASK_ARN}" = "None" ]; then
+  echo "エラー: 実行中のタスクが見つかりません" >&2
+  exit 1
+fi
+
+echo "タスク ARN: ${TASK_ARN}"
+
+# タスクの ENI ID を取得
+ENI_ID=$(aws ecs describe-tasks \
+  --cluster "${CLUSTER}" \
+  --tasks "${TASK_ARN}" \
+  --query 'tasks[0].attachments[0].details[?name==`networkInterfaceId`].value' \
+  --output text)
+
+if [ -z "${ENI_ID}" ] || [ "${ENI_ID}" = "None" ]; then
+  echo "エラー: ENI ID を取得できませんでした" >&2
+  exit 1
+fi
+
+echo "ENI ID: ${ENI_ID}"
+
+# ENI から Public IP を取得
+PUBLIC_IP=$(aws ec2 describe-network-interfaces \
+  --network-interface-ids "${ENI_ID}" \
+  --query 'NetworkInterfaces[0].Association.PublicIp' \
+  --output text)
+
+if [ -z "${PUBLIC_IP}" ] || [ "${PUBLIC_IP}" = "None" ]; then
+  echo "エラー: Public IP を取得できませんでした" >&2
+  exit 1
+fi
+
+echo "取得した Public IP: ${PUBLIC_IP}"
+
+# ─── CloudFront ディストリビューション設定を取得 ──────────────────────────────
+
+echo "CloudFront ディストリビューション '${CLOUDFRONT_DIST_ID}' の設定を取得中..."
+
+DIST_CONFIG=$(aws cloudfront get-distribution-config \
+  --id "${CLOUDFRONT_DIST_ID}")
+
+ETAG=$(echo "${DIST_CONFIG}" | jq -r '.ETag')
+CONFIG=$(echo "${DIST_CONFIG}" | jq '.DistributionConfig')
+
+echo "現在の ETag: ${ETAG}"
+
+# ─── オリジンドメインを新しい Public IP に書き換え ────────────────────────────
+
+UPDATED_CONFIG=$(echo "${CONFIG}" | jq \
+  --arg IP "${PUBLIC_IP}" \
+  '.Origins.Items[0].DomainName = $IP')
+
+echo "オリジン設定を ${PUBLIC_IP} に更新中..."
+
+aws cloudfront update-distribution \
+  --id "${CLOUDFRONT_DIST_ID}" \
+  --distribution-config "${UPDATED_CONFIG}" \
+  --if-match "${ETAG}" \
+  --output text > /dev/null
+
+echo "CloudFront オリジン更新完了"
+
+# ─── キャッシュ無効化（Invalidation） ────────────────────────────────────────
+
+echo "CloudFront キャッシュを無効化中..."
+
+INVALIDATION_ID=$(aws cloudfront create-invalidation \
+  --distribution-id "${CLOUDFRONT_DIST_ID}" \
+  --paths "/*" \
+  --query 'Invalidation.Id' \
+  --output text)
+
+echo "Invalidation ID: ${INVALIDATION_ID}"
+echo "キャッシュ無効化リクエストを送信しました（完了まで数分かかる場合があります）"
+echo "完了: CloudFront オリジン → ${PUBLIC_IP} / Invalidation → ${INVALIDATION_ID}"


### PR DESCRIPTION
## Summary

- **Dockerfile (web/api)**: pnpm workspace 対応マルチステージビルド。Next.js は `output: 'standalone'` で最小イメージサイズを実現
- **GitHub Actions deploy.yml**: main プッシュで変更検出 → ECR Push → DB Migration → ECS Deploy → CloudFront 更新まで全自動化。アクセスキー不使用（OIDC のみ）
- **update-cloudfront-origin.sh**: ECS タスクの Public IP を取得し CloudFront オリジンを自動書き換え + Invalidation
- **Terraform modules/ecs**: Fargate 0.25vCPU/512MB、SSM から DATABASE_URL/JWT_SECRET を注入（ハードコード禁止）
- **Terraform modules/cloudfront**: HTTPS 終端・`/_next/static/*` 長期キャッシュ・`/api/*` キャッシュ無効

## セキュリティ確認

| 項目 | 状態 |
|------|------|
| AWS アクセスキー | 不使用（OIDC のみ） |
| GitHub Secrets | すべて `${{ secrets.xxx }}` 参照、値のハードコードなし |
| DATABASE_URL / JWT_SECRET | SSM Parameter Store `valueFrom` で注入、タスク定義に平文なし |
| CloudFront → ECS 通信 | HTTP（コンテナポート直接）、外部 HTTPS は CloudFront が終端 |

## terraform apply 後に設定が必要な GitHub Secrets

| Secret 名 | 取得元 |
|-----------|--------|
| `AWS_ROLE_ARN` | `terraform output github_actions_role_arn` |
| `ECR_REGISTRY` | `<account-id>.dkr.ecr.ap-northeast-1.amazonaws.com` |
| `ECS_CLUSTER` | `terraform output ecs_cluster_name` |
| `ECS_SERVICE_WEB` / `ECS_SERVICE_API` | `terraform output ecs_web_service_name` etc. |
| `ECS_SUBNETS` | `terraform output public_subnet_ids` |
| `SG_API_ID` | `terraform output sg_api_id` |
| `CLOUDFRONT_DIST_ID` | `terraform output cloudfront_distribution_id` |

## Test plan

- [ ] `terraform apply` で ECS クラスター・CloudFront ディストリビューションが作成されることを確認
- [ ] `git push origin main` で deploy.yml が起動し、全ジョブが green になることを確認
- [ ] `terraform output cloudfront_domain_name` の URL で Next.js 画面が表示されることを確認
- [ ] CloudFront 経由の `/api/health` が 200 を返すことを確認（rewrites プロキシ動作）
- [ ] AWS コスト管理コンソールで ALB・NAT Gateway の費用が発生していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)