### PR TITLE
chore: PR時セキュリティ・品質チェック導入とデプロイフロー簡素化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,12 @@
 # フロー:
 #   1. 変更検出    — apps/web / apps/api の差分を検出し、不要なビルドをスキップ
 #   2. Build & Push — ECR へイメージをプッシュ
-#   3. trivy スキャン — HIGH/CRITICAL 脆弱性を検知した場合デプロイを強制中断
-#   4. DB Migration — ECS Run Task で prisma migrate deploy を実行
-#   5. ECS Deploy   — タスク定義を更新しサービスをローリングアップデート
-#   6. CF Update    — ECS タスクの Public IP を CloudFront オリジンに反映
+#   3. DB Migration — ECS Run Task で prisma migrate deploy を実行
+#   4. ECS Deploy   — タスク定義を更新しサービスをローリングアップデート
+#   5. CF Update    — ECS タスクの Public IP を CloudFront オリジンに反映
+#
+# セキュリティスキャン（Trivy）は pr-checks.yml で PR 時に実施。
+# デプロイフローには含めない（PR マージ後は済み扱い）。
 #
 # 必須 GitHub Secrets:
 #   AWS_ROLE_ARN          — terraform output github_actions_role_arn の値
@@ -130,77 +132,12 @@ jobs:
             .
           echo "built=true" >> "$GITHUB_OUTPUT"
 
-  # ─── trivy 脆弱性スキャン ──────────────────────────────────────────────────────
-  # HIGH / CRITICAL が検出された場合はここで強制中断し、後続ジョブをすべてブロックする
-  trivy-scan:
-    name: Trivy Security Scan
-    runs-on: ubuntu-latest
-    needs: build-and-push
-    if: needs.build-and-push.outputs.web-built == 'true' || needs.build-and-push.outputs.api-built == 'true'
-    permissions:
-      security-events: write # SARIF 結果を GitHub Security タブへアップロードするために必要
-      id-token: write        # OIDC トークン取得（ECR ログインに必要）
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Configure AWS credentials (OIDC)
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-      - name: Login to ECR
-        uses: aws-actions/amazon-ecr-login@v2
-
-      - name: Scan web image
-        id: scan-web
-        if: needs.build-and-push.outputs.web-built == 'true'
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ secrets.ECR_REGISTRY }}/budget-dev-web:${{ github.sha }}
-          format: sarif
-          output: trivy-web.sarif
-          # HIGH / CRITICAL を検知した場合はステップを失敗させデプロイを中断
-          severity: HIGH,CRITICAL
-          exit-code: "1"
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-
-      - name: Upload web scan results to GitHub Security
-        # スキャンが実行された場合のみアップロード（SARIF ファイルが存在しない場合はスキップ）
-        if: always() && steps.scan-web.conclusion != 'skipped'
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-web.sarif
-          category: trivy-web
-
-      - name: Scan api image
-        id: scan-api
-        if: needs.build-and-push.outputs.api-built == 'true'
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ${{ secrets.ECR_REGISTRY }}/budget-dev-api:${{ github.sha }}
-          format: sarif
-          output: trivy-api.sarif
-          severity: HIGH,CRITICAL
-          exit-code: "1"
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-
-      - name: Upload api scan results to GitHub Security
-        if: always() && steps.scan-api.conclusion != 'skipped'
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-api.sarif
-          category: trivy-api
-
   # ─── DB マイグレーション ─────────────────────────────────────────────────────
   db-migrate:
     name: DB Migration
     runs-on: ubuntu-latest
-    needs: [build-and-push, trivy-scan]
-    if: needs.build-and-push.outputs.api-built == 'true' && needs.trivy-scan.result == 'success'
+    needs: build-and-push
+    if: needs.build-and-push.outputs.api-built == 'true'
     steps:
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
@@ -256,12 +193,11 @@ jobs:
   deploy-ecs:
     name: Deploy ECS
     runs-on: ubuntu-latest
-    needs: [build-and-push, trivy-scan, db-migrate]
-    # db-migrate がスキップ（API 変更なし）の場合も実行する。trivy が失敗した場合は中断。
+    needs: [build-and-push, db-migrate]
+    # db-migrate がスキップ（API 変更なし）の場合も実行する
     if: |
       always() &&
       needs.build-and-push.result == 'success' &&
-      needs.trivy-scan.result == 'success' &&
       (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,249 @@
+# ============================================================
+# pr-checks.yml — PR 時の自動チェック（マージブロックのガードレール）
+#
+# フロー（全ジョブ並列実行）:
+#   1. lint-typecheck    — lint + 型チェック
+#   2. unit-test         — ユニットテスト
+#   3. integration-test  — 統合テスト（MySQL サービスコンテナ使用）
+#   4. security-scan     — Trivy FS スキャン（Docker ビルド不要）
+#   5. migration-check   — Prisma スキーマ検証 + 破壊的変更の検出
+#   6. infra-check       — Terraform 構文・フォーマットチェック
+#
+# ブランチ保護設定（GitHub Settings > Branches > main）:
+#   Require status checks to pass before merging に以下を登録すること:
+#   - Lint & Type Check
+#   - Unit Test
+#   - Integration Test
+#   - Security Scan (FS)
+#   - Migration Check
+#   - Infrastructure Check
+# ============================================================
+
+name: PR Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  # ─── lint + 型チェック ─────────────────────────────────────────────────────
+  lint-typecheck:
+    name: Lint & Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Generate Prisma client
+        run: pnpm --filter @budget/api exec prisma generate
+
+      - name: Lint & type-check
+        run: pnpm turbo run lint type-check
+
+  # ─── ユニットテスト ────────────────────────────────────────────────────────
+  unit-test:
+    name: Unit Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Generate Prisma client
+        run: pnpm --filter @budget/api exec prisma generate
+
+      - name: Run unit tests
+        run: pnpm test:unit
+
+  # ─── 統合テスト（実 DB） ───────────────────────────────────────────────────
+  integration-test:
+    name: Integration Test
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: rootpassword
+          MYSQL_USER: Admin
+          MYSQL_PASSWORD: password
+          MYSQL_DATABASE: budgetdb_test
+        ports:
+          - 3307:3306  # .env.test の DB_PORT=3307 に合わせてマッピング
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -u root -prootpassword"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Generate Prisma client
+        env:
+          DATABASE_URL: "mysql://Admin:password@127.0.0.1:3307/budgetdb_test"
+        run: pnpm --filter @budget/api exec prisma generate
+
+      - name: Push schema to test DB
+        env:
+          DATABASE_URL: "mysql://Admin:password@127.0.0.1:3307/budgetdb_test"
+        run: pnpm --filter @budget/api exec prisma db push --skip-generate
+
+      - name: Run integration tests
+        env:
+          # DATABASE_URL を明示指定（dotenv の .env.test より優先される）
+          DATABASE_URL: "mysql://Admin:password@127.0.0.1:3307/budgetdb_test"
+        run: pnpm test:integration
+
+  # ─── セキュリティスキャン（FS） ────────────────────────────────────────────
+  # Docker ビルド・ECR 不要。pnpm-lock.yaml を直接スキャンするため高速。
+  security-scan:
+    name: Security Scan (FS)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # SARIF 結果を GitHub Security タブへアップロード
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: sarif
+          output: trivy-fs.sarif
+          severity: HIGH,CRITICAL
+          exit-code: "1"
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+
+      - name: Upload scan results to GitHub Security
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs
+
+  # ─── マイグレーションチェック ──────────────────────────────────────────────
+  migration-check:
+    name: Migration Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # git diff で base ブランチとの比較に必要
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Validate Prisma schema
+        run: pnpm --filter @budget/api exec prisma validate
+
+      - name: Check for destructive migrations
+        run: |
+          MIGRATION_DIR="apps/api/prisma/migrations"
+
+          # ベースブランチとの差分でマイグレーションファイルの変更を検出
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          CHANGED=$(git diff --name-only --diff-filter=AM \
+            "origin/${{ github.base_ref }}...HEAD" \
+            -- "${MIGRATION_DIR}" 2>/dev/null | grep "\.sql$" || true)
+
+          if [ -z "${CHANGED}" ]; then
+            echo "変更されたマイグレーションなし。スキップ。"
+            exit 0
+          fi
+
+          echo "変更されたマイグレーション:"
+          echo "${CHANGED}"
+          echo ""
+
+          FOUND=0
+          while IFS= read -r FILE; do
+            if [ -f "${FILE}" ] && grep -iEq \
+              "DROP\s+(TABLE|COLUMN)|ALTER\s+TABLE\s+\S+\s+DROP\s+(COLUMN|INDEX)" \
+              "${FILE}"; then
+              echo "破壊的変更検出: ${FILE}"
+              grep -inE \
+                "DROP\s+(TABLE|COLUMN)|ALTER\s+TABLE\s+\S+\s+DROP\s+(COLUMN|INDEX)" \
+                "${FILE}"
+              FOUND=1
+            fi
+          done <<< "${CHANGED}"
+
+          if [ "${FOUND}" = "1" ]; then
+            echo ""
+            echo "破壊的なマイグレーションが検出されました。"
+            echo "意図的な変更であれば DBA またはチームの承認を得てからマージしてください。"
+            exit 1
+          fi
+
+          echo "チェック完了: 破壊的変更なし。"
+
+  # ─── インフラ構成チェック ──────────────────────────────────────────────────
+  infra-check:
+    name: Infrastructure Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.7"
+
+      - name: Terraform format check
+        working-directory: infra/dev
+        run: terraform fmt -check -recursive
+
+      - name: Terraform init (backend=false)
+        working-directory: infra/dev
+        # プロバイダーのダウンロードのみ実行。S3 backend への接続は不要。
+        run: terraform init -backend=false
+
+      - name: Terraform validate
+        working-directory: infra/dev
+        run: terraform validate


### PR DESCRIPTION
## Summary

- `pr-checks.yml` を新規追加 — mainへのPRで6ジョブを並列実行してマージをブロック
  - **Lint & Type Check**: `pnpm turbo run lint type-check`
  - **Unit Test**: `pnpm test:unit`
  - **Integration Test**: MySQL 8.0サービスコンテナ（port 3307）+ `prisma db push` + `pnpm test:integration`
  - **Security Scan (FS)**: Trivy fsスキャン（pnpm-lock.yaml直接スキャン、Dockerビルド不要）→ SARIF → GitHub Security
  - **Migration Check**: `prisma validate` + 破壊的変更（DROP TABLE/COLUMN）検出
  - **Infrastructure Check**: `terraform fmt -check` + `terraform init -backend=false` + `terraform validate`
- `deploy.yml` からTrivy imageスキャンジョブ（`trivy-scan`）を削除
  - デプロイ依存チェーン: `build-and-push → db-migrate → deploy-ecs → update-cloudfront` に整理
  - セキュリティチェックはPR時に完結させるため、デプロイ時の再スキャンは不要

## ブランチ保護設定（マージ後に手動で設定が必要）

GitHub Settings → Branches → main → Require status checks に以下を登録:

- `Lint & Type Check`
- `Unit Test`
- `Integration Test`
- `Security Scan (FS)`
- `Migration Check`
- `Infrastructure Check`

## Test plan

- [ ] PRをmainへ向けて作成し、6ジョブが並列起動することを確認
- [ ] マージ後に `workflow_dispatch` で `force_deploy=true` を実行し、デプロイが `build-and-push → db-migrate → deploy-ecs → update-cloudfront` の順で完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)