### PR TITLE
fix: マイグレーション実行方式の根本改善と CloudWatch ログ可視化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,16 +160,17 @@ jobs:
 
           echo "Using task definition: ${TASK_DEF}"
 
-          # prisma migrate deploy を index.js の --migrate フラグ経由で実行
-          # .bin/ symlink は pnpm + Docker multi-stage build で壊れる場合があるため
-          # index.ts 内で require.resolve() を使って prisma CLI のパスを解決している
+          # prisma migrate deploy を専用スクリプト経由で実行する
+          # scripts/run-migrate.js は require.resolve() で prisma CLI パスを解決するため
+          # .bin/ symlink の壊れ問題を回避できる。詳細ログを出力するため
+          # CloudWatch Logs で実際のエラー内容を確認できる。
           # DATABASE_URL はタスク定義の secrets セクションから SSM 経由で注入される
           TASK_ARN=$(aws ecs run-task \
             --cluster "${CLUSTER}" \
             --task-definition "${TASK_DEF}" \
             --launch-type FARGATE \
             --network-configuration "awsvpcConfiguration={subnets=[${SUBNETS}],securityGroups=[${SG_API}],assignPublicIp=ENABLED}" \
-            --overrides '{"containerOverrides":[{"name":"api","command":["node","build/apps/api/src/index.js","--migrate"]}]}' \
+            --overrides '{"containerOverrides":[{"name":"api","command":["node","scripts/run-migrate.js"]}]}' \
             --query 'tasks[0].taskArn' \
             --output text)
 
@@ -180,7 +181,7 @@ jobs:
             --cluster "${CLUSTER}" \
             --tasks "${TASK_ARN}"
 
-          # 終了コードと停止理由を取得（失敗時のデバッグ用）
+          # 終了コードと停止理由を取得
           TASK_INFO=$(aws ecs describe-tasks \
             --cluster "${CLUSTER}" \
             --tasks "${TASK_ARN}" \
@@ -193,6 +194,24 @@ jobs:
           echo "Stopped reason   : ${STOP_REASON}"
           echo "Container reason : ${CONTAINER_REASON}"
           echo "Exit code        : ${EXIT_CODE}"
+
+          # CloudWatch Logs からマイグレーション実行ログを取得して表示する
+          # exit code に関わらず常に表示することで、失敗時の原因調査を GitHub Actions 上で完結させる
+          TASK_ID=$(echo "${TASK_ARN}" | sed 's|.*/||')
+          NAME_PREFIX="${TASK_FAMILY%-api}"
+          LOG_GROUP="/ecs/${NAME_PREFIX}/api"
+          LOG_STREAM="ecs/api/${TASK_ID}"
+          echo ""
+          echo "=== CloudWatch Logs: ${LOG_GROUP}/${LOG_STREAM} ==="
+          # ログが CloudWatch に書き込まれるまで数秒待機
+          sleep 5
+          aws logs get-log-events \
+            --log-group-name "${LOG_GROUP}" \
+            --log-stream-name "${LOG_STREAM}" \
+            --query 'events[].message' \
+            --output text 2>/dev/null || echo "(CloudWatch ログの取得に失敗しました。IAM ポリシーまたはログストリーム名を確認してください)"
+          echo "============================================================"
+          echo ""
 
           if [ "${EXIT_CODE}" != "0" ]; then
             echo "Migration failed with exit code ${EXIT_CODE}"

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -64,6 +64,7 @@ COPY --from=builder /repo/packages/common/node_modules ./packages/common/node_mo
 # ビルド成果物
 COPY --from=builder /repo/apps/api/build ./apps/api/build
 COPY --from=builder /repo/apps/api/prisma ./apps/api/prisma
+COPY --from=builder /repo/apps/api/scripts ./apps/api/scripts
 COPY --from=builder /repo/packages/common/dist ./packages/common/dist
 
 USER honoapi

--- a/apps/api/scripts/run-migrate.js
+++ b/apps/api/scripts/run-migrate.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Prisma マイグレーション実行スクリプト
+ *
+ * ECS Run Task でコンテナ起動時のエントリポイントとして使用する。
+ * .bin/ の shell symlink は pnpm + Docker multi-stage build 環境で
+ * 実行権限が解決されないため、require.resolve() で prisma CLI の
+ * 実際のパスを取得して Node.js 自身で直接実行する。
+ *
+ * このスクリプトは /repo/apps/api/scripts/ に配置される。
+ * WORKDIR = /repo/apps/api なので __dirname = /repo/apps/api/scripts
+ */
+
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+// このスクリプトを基準に apps/api ルートを確定する
+const apiDir = path.resolve(__dirname, '..');
+
+console.log('=== Prisma Migration Runner ===');
+console.log('Node.js   :', process.execPath);
+console.log('apiDir    :', apiDir);
+console.log('DATABASE_URL defined:', !!process.env.DATABASE_URL);
+
+// Node モジュール解決で prisma CLI の実際のパスを取得する
+// { paths } オプションで検索開始ディレクトリを明示することで
+// スクリプト配置場所に依存しない安定した解決を実現する
+let prismaCli;
+try {
+    const prismaPkgPath = require.resolve('prisma/package.json', { paths: [apiDir] });
+    const pkg = JSON.parse(fs.readFileSync(prismaPkgPath, 'utf-8'));
+    prismaCli = path.resolve(path.dirname(prismaPkgPath), pkg.bin.prisma);
+    console.log('prisma pkg :', prismaPkgPath);
+    console.log('prisma CLI :', prismaCli);
+    console.log('CLI exists :', fs.existsSync(prismaCli));
+} catch (err) {
+    console.error('prisma CLI の特定に失敗しました:', err.message);
+    process.exit(1);
+}
+
+// prisma migrate deploy を実行する
+// stdio: 'inherit' で prisma のログを CloudWatch Logs に直接出力する
+console.log('実行: prisma migrate deploy');
+const result = spawnSync(process.execPath, [prismaCli, 'migrate', 'deploy'], {
+    stdio: 'inherit',
+    cwd: apiDir,
+    env: process.env,
+});
+
+if (result.error) {
+    console.error('spawn エラー:', result.error.message);
+    process.exit(1);
+}
+
+const exitCode = result.status ?? 1;
+if (exitCode !== 0) {
+    console.error(`マイグレーション失敗 (exit code: ${exitCode})`);
+    process.exit(exitCode);
+}
+
+console.log('マイグレーション完了');
+process.exit(0);

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,6 +1,4 @@
 import * as path from 'node:path';
-import * as fs from 'node:fs';
-import { execFileSync } from 'node:child_process';
 
 if (process.env.NODE_ENV !== 'production') {
     // CWD は turbo 実行時に apps/api/ になるため、リポジトリルートの .env を明示的に指定する
@@ -11,40 +9,6 @@ import { serve } from '@hono/node-server';
 import { prisma } from './infrastructure/persistence/prisma-client';
 import { buildDeps } from './container';
 import { createApp } from './app';
-
-// --migrate フラグ: ECS Run Task でマイグレーションのみ実行して終了する
-// .bin/ の shell symlink は pnpm + Docker multi-stage build 環境で壊れることがあるため、
-// Node.js の require.resolve() で prisma パッケージのパスを解決し、
-// Node.js 自身 (process.execPath) で直接実行する。
-if (process.argv.includes('--migrate')) {
-    try {
-        // Node モジュール解決で prisma CLI の実際のパスを取得
-        const prismaPkgPath = require.resolve('prisma/package.json');
-        const pkgJson = JSON.parse(fs.readFileSync(prismaPkgPath, 'utf-8')) as {
-            bin: Record<string, string>;
-        };
-        const prismaCli = path.resolve(path.dirname(prismaPkgPath), pkgJson.bin.prisma);
-
-        // __dirname = /repo/apps/api/build/apps/api/src のため 4 階層上が WORKDIR /repo/apps/api
-        // prisma は CWD/prisma/schema.prisma を自動検出するため CWD を明示する
-        const migrationCwd = path.resolve(__dirname, '../../../..');
-
-        console.log(`prisma CLI  : ${prismaCli}`);
-        console.log(`cwd         : ${migrationCwd}`);
-
-        execFileSync(process.execPath, [prismaCli, 'migrate', 'deploy'], {
-            stdio: 'inherit',
-            env: process.env,
-            cwd: migrationCwd,
-        });
-
-        console.log('Migration completed successfully');
-        process.exit(0);
-    } catch (err) {
-        console.error('Migration failed:', err);
-        process.exit(1);
-    }
-}
 
 const port = Number(process.env.PORT ?? 3001);
 

--- a/infra/modules/iam/main.tf
+++ b/infra/modules/iam/main.tf
@@ -165,6 +165,20 @@ data "aws_iam_policy_document" "github_actions_policy" {
     ]
     resources = [local.ssm_resource_arn]
   }
+
+  # CloudWatch Logs: マイグレーション実行ログの読取（GitHub Actions でのデバッグ用）
+  # ECS タスクのログを GitHub Actions 上に表示することで、失敗原因の調査を完結させる
+  statement {
+    sid    = "CloudWatchLogsRead"
+    effect = "Allow"
+    actions = [
+      "logs:GetLogEvents",
+    ]
+    # ログストリーム ARN: arn:aws:logs:region:account:log-group:name:log-stream:stream-name
+    resources = [
+      "arn:aws:logs:${var.aws_region}:${local.account_id}:log-group:/ecs/${var.name_prefix}/*:log-stream:*",
+    ]
+  }
 }
 
 # ─── EcsTaskExecutionRole ────────────────────────────────────────────────────


### PR DESCRIPTION
## 問題の構造

今まで「エラー → 推測修正 → 再エラー」を繰り返していた根本原因：

> **コンテナ内で何が起きているか見えなかった**

CloudWatch Logs に出力されているのに、GitHub Actions から取得する手段がなかったため、exit code だけで原因を推測せざるを得なかった。

## 変更内容

### 1. `apps/api/scripts/run-migrate.js`（新規）
専用マイグレーションスクリプト。`index.ts` との混在を排除。

- `require.resolve('prisma/package.json', { paths: [apiDir] })` で検索ディレクトリを明示指定
- `__dirname = /repo/apps/api/scripts` → `apiDir = /repo/apps/api`（安定した基準点）
- `spawnSync` で prisma の stdout/stderr をそのまま CloudWatch Logs へ出力
- 各ステップの診断ログ（Node パス、DATABASE_URL の存在、prisma CLI パス、ファイル存在確認）

### 2. `apps/api/Dockerfile`
runner ステージに `COPY scripts ./apps/api/scripts` を追加

### 3. `apps/api/src/index.ts`
`--migrate` ハンドラを削除し元の状態に戻す（起動ロジックに不要なコードを混在させない）

### 4. `.github/workflows/deploy.yml`
- マイグレーションコマンドを `node scripts/run-migrate.js` に変更
- タスク完了後に **CloudWatch Logs を取得して GitHub Actions に表示**
  - 成功・失敗に関わらず常に表示するため、次回以降もコンソール不要で原因特定できる

### 5. `infra/modules/iam/main.tf`（要 terraform apply）
- `logs:GetLogEvents` を `/ecs/budget-dev/*` スコープで付与
- これにより deploy.yml の CloudWatch ログ取得が動作する

## マージ後の手順

1. **PR マージ**
2. `terraform apply -target=module.iam`（IAM ポリシー更新）
3. `workflow_dispatch` で `force_deploy=true` でデプロイ実行
4. マイグレーションが失敗した場合でも **GitHub Actions の DB Migration ジョブのログ** に実際の prisma エラーが表示されるため、原因を特定して対処する

🤖 Generated with [Claude Code](https://claude.com/claude-code)