### PR TITLE
fix: デプロイ根本問題2件を修正（マイグレーションコマンド・サイドカータスク定義）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,13 +158,18 @@ jobs:
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
 
-          # マイグレーション専用タスクを実行（コマンド上書き）
+          echo "Using task definition: ${TASK_DEF}"
+
+          # prisma migrate deploy を直接実行
+          # index.ts は --migrate フラグを処理しないため、prisma CLI を直接呼び出す
+          # WORKDIR=/repo/apps/api なので schema は ./prisma/schema.prisma で自動検出される
+          # DATABASE_URL はタスク定義の secrets セクションから SSM 経由で注入される
           TASK_ARN=$(aws ecs run-task \
             --cluster "${CLUSTER}" \
             --task-definition "${TASK_DEF}" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SG_API}],assignPublicIp=ENABLED}" \
-            --overrides '{"containerOverrides":[{"name":"api","command":["node","build/apps/api/src/index.js","--migrate"]}]}' \
+            --overrides '{"containerOverrides":[{"name":"api","command":["/bin/sh","-c","/repo/node_modules/.bin/prisma migrate deploy"]}]}' \
             --query 'tasks[0].taskArn' \
             --output text)
 
@@ -175,12 +180,19 @@ jobs:
             --cluster "${CLUSTER}" \
             --tasks "${TASK_ARN}"
 
-          # 終了コードを確認
-          EXIT_CODE=$(aws ecs describe-tasks \
+          # 終了コードと停止理由を取得（失敗時のデバッグ用）
+          TASK_INFO=$(aws ecs describe-tasks \
             --cluster "${CLUSTER}" \
             --tasks "${TASK_ARN}" \
-            --query 'tasks[0].containers[0].exitCode' \
-            --output text)
+            --output json)
+
+          STOP_REASON=$(echo "${TASK_INFO}" | jq -r '.tasks[0].stoppedReason // "N/A"')
+          CONTAINER_REASON=$(echo "${TASK_INFO}" | jq -r '.tasks[0].containers[0].reason // "N/A"')
+          EXIT_CODE=$(echo "${TASK_INFO}" | jq -r '.tasks[0].containers[0].exitCode // "null"')
+
+          echo "Stopped reason   : ${STOP_REASON}"
+          echo "Container reason : ${CONTAINER_REASON}"
+          echo "Exit code        : ${EXIT_CODE}"
 
           if [ "${EXIT_CODE}" != "0" ]; then
             echo "Migration failed with exit code ${EXIT_CODE}"

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -40,7 +40,14 @@ resource "aws_cloudwatch_log_group" "api" {
   retention_in_days = 7
 }
 
-# ─── タスク定義: web ─────────────────────────────────────────────────────────
+# ─── タスク定義: web (サイドカー構成: web + api を同一タスクで起動) ──────────
+#
+# web と api を同一 Fargate タスクに同居させ、localhost で通信する。
+# - web (Next.js)  : port 3000 — CloudFront がオリジンとして参照
+# - api (Hono)     : port 3001 — web から http://localhost:3001 で呼び出す
+#
+# deploy.yml の deploy-ecs ジョブが CI/CD でイメージを差し替えるため、
+# lifecycle.ignore_changes = [task_definition] で Terraform 側の上書きを防ぐ。
 
 resource "aws_ecs_task_definition" "web" {
   family                   = "${var.name_prefix}-web"
@@ -51,6 +58,7 @@ resource "aws_ecs_task_definition" "web" {
   execution_role_arn       = var.task_execution_role_arn
 
   container_definitions = jsonencode([
+    # ─ index 0: web (Next.js) ─────────────────────────────────────────────
     {
       name      = "web"
       image     = var.web_image
@@ -64,15 +72,13 @@ resource "aws_ecs_task_definition" "web" {
       ]
 
       environment = [
-        # API_URL は VPC 内部の api タスク IP を指定（デプロイ後に更新）
-        # 初期値は placeholder。ECS Service Connect または手動更新で解決
         {
           name  = "NODE_ENV"
           value = "production"
         }
       ]
 
-      # SSM から環境変数を注入（ハードコード禁止）
+      # NEXT_PUBLIC_API_URL は同一タスク内 localhost を指す
       secrets = [
         {
           name      = "NEXT_PUBLIC_API_URL"
@@ -91,6 +97,63 @@ resource "aws_ecs_task_definition" "web" {
 
       healthCheck = {
         command     = ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    },
+
+    # ─ index 1: api (Hono) ────────────────────────────────────────────────
+    {
+      name      = "api"
+      image     = var.api_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = 3001
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = [
+        {
+          name  = "NODE_ENV"
+          value = "production"
+        },
+        {
+          name  = "PORT"
+          value = "3001"
+        }
+      ]
+
+      secrets = [
+        {
+          name      = "DATABASE_URL"
+          valueFrom = "${var.ssm_prefix}/database_url"
+        },
+        {
+          name      = "JWT_SECRET"
+          valueFrom = "${var.ssm_prefix}/jwt_secret"
+        },
+        {
+          name      = "CF_ORIGIN_SECRET"
+          valueFrom = "${var.ssm_prefix}/cf_origin_secret"
+        }
+      ]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          awslogs-group         = aws_cloudwatch_log_group.api.name
+          awslogs-region        = var.aws_region
+          awslogs-stream-prefix = "ecs"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:3001/api/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3


### PR DESCRIPTION
## 修正した根本原因

### 1. マイグレーションコマンドが `prisma migrate deploy` を実行していなかった

**問題**: `index.ts` は `--migrate` フラグを一切処理しない。ECS タスクは HTTP サーバーを起動したまま停止せず、ECS に強制停止されて `exitCode = null (None)` になっていた。

**修正**: コンテナオーバーライドコマンドを prisma CLI 直接呼び出しに変更

```
Before: ["node","build/apps/api/src/index.js","--migrate"]
After:  ["/bin/sh","-c","/repo/node_modules/.bin/prisma migrate deploy"]
```

- WORKDIR `/repo/apps/api` から `./prisma/schema.prisma` を自動検出
- `DATABASE_URL` はタスク定義の SSM secrets から引き続き注入される
- 失敗時に `stoppedReason` / `containerReason` もログ出力するよう追加

### 2. web タスク定義にサイドカーコンテナが定義されていなかった

**問題**: Terraform の web タスク定義に `web` コンテナ1つしかなかった。`deploy-ecs` ステップが `containerDefinitions[1]`（api サイドカー）を書き換えようとして、フィールドが `image` だけの壊れたコンテナをタスク定義に追加し続けていた。

**修正**: web タスク定義に api コンテナ（index 1）をサイドカーとして追加

```
web task definition:
  [0] web  (Next.js, port 3000) ← CloudFront がオリジンとして参照
  [1] api  (Hono,    port 3001) ← web から localhost:3001 で呼び出す
```

## マージ後に必要な手順（必須）

```bash
cd infra/dev
terraform init
terraform apply -target=module.ecs -target=module.iam
```

その後 `workflow_dispatch` → `force_deploy=true` で再実行。

## Test plan

- [ ] `terraform apply` 完了後、`force_deploy=true` でマイグレーションが exit code 0 で完了することを確認
- [ ] deploy-ecs ジョブで web サービスが安定することを確認
- [ ] update-cloudfront ジョブが完走することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)