### PR TITLE
fix: IAMモジュールのSSMリソースARNパスを修正（budget-dev/* → budget/dev/*）

### DIFF
--- a/infra/dev/main.tf
+++ b/infra/dev/main.tf
@@ -28,6 +28,7 @@ module "iam" {
   aws_region  = var.aws_region
   github_org  = var.github_org
   github_repo = var.github_repo
+  ssm_prefix  = var.ssm_prefix
 }
 
 # ─── フェーズ 3: ECR リポジトリ ───────────────────────────────────────────────

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -20,7 +20,9 @@ locals {
   account_id       = data.aws_caller_identity.current.account_id
   github_oidc_url  = "https://token.actions.githubusercontent.com"
   ecr_resource_arn = "arn:aws:ecr:${var.aws_region}:${local.account_id}:repository/${var.name_prefix}-*"
-  ssm_resource_arn = "arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter/${var.name_prefix}/*"
+  # ssm_prefix は "/budget/dev" 形式（先頭スラッシュあり）のため parameter と直接結合する
+  # 例: parameter/budget/dev/* → arn:aws:ssm:...:parameter/budget/dev/*
+  ssm_resource_arn = "arn:aws:ssm:${var.aws_region}:${local.account_id}:parameter${var.ssm_prefix}/*"
 }
 
 # ─── GitHub Actions OIDC ID プロバイダー ────────────────────────────────────

--- a/infra/modules/iam/variables.tf
+++ b/infra/modules/iam/variables.tf
@@ -18,6 +18,11 @@ variable "github_repo" {
   type        = string
 }
 
+variable "ssm_prefix" {
+  description = "SSM Parameter Store のパスプレフィックス（例: /budget/dev）。IAM ポリシーのリソース ARN 生成に使用"
+  type        = string
+}
+
 variable "rds_resource_id" {
   description = "RDS インスタンスの Resource ID（例: db-XXXXXXXXXX）。IAM DB Auth の rds-db:connect リソース指定に使用。空文字の場合は権限を付与しない"
   type        = string


### PR DESCRIPTION
## 問題

ECS タスクが SSM secrets を取得できず起動失敗:
```
AccessDeniedException: not authorized to perform: ssm:GetParameters on resource:
arn:aws:ssm:...:parameter/budget/dev/database_url
```

## 原因

IAM ポリシーの SSM リソース ARN が `name_prefix`（`budget-dev`）から生成されていたため `parameter/budget-dev/*` となっていたが、実際のパラメータパスは `ssm_prefix`（`/budget/dev`）ベースの `parameter/budget/dev/database_url`。パスが一致しないため権限チェックに失敗していた。

| | パス |
|---|---|
| IAM ポリシー (Before) | `parameter/budget-dev/*` |
| 実際のパラメータ | `parameter/budget/dev/database_url` |
| IAM ポリシー (After) | `parameter/budget/dev/*` ✓ |

## 修正内容

- `infra/modules/iam/variables.tf` — `ssm_prefix` 変数を追加
- `infra/modules/iam/main.tf` — `ssm_resource_arn` を `parameter${ssm_prefix}/*` に変更
- `infra/dev/main.tf` — IAM モジュールに `ssm_prefix` を渡すよう追加

## マージ後に必要な手順（必須）

```bash
cd infra/dev
terraform apply -target=module.iam
```

その後 `workflow_dispatch` → `force_deploy=true` で再実行。

🤖 Generated with [Claude Code](https://claude.com/claude-code)