### PR TITLE
fix: API Dockerfile CMD パス修正 + サイドカーデプロイ対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -219,7 +219,7 @@ jobs:
             --task-definition "${TASK_DEF}" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SG_API}],assignPublicIp=ENABLED}" \
-            --overrides '{"containerOverrides":[{"name":"api","command":["node","build/index.js","--migrate"]}]}' \
+            --overrides '{"containerOverrides":[{"name":"api","command":["node","build/apps/api/src/index.js","--migrate"]}]}' \
             --query 'tasks[0].taskArn' \
             --output text)
 
@@ -264,23 +264,28 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Deploy web service
-        if: needs.build-and-push.outputs.web-image != ''
+      - name: Deploy web service (sidecar: web + api)
+        # web または api のいずれかが変更された場合にサイドカータスク定義を更新
+        if: needs.build-and-push.outputs.web-image != '' || needs.build-and-push.outputs.api-image != ''
         env:
           CLUSTER: ${{ secrets.ECS_CLUSTER }}
           SERVICE: ${{ secrets.ECS_SERVICE_WEB }}
           TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_WEB }}
-          NEW_IMAGE: ${{ needs.build-and-push.outputs.web-image }}
+          NEW_WEB_IMAGE: ${{ needs.build-and-push.outputs.web-image }}
+          NEW_API_IMAGE: ${{ needs.build-and-push.outputs.api-image }}
         run: |
-          # 現在のタスク定義を取得して image を差し替え
+          # 現在のサイドカータスク定義を取得
           TASK_DEF=$(aws ecs describe-task-definition \
             --task-definition "${TASK_FAMILY}" \
             --query 'taskDefinition' \
             --output json)
 
+          # 変更があったコンテナのみ image を差し替え（空文字の場合は現在の image を維持）
           NEW_TASK_DEF=$(echo "${TASK_DEF}" | \
-            jq --arg IMAGE "${NEW_IMAGE}" \
-            '.containerDefinitions[0].image = $IMAGE |
+            jq --arg WEB_IMAGE "${NEW_WEB_IMAGE}" \
+               --arg API_IMAGE "${NEW_API_IMAGE}" \
+            '(if $WEB_IMAGE != "" then .containerDefinitions[0].image = $WEB_IMAGE else . end) |
+             (if $API_IMAGE != "" then .containerDefinitions[1].image = $API_IMAGE else . end) |
              del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .placementConstraints, .compatibilities, .registeredAt, .registeredBy)')
 
           NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
@@ -296,11 +301,10 @@ jobs:
 
           echo "web-task-def=${NEW_TASK_DEF_ARN}" >> "$GITHUB_ENV"
 
-      - name: Deploy api service
+      - name: Update api task definition (DB migration 専用、サービスは 0 のまま)
+        # api タスク定義を最新イメージで更新（migrate コマンド実行のベースとして使用）
         if: needs.build-and-push.outputs.api-image != ''
         env:
-          CLUSTER: ${{ secrets.ECS_CLUSTER }}
-          SERVICE: ${{ secrets.ECS_SERVICE_API }}
           TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_API }}
           NEW_IMAGE: ${{ needs.build-and-push.outputs.api-image }}
         run: |
@@ -314,19 +318,13 @@ jobs:
             '.containerDefinitions[0].image = $IMAGE |
              del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .placementConstraints, .compatibilities, .registeredAt, .registeredBy)')
 
-          NEW_TASK_DEF_ARN=$(aws ecs register-task-definition \
+          aws ecs register-task-definition \
             --cli-input-json "${NEW_TASK_DEF}" \
             --query 'taskDefinition.taskDefinitionArn' \
-            --output text)
-
-          aws ecs update-service \
-            --cluster "${CLUSTER}" \
-            --service "${SERVICE}" \
-            --task-definition "${NEW_TASK_DEF_ARN}" \
-            --force-new-deployment
+            --output text
 
       - name: Wait for web service stability
-        if: needs.build-and-push.outputs.web-image != ''
+        if: needs.build-and-push.outputs.web-image != '' || needs.build-and-push.outputs.api-image != ''
         env:
           CLUSTER: ${{ secrets.ECS_CLUSTER }}
           SERVICE: ${{ secrets.ECS_SERVICE_WEB }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,4 +64,4 @@ USER honoapi
 EXPOSE 3001
 ENV PORT=3001
 
-CMD ["node", "build/index.js"]
+CMD ["node", "build/apps/api/src/index.js"]

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -44,19 +44,26 @@ RUN pnpm --filter @budget/api exec prisma generate
 RUN pnpm --filter @budget/api build
 
 # ─── runner: 最小ランタイム ───────────────────────────────────────────────────
+# pnpm ワークスペースは仮想ストア（.pnpm/）へのシンボリックリンクを使用するため、
+# monorepo のディレクトリ構造をそのまま維持する必要がある。
+# WORKDIR を /repo にして builder と同じパス構成を再現することで symlink が正しく解決される。
 FROM node:20-alpine AS runner
-WORKDIR /app
+WORKDIR /repo
 
 ENV NODE_ENV=production
 
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 honoapi
 
-# ビルド成果物のみコピー（ソースは含めない）
-COPY --from=builder /repo/apps/api/build ./build
-COPY --from=builder /repo/apps/api/node_modules ./node_modules
-COPY --from=builder /repo/apps/api/prisma ./prisma
-# Prisma クライアントは node_modules に含まれるが、スキーマファイルが必要
+# pnpm 仮想ストア（.pnpm/）を含むルート node_modules — symlink 解決に必須
+COPY --from=builder /repo/node_modules ./node_modules
+# per-package node_modules（各パッケージのシンボリックリンクエントリ）
+COPY --from=builder /repo/apps/api/node_modules ./apps/api/node_modules
+COPY --from=builder /repo/packages/common/node_modules ./packages/common/node_modules
+
+# ビルド成果物
+COPY --from=builder /repo/apps/api/build ./apps/api/build
+COPY --from=builder /repo/apps/api/prisma ./apps/api/prisma
 COPY --from=builder /repo/packages/common/dist ./packages/common/dist
 
 USER honoapi
@@ -64,4 +71,6 @@ USER honoapi
 EXPOSE 3001
 ENV PORT=3001
 
+# WORKDIR が /repo/apps/api のため、build/apps/api/src/index.js が実際のエントリポイント
+WORKDIR /repo/apps/api
 CMD ["node", "build/apps/api/src/index.js"]


### PR DESCRIPTION
## Summary

- `apps/api/Dockerfile`: CMD を `build/index.js` → `build/apps/api/src/index.js` に修正
  - TypeScript の paths マッピング (`@budget/common: packages/common/src/...`) により `packages/common` が compilation に含まれ、出力が `build/apps/api/src/` 以下に生成される
- `.github/workflows/deploy.yml`: DB マイグレーション実行コマンドのパスを同様に修正
- `.github/workflows/deploy.yml`: Deploy ECS ステップをサイドカー構成に対応
  - web サービスのタスク定義 (`budget-dev-web`) が web + api の両コンテナを持つ
  - web/api いずれかが変更された場合に両コンテナの image を更新する
  - api サービスは 0 にスケールダウン済みのため、api タスク定義のみ更新するステップに変更

## Background

手動で ECS タスク定義をサイドカー構成（web + api 同一タスク）に移行済み:
- Web と API を別タスクに分けると `API_URL=http://localhost:3001` が機能しない
- CloudFront は IP アドレスをオリジンとして使えないため API の Public IP をオリジン登録できない
- サイドカーパターンにより `http://localhost:3001` で API に到達できる

## Test plan

- [ ] `apps/api/build/apps/api/src/index.js` が Docker イメージ内に存在することを確認
- [ ] ECS タスクが起動し、API・Web 両コンテナが HEALTHY になることを確認
- [ ] `https://d1n9sux6qvf4lx.cloudfront.net/` がアクセス可能になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)