### PR TITLE
fix: trivy-scan ジョブに OIDC 権限を追加し SARIF アップロード条件を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -139,6 +139,8 @@ jobs:
     if: needs.build-and-push.outputs.web-built == 'true' || needs.build-and-push.outputs.api-built == 'true'
     permissions:
       security-events: write # SARIF 結果を GitHub Security タブへアップロードするために必要
+      id-token: write        # OIDC トークン取得（ECR ログインに必要）
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -152,6 +154,7 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v2
 
       - name: Scan web image
+        id: scan-web
         if: needs.build-and-push.outputs.web-built == 'true'
         uses: aquasecurity/trivy-action@master
         with:
@@ -164,13 +167,15 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload web scan results to GitHub Security
-        if: always() && needs.build-and-push.outputs.web-built == 'true'
+        # スキャンが実行された場合のみアップロード（SARIF ファイルが存在しない場合はスキップ）
+        if: always() && steps.scan-web.conclusion != 'skipped'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-web.sarif
           category: trivy-web
 
       - name: Scan api image
+        id: scan-api
         if: needs.build-and-push.outputs.api-built == 'true'
         uses: aquasecurity/trivy-action@master
         with:
@@ -182,7 +187,7 @@ jobs:
           ignore-unfixed: true
 
       - name: Upload api scan results to GitHub Security
-        if: always() && needs.build-and-push.outputs.api-built == 'true'
+        if: always() && steps.scan-api.conclusion != 'skipped'
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: trivy-api.sarif


### PR DESCRIPTION
## 原因

`trivy-scan` ジョブに job-level の `permissions` を指定したとき、top-level の `id-token: write` が上書きされて OIDC トークンが取得できず、ECR 認証が失敗していた。

## 変更内容

- `trivy-scan` 権限に `id-token: write` と `contents: read` を追加
- SARIF アップロードステップの条件を `always() && web-built == 'true'` から `steps.scan-web.conclusion != 'skipped'` に変更（スキャン未実行時に `.sarif` ファイルが存在しないエラーを防止）

## Test plan

- [ ] マージ後 `force_deploy=true` で手動実行
- [ ] Trivy Security Scan が成功することを確認
- [ ] DB Migration → Deploy ECS → Update CloudFront まで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)