### PR TITLE
fix: deploy.yml ステップ名の YAML 構文エラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -264,7 +264,7 @@ jobs:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
-      - name: Deploy web service (sidecar: web + api)
+      - name: Deploy web service sidecar
         # web または api のいずれかが変更された場合にサイドカータスク定義を更新
         if: needs.build-and-push.outputs.web-image != '' || needs.build-and-push.outputs.api-image != ''
         env:
@@ -301,7 +301,7 @@ jobs:
 
           echo "web-task-def=${NEW_TASK_DEF_ARN}" >> "$GITHUB_ENV"
 
-      - name: Update api task definition (DB migration 専用、サービスは 0 のまま)
+      - name: Update api task definition for DB migration
         # api タスク定義を最新イメージで更新（migrate コマンド実行のベースとして使用）
         if: needs.build-and-push.outputs.api-image != ''
         env:


### PR DESCRIPTION
## Summary

- ステップ名 `Deploy web service (sidecar: web + api)` の `sidecar: ` がコロン+スペースのため YAML のマッピング区切り文字として解釈されていた
- ステップ名を `Deploy web service sidecar` / `Update api task definition for DB migration` に変更

## 原因

GitHub Actions が報告していたエラー:
```
YAML 構文の 267 行目にエラーがあります
```

YAML において plain scalar（引用符なしの文字列）内の `: `（コロン+スペース）は
マッピング区切りとして解釈される仕様のため、`name:` の値に含まれると構文エラーになる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)