### PR TITLE
fix: GitHub ActionsロールにECS RunTask・CloudFront更新権限を追加

### DIFF
--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -97,7 +97,7 @@ data "aws_iam_policy_document" "github_actions_policy" {
     resources = [local.ecr_resource_arn]
   }
 
-  # ECS: タスク定義更新・サービス更新
+  # ECS: タスク定義更新・サービス更新・マイグレーションタスク実行
   statement {
     sid    = "ECSDeployDescribe"
     effect = "Allow"
@@ -108,6 +108,9 @@ data "aws_iam_policy_document" "github_actions_policy" {
       "ecs:DescribeTaskDefinition",
       "ecs:ListTaskDefinitions",
       "ecs:ListClusters",
+      "ecs:RunTask",      # DB マイグレーション用 ECS Run Task
+      "ecs:DescribeTasks", # マイグレーションタスクの完了確認・CloudFront 更新時の IP 取得
+      "ecs:ListTasks",    # CloudFront 更新時のタスク一覧取得
     ]
     resources = ["*"]
   }
@@ -125,6 +128,28 @@ data "aws_iam_policy_document" "github_actions_policy" {
       variable = "iam:PassedToService"
       values   = ["ecs-tasks.amazonaws.com"]
     }
+  }
+
+  # EC2: ECS タスクの ENI から Public IP を取得（CloudFront オリジン更新に必要）
+  statement {
+    sid    = "EC2DescribeENI"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeNetworkInterfaces",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudFront: オリジン更新・キャッシュ無効化
+  statement {
+    sid    = "CloudFrontUpdate"
+    effect = "Allow"
+    actions = [
+      "cloudfront:GetDistributionConfig",
+      "cloudfront:UpdateDistribution",
+      "cloudfront:CreateInvalidation",
+    ]
+    resources = ["*"]
   }
 
   # SSM Parameter Store: アプリ設定の読取（シークレット含む）


### PR DESCRIPTION
## Summary

`ecs:RunTask` を含む必要な IAM 権限が GitHub Actions ロールに付与されていなかったため、DB マイグレーションと CloudFront 更新が AccessDeniedException で失敗していた。

追加した権限:

| 権限 | 用途 |
|------|------|
| `ecs:RunTask` | DB マイグレーション用 ECS Run Task |
| `ecs:DescribeTasks` | マイグレーションタスクの完了確認・CF 更新時の IP 取得 |
| `ecs:ListTasks` | CloudFront 更新時の実行中タスク一覧取得 |
| `ec2:DescribeNetworkInterfaces` | ECS タスクの ENI から Public IP を取得 |
| `cloudfront:GetDistributionConfig` | CloudFront オリジン設定の取得 |
| `cloudfront:UpdateDistribution` | CloudFront オリジンの書き換え |
| `cloudfront:CreateInvalidation` | キャッシュ無効化 |

## マージ後に必要な手順

**`terraform apply` を実行して AWS の IAM ポリシーを実際に更新すること。**

```bash
cd infra/dev
terraform init
terraform apply -target=module.iam
```

その後、GitHub Actions の `workflow_dispatch` → `force_deploy=true` でデプロイを再実行する。

## Test plan

- [ ] `terraform apply` 完了後、`force_deploy=true` でデプロイが最後まで通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)