### PR TITLE
fix: ECRイメージURIのシークレットマスクによるジョブスキップを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,8 +75,9 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.web == 'true' || needs.detect-changes.outputs.api == 'true' || github.event.inputs.force_deploy == 'true'
     outputs:
-      web-image: ${{ steps.web-image.outputs.image }}
-      api-image: ${{ steps.api-image.outputs.image }}
+      # ECR URL はシークレット値を含むためマスクされる。boolean フラグのみ渡し、後続ジョブで URI を再構成する
+      web-built: ${{ steps.web-image.outputs.built }}
+      api-built: ${{ steps.api-image.outputs.built }}
     steps:
       - uses: actions/checkout@v4
 
@@ -109,7 +110,7 @@ jobs:
             --cache-to type=inline \
             --push \
             .
-          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "built=true" >> "$GITHUB_OUTPUT"
 
       - name: Build & push api image
         id: api-image
@@ -127,7 +128,7 @@ jobs:
             --cache-to type=inline \
             --push \
             .
-          echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
+          echo "built=true" >> "$GITHUB_OUTPUT"
 
   # ─── trivy 脆弱性スキャン ──────────────────────────────────────────────────────
   # HIGH / CRITICAL が検出された場合はここで強制中断し、後続ジョブをすべてブロックする
@@ -135,7 +136,7 @@ jobs:
     name: Trivy Security Scan
     runs-on: ubuntu-latest
     needs: build-and-push
-    if: needs.build-and-push.outputs.web-image != '' || needs.build-and-push.outputs.api-image != ''
+    if: needs.build-and-push.outputs.web-built == 'true' || needs.build-and-push.outputs.api-built == 'true'
     permissions:
       security-events: write # SARIF 結果を GitHub Security タブへアップロードするために必要
     steps:
@@ -151,10 +152,10 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Scan web image
-        if: needs.build-and-push.outputs.web-image != ''
+        if: needs.build-and-push.outputs.web-built == 'true'
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ needs.build-and-push.outputs.web-image }}
+          image-ref: ${{ secrets.ECR_REGISTRY }}/budget-dev-web:${{ github.sha }}
           format: sarif
           output: trivy-web.sarif
           # HIGH / CRITICAL を検知した場合はステップを失敗させデプロイを中断
@@ -163,17 +164,17 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload web scan results to GitHub Security
-        if: always() && needs.build-and-push.outputs.web-image != ''
+        if: always() && needs.build-and-push.outputs.web-built == 'true'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-web.sarif
           category: trivy-web
 
       - name: Scan api image
-        if: needs.build-and-push.outputs.api-image != ''
+        if: needs.build-and-push.outputs.api-built == 'true'
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ needs.build-and-push.outputs.api-image }}
+          image-ref: ${{ secrets.ECR_REGISTRY }}/budget-dev-api:${{ github.sha }}
           format: sarif
           output: trivy-api.sarif
           severity: HIGH,CRITICAL
@@ -181,7 +182,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload api scan results to GitHub Security
-        if: always() && needs.build-and-push.outputs.api-image != ''
+        if: always() && needs.build-and-push.outputs.api-built == 'true'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-api.sarif
@@ -192,7 +193,7 @@ jobs:
     name: DB Migration
     runs-on: ubuntu-latest
     needs: [build-and-push, trivy-scan]
-    if: needs.build-and-push.outputs.api-image != '' && needs.trivy-scan.result == 'success'
+    if: needs.build-and-push.outputs.api-built == 'true' && needs.trivy-scan.result == 'success'
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -266,14 +267,22 @@ jobs:
 
       - name: Deploy web service sidecar
         # web または api のいずれかが変更された場合にサイドカータスク定義を更新
-        if: needs.build-and-push.outputs.web-image != '' || needs.build-and-push.outputs.api-image != ''
+        if: needs.build-and-push.outputs.web-built == 'true' || needs.build-and-push.outputs.api-built == 'true'
         env:
           CLUSTER: ${{ secrets.ECS_CLUSTER }}
           SERVICE: ${{ secrets.ECS_SERVICE_WEB }}
           TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_WEB }}
-          NEW_WEB_IMAGE: ${{ needs.build-and-push.outputs.web-image }}
-          NEW_API_IMAGE: ${{ needs.build-and-push.outputs.api-image }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
+          WEB_BUILT: ${{ needs.build-and-push.outputs.web-built }}
+          API_BUILT: ${{ needs.build-and-push.outputs.api-built }}
         run: |
+          # イメージ URI を再構成（ECR_REGISTRY シークレットはここで展開するため job output には含めない）
+          NEW_WEB_IMAGE=""
+          NEW_API_IMAGE=""
+          [ "${WEB_BUILT}" = "true" ] && NEW_WEB_IMAGE="${ECR_REGISTRY}/budget-dev-web:${IMAGE_TAG}"
+          [ "${API_BUILT}" = "true" ] && NEW_API_IMAGE="${ECR_REGISTRY}/budget-dev-api:${IMAGE_TAG}"
+
           # 現在のサイドカータスク定義を取得
           TASK_DEF=$(aws ecs describe-task-definition \
             --task-definition "${TASK_FAMILY}" \
@@ -299,15 +308,16 @@ jobs:
             --task-definition "${NEW_TASK_DEF_ARN}" \
             --force-new-deployment
 
-          echo "web-task-def=${NEW_TASK_DEF_ARN}" >> "$GITHUB_ENV"
-
       - name: Update api task definition for DB migration
         # api タスク定義を最新イメージで更新（migrate コマンド実行のベースとして使用）
-        if: needs.build-and-push.outputs.api-image != ''
+        if: needs.build-and-push.outputs.api-built == 'true'
         env:
           TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_API }}
-          NEW_IMAGE: ${{ needs.build-and-push.outputs.api-image }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
         run: |
+          NEW_IMAGE="${ECR_REGISTRY}/budget-dev-api:${IMAGE_TAG}"
+
           TASK_DEF=$(aws ecs describe-task-definition \
             --task-definition "${TASK_FAMILY}" \
             --query 'taskDefinition' \
@@ -324,7 +334,7 @@ jobs:
             --output text
 
       - name: Wait for web service stability
-        if: needs.build-and-push.outputs.web-image != '' || needs.build-and-push.outputs.api-image != ''
+        if: needs.build-and-push.outputs.web-built == 'true' || needs.build-and-push.outputs.api-built == 'true'
         env:
           CLUSTER: ${{ secrets.ECS_CLUSTER }}
           SERVICE: ${{ secrets.ECS_SERVICE_WEB }}


### PR DESCRIPTION
## Summary

- `build-and-push` ジョブの output に ECR レジストリ URL（`ECR_REGISTRY` シークレット値）が含まれるため、GitHub Actions が自動マスクし後続ジョブで空文字として評価されていた
- これにより `trivy-scan` / `db-migrate` / `deploy-ecs` / `update-cloudfront` がすべてスキップされていた

## 変更内容

- `web-image` / `api-image` output（ECR URI）を廃止
- マスクされない `web-built` / `api-built`（boolean: `'true'` or 空文字）に変更
- 後続ジョブ内で `${{ secrets.ECR_REGISTRY }}/budget-dev-{web,api}:${{ github.sha }}` としてイメージ URI を再構成

## Test plan

- [ ] PRマージ後、`workflow_dispatch` で `force_deploy=true` を選択して手動実行
- [ ] Trivy scan → DB Migration → Deploy ECS → Update CloudFront がすべて実行されることを確認
- [ ] `https://d1n9sux6qvf4lx.cloudfront.net` でアプリにアクセスできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)