### PR TITLE
fix: --migrate フラグで prisma CLI を require.resolve() 経由で実行（exit code 127 解消）

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,16 +160,16 @@ jobs:
 
           echo "Using task definition: ${TASK_DEF}"
 
-          # prisma migrate deploy を直接実行
-          # index.ts は --migrate フラグを処理しないため、prisma CLI を直接呼び出す
-          # WORKDIR=/repo/apps/api なので schema は ./prisma/schema.prisma で自動検出される
+          # prisma migrate deploy を index.js の --migrate フラグ経由で実行
+          # .bin/ symlink は pnpm + Docker multi-stage build で壊れる場合があるため
+          # index.ts 内で require.resolve() を使って prisma CLI のパスを解決している
           # DATABASE_URL はタスク定義の secrets セクションから SSM 経由で注入される
           TASK_ARN=$(aws ecs run-task \
             --cluster "${CLUSTER}" \
             --task-definition "${TASK_DEF}" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SG_API}],assignPublicIp=ENABLED}" \
-            --overrides '{"containerOverrides":[{"name":"api","command":["/bin/sh","-c","/repo/node_modules/.bin/prisma migrate deploy"]}]}' \
+            --overrides '{"containerOverrides":[{"name":"api","command":["node","build/apps/api/src/index.js","--migrate"]}]}' \
             --query 'tasks[0].taskArn' \
             --output text)
 

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,6 @@
 import * as path from 'node:path';
+import * as fs from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
 if (process.env.NODE_ENV !== 'production') {
     // CWD は turbo 実行時に apps/api/ になるため、リポジトリルートの .env を明示的に指定する
@@ -9,6 +11,40 @@ import { serve } from '@hono/node-server';
 import { prisma } from './infrastructure/persistence/prisma-client';
 import { buildDeps } from './container';
 import { createApp } from './app';
+
+// --migrate フラグ: ECS Run Task でマイグレーションのみ実行して終了する
+// .bin/ の shell symlink は pnpm + Docker multi-stage build 環境で壊れることがあるため、
+// Node.js の require.resolve() で prisma パッケージのパスを解決し、
+// Node.js 自身 (process.execPath) で直接実行する。
+if (process.argv.includes('--migrate')) {
+    try {
+        // Node モジュール解決で prisma CLI の実際のパスを取得
+        const prismaPkgPath = require.resolve('prisma/package.json');
+        const pkgJson = JSON.parse(fs.readFileSync(prismaPkgPath, 'utf-8')) as {
+            bin: Record<string, string>;
+        };
+        const prismaCli = path.resolve(path.dirname(prismaPkgPath), pkgJson.bin.prisma);
+
+        // __dirname = /repo/apps/api/build/apps/api/src のため 4 階層上が WORKDIR /repo/apps/api
+        // prisma は CWD/prisma/schema.prisma を自動検出するため CWD を明示する
+        const migrationCwd = path.resolve(__dirname, '../../../..');
+
+        console.log(`prisma CLI  : ${prismaCli}`);
+        console.log(`cwd         : ${migrationCwd}`);
+
+        execFileSync(process.execPath, [prismaCli, 'migrate', 'deploy'], {
+            stdio: 'inherit',
+            env: process.env,
+            cwd: migrationCwd,
+        });
+
+        console.log('Migration completed successfully');
+        process.exit(0);
+    } catch (err) {
+        console.error('Migration failed:', err);
+        process.exit(1);
+    }
+}
 
 const port = Number(process.env.PORT ?? 3001);
 


### PR DESCRIPTION
## Summary

- ECS Run Task でのマイグレーション実行が exit code 127 で失敗していた根本原因を修正
- pnpm + Docker multi-stage build 環境で `.bin/prisma` の shell symlink が機能しないため、`require.resolve('prisma/package.json')` で CLI パスを解決する方式に変更
- `apps/api/src/index.ts` に `--migrate` フラグのハンドラを実装
- `deploy.yml` のマイグレーションコマンドを `/bin/sh -c ".../.bin/prisma"` から `node build/apps/api/src/index.js --migrate` に変更

## Root Cause

以前の修正で `/bin/sh -c "/repo/node_modules/.bin/prisma migrate deploy"` を使用していたが、pnpm の `.bin/` は symlink であり、Docker コンテナ内では実行権限が解決されず exit code 127 (command not found) が発生していた。

## Solution

`require.resolve('prisma/package.json')` を使って Node.js のモジュール解決アルゴリズムで prisma CLI の実際のパス（`.pnpm/` 仮想ストア内）を取得し、`process.execPath`（Node.js 自身）で直接実行することで shell と symlink への依存を完全に排除した。

## Test plan

- [ ] PR マージ後に `terraform apply` で IAM/ECS を更新（既に適用済みの場合はスキップ可）
- [ ] `workflow_dispatch` で `force_deploy=true` を指定してデプロイを実行
- [ ] DB Migration ジョブが exit code 0 で完了することを確認
- [ ] CloudFront URL でアプリがアクセス可能なことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)