### PR TITLE
feature: 環境識別タグ管理と dev/prod リソースグループ論理分離の構築

### DIFF
--- a/infra/dev/providers.tf
+++ b/infra/dev/providers.tf
@@ -19,8 +19,14 @@ provider "aws" {
   default_tags {
     tags = {
       Project     = var.project
-      Environment = var.env
-      ManagedBy   = "terraform"
+      # var.env が環境識別子（dev / stg / prod）の単一の起点。
+      # prod 環境を立ち上げた場合、このタグ値が変わるだけで全リソースに伝播する。
+      Environment    = var.env
+      ManagedBy      = "terraform"
+      Owner          = "yamamoto-yudai"
+      # AWS myApplications ダッシュボードとの連携用タグ。
+      # 環境ごとに一意のアプリケーション識別子を付与し、コスト・セキュリティ分析を環境単位で行う。
+      awsApplication = "budget-app-${var.env}"
     }
   }
 }

--- a/infra/dev/resource_groups.tf
+++ b/infra/dev/resource_groups.tf
@@ -1,0 +1,43 @@
+# ============================================================
+# 環境別リソースグループ
+#
+# 目的:
+#   AWS Resource Groups で「Environment = dev」タグを持つリソースだけを
+#   一覧・管理し、dev/prod 間のリソース混入を防ぐ。
+#
+# prod 環境との分離の仕組み:
+#   TagFilters に `Environment = ${var.env}` を指定することで、
+#   このグループは同 var.env の値を持つリソースのみを収集する。
+#   prod 環境は別の tfvars (env = "prod") から独立した apply で作成されるため、
+#   dev グループに prod リソースが混入することは構造的に不可能。
+#
+# 将来の prod 展開:
+#   infra/prod/ ディレクトリを作成し、env = "prod" を指定して apply するだけで
+#   prod 専用のリソースグループが自動生成される。
+# ============================================================
+
+resource "aws_resourcegroups_group" "env" {
+  name        = "${var.project}-${var.env}-group"
+  description = "${var.project} ${var.env} environment resource group"
+
+  resource_query {
+    query = jsonencode({
+      ResourceTypeFilters = ["AWS::AllSupported"]
+      TagFilters = [
+        {
+          Key    = "Project"
+          Values = [var.project]
+        },
+        {
+          Key    = "Environment"
+          Values = [var.env]
+        }
+      ]
+    })
+    type = "TAG_FILTERS_1_0"
+  }
+
+  tags = {
+    Name = "${var.project}-${var.env}-group"
+  }
+}


### PR DESCRIPTION
## Summary

- `Owner` / `awsApplication` タグを全リソースに自動伝播させ、AWS myApplications との連携を実現
- `aws_resourcegroups_group` で **dev/prod が構造的に混入しない**環境別リソースグループを構築
- 既存コードへの破壊的変更ゼロ（`var.env` を環境識別子として継続使用）

## 変更内容

### `infra/dev/providers.tf`
- `default_tags` に以下を追加（全リソースに自動伝播）:
  - `Owner`: `yamamoto-yudai`（リソース責任者の明示）
  - `awsApplication`: `budget-app-${var.env}`（AWS myApplications 連携・環境ごとに一意）

### `infra/dev/resource_groups.tf` (新規)
- `aws_resourcegroups_group "env"` で `budget-dev-group` を定義
- TagFilters: `Project = budget` **AND** `Environment = dev` の AND 条件
- prod 環境（`env = "prod"`）の apply では `budget-prod-group` が生成され、dev グループとは完全独立

## Plan 検証結果

```
Plan: 11 to add, 26 to change, 0 to destroy.
```

リソースグループの `tags_all` 確認:
```hcl
Environment    = "dev"
ManagedBy      = "terraform"
Owner          = "yamamoto-yudai"
Project        = "budget"
awsApplication = "budget-app-dev"
```

## 環境分離の論理的確認

prod 環境を `infra/prod/` + `env = "prod"` で apply した場合:
- `budget-prod-group` が新規作成される
- `budget-dev-group` の TagFilter `Environment = dev` には prod リソースが一切ヒットしない
- タグ起点が `var.env` の単一変数であるため、名前・タグが自動的に分離される

## Test plan

- [ ] `terraform plan` で `tags_all.awsApplication = "budget-app-dev"` を確認
- [ ] `terraform apply` 後、AWS コンソールのリソースグループで `budget-dev-group` を確認
- [ ] dev グループに prod タグのリソースが含まれないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)