### PR TITLE
fix: CloudFront オリジンを IP から DNS 名（sslip.io）に変更

### DIFF
--- a/scripts/update-cloudfront-origin.sh
+++ b/scripts/update-cloudfront-origin.sh
@@ -13,6 +13,12 @@
 #   CLUSTER             — ECS クラスター名（例: budget-dev-cluster）
 #   SERVICE             — ECS サービス名（例: budget-dev-web）
 #   CLOUDFRONT_DIST_ID  — CloudFront ディストリビューション ID
+#
+# CloudFront と IP アドレスの制限:
+#   CloudFront のカスタムオリジンは DomainName に IP アドレスを直接指定できない。
+#   sslip.io を使って IP を DNS 名に変換する（例: 1.2.3.4.sslip.io → 1.2.3.4）。
+#   また、過去の状態で Origin.Id が IP アドレスになっている場合も
+#   正規の名前（{name_prefix}-web-origin）に修正する。
 # ============================================================
 
 set -euo pipefail
@@ -80,13 +86,52 @@ CONFIG=$(echo "${DIST_CONFIG}" | jq '.DistributionConfig')
 
 echo "現在の ETag: ${ETAG}"
 
-# ─── オリジンドメインを新しい Public IP に書き換え ────────────────────────────
+# ─── オリジン設定を更新 ────────────────────────────────────────────────────────
 
+# CloudFront は IP アドレスを DomainName に直接指定できないため（InvalidArgument エラー）、
+# sslip.io で IP を DNS 名に変換する。
+# sslip.io はオープンソースで、x.y.z.w.sslip.io を x.y.z.w に解決する。
+ORIGIN_DOMAIN="${PUBLIC_IP}.sslip.io"
+
+# SERVICE 名から name_prefix を導出して期待する Origin ID を構築する
+# 例: budget-dev-web → budget-dev → budget-dev-web-origin
+NAME_PREFIX="${SERVICE%-web}"
+EXPECTED_ORIGIN_ID="${NAME_PREFIX}-web-origin"
+
+# 現在の Origin ID（過去の操作で IP アドレスになっている可能性がある）
+CURRENT_ORIGIN_ID=$(echo "${CONFIG}" | jq -r '.Origins.Items[0].Id')
+CURRENT_DOMAIN=$(echo "${CONFIG}" | jq -r '.Origins.Items[0].DomainName')
+
+echo ""
+echo "現在の Origin:"
+echo "  Id         : ${CURRENT_ORIGIN_ID}"
+echo "  DomainName : ${CURRENT_DOMAIN}"
+echo "更新後の Origin:"
+echo "  Id         : ${EXPECTED_ORIGIN_ID}"
+echo "  DomainName : ${ORIGIN_DOMAIN}"
+echo ""
+
+# DomainName を IP から DNS 名（sslip.io）に変換して更新する。
+# Origin.Id が IP アドレスの場合は正規の名前に修正し、
+# DefaultCacheBehavior と CacheBehaviors の TargetOriginId も追従させる。
 UPDATED_CONFIG=$(echo "${CONFIG}" | jq \
-  --arg IP "${PUBLIC_IP}" \
-  '.Origins.Items[0].DomainName = $IP')
+  --arg DOMAIN "${ORIGIN_DOMAIN}" \
+  --arg OLD_ID "${CURRENT_ORIGIN_ID}" \
+  --arg NEW_ID "${EXPECTED_ORIGIN_ID}" \
+  '
+    .Origins.Items[0].DomainName = $DOMAIN |
+    .Origins.Items[0].Id = $NEW_ID |
+    (if .DefaultCacheBehavior.TargetOriginId == $OLD_ID
+     then .DefaultCacheBehavior.TargetOriginId = $NEW_ID
+     else . end) |
+    (if (.CacheBehaviors.Items // []) | length > 0
+     then .CacheBehaviors.Items |= map(
+       if .TargetOriginId == $OLD_ID then .TargetOriginId = $NEW_ID else . end
+     )
+     else . end)
+  ')
 
-echo "オリジン設定を ${PUBLIC_IP} に更新中..."
+echo "オリジン設定を ${ORIGIN_DOMAIN} に更新中..."
 
 aws cloudfront update-distribution \
   --id "${CLOUDFRONT_DIST_ID}" \
@@ -108,4 +153,4 @@ INVALIDATION_ID=$(aws cloudfront create-invalidation \
 
 echo "Invalidation ID: ${INVALIDATION_ID}"
 echo "キャッシュ無効化リクエストを送信しました（完了まで数分かかる場合があります）"
-echo "完了: CloudFront オリジン → ${PUBLIC_IP} / Invalidation → ${INVALIDATION_ID}"
+echo "完了: CloudFront オリジン → ${ORIGIN_DOMAIN} / Invalidation → ${INVALIDATION_ID}"


### PR DESCRIPTION
## 問題

```
InvalidArgument: The parameter origin name cannot be an IP address.
```

CloudFront のカスタムオリジンは `DomainName` に **IP アドレスを直接指定できない**（AWS の制約）。

ECS Fargate タスクはデプロイのたびに IP が変わるため、動的に IP を取得して CloudFront に設定するアーキテクチャが必要だが、  
従来のスクリプトは生の IP アドレス（例: `35.78.86.20`）をそのまま `DomainName` に設定しようとしていた。

## 原因

`update-cloudfront-origin.sh` の旧実装:
```bash
UPDATED_CONFIG=$(echo "${CONFIG}" | jq \
  --arg IP "${PUBLIC_IP}" \
  '.Origins.Items[0].DomainName = $IP')  # 生 IP → CloudFront が拒否
```

## 修正

**sslip.io** を使って IP を DNS 名に変換する。  
`x.y.z.w.sslip.io` は `x.y.z.w` に解決されるオープンソースの DNS サービス。

```bash
ORIGIN_DOMAIN="${PUBLIC_IP}.sslip.io"
# 例: 35.78.86.20 → 35.78.86.20.sslip.io（同じ IP に解決）
```

これによりインフラ変更・追加コストなしで CloudFront の制約を回避できる。

## 追加対処

過去の操作で `Origin.Id` が IP アドレスになっている可能性がある場合にも対応:
- `Id` を正規名（`{name_prefix}-web-origin`）に修正
- `DefaultCacheBehavior` と `CacheBehaviors` の `TargetOriginId` を追従更新

## マージ後の手順

PR をマージして `workflow_dispatch` で再デプロイ（`terraform apply` 不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)