### PR TITLE
fix: ECS desired_count=0 対応と CloudFront IP 制約の一括修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -276,10 +276,14 @@ jobs:
             --query 'taskDefinition.taskDefinitionArn' \
             --output text)
 
+          # --desired-count 1: コスト節約のため desired_count=0 に停止していた場合でも
+          # デプロイ時は必ず 1 タスク起動する。lifecycle.ignore_changes で
+          # terraform が desired_count を管理しないため、ここで明示的に指定する。
           aws ecs update-service \
             --cluster "${CLUSTER}" \
             --service "${SERVICE}" \
             --task-definition "${NEW_TASK_DEF_ARN}" \
+            --desired-count 1 \
             --force-new-deployment
 
       - name: Update api task definition for DB migration

--- a/scripts/update-cloudfront-origin.sh
+++ b/scripts/update-cloudfront-origin.sh
@@ -33,19 +33,33 @@ set -euo pipefail
 
 echo "ECS サービス '${SERVICE}' の実行中タスクを取得中..."
 
-TASK_ARN=$(aws ecs list-tasks \
-  --cluster "${CLUSTER}" \
-  --service-name "${SERVICE}" \
-  --desired-status RUNNING \
-  --query 'taskArns[0]' \
-  --output text)
+# デプロイ直後はタスクが起動中の場合があるためリトライする
+TASK_ARN=""
+MAX_ATTEMPTS=20
+for i in $(seq 1 ${MAX_ATTEMPTS}); do
+  TASK_ARN=$(aws ecs list-tasks \
+    --cluster "${CLUSTER}" \
+    --service-name "${SERVICE}" \
+    --desired-status RUNNING \
+    --query 'taskArns[0]' \
+    --output text 2>/dev/null || echo "")
+
+  if [ -n "${TASK_ARN}" ] && [ "${TASK_ARN}" != "None" ]; then
+    echo "タスク ARN: ${TASK_ARN}"
+    break
+  fi
+
+  if [ "${i}" -lt "${MAX_ATTEMPTS}" ]; then
+    echo "実行中タスクなし。15秒後にリトライ... (${i}/${MAX_ATTEMPTS})"
+    sleep 15
+  fi
+done
 
 if [ -z "${TASK_ARN}" ] || [ "${TASK_ARN}" = "None" ]; then
-  echo "エラー: 実行中のタスクが見つかりません" >&2
+  echo "エラー: ${MAX_ATTEMPTS}回リトライしましたが実行中のタスクが見つかりません" >&2
+  echo "ECS サービスの desired_count と最近のイベントを確認してください" >&2
   exit 1
 fi
-
-echo "タスク ARN: ${TASK_ARN}"
 
 # タスクの ENI ID を取得
 ENI_ID=$(aws ecs describe-tasks \


### PR DESCRIPTION
## 修正した問題

### 問題 1: 実行中のタスクが見つからない
`lifecycle { ignore_changes = [desired_count] }` により、コスト節約で停止した（desired_count=0）状態のまま `--force-new-deployment` しても ECS タスクが起動しない。`wait services-stable` は `0/0 = stable` で即完了するため後続の CloudFront 更新でタスクが見つからなかった。

**修正**: `update-service` に `--desired-count 1` を追加してデプロイ時は必ず 1 タスクを起動させる。

### 問題 2: CloudFront が IP アドレスを拒否（前回 PR #60 の内容を統合）
CloudFront カスタムオリジンは `DomainName` に IP を直接指定できない。

**修正**: `sslip.io` で IP を DNS 名に変換（`35.78.86.20` → `35.78.86.20.sslip.io`）。

### 追加改善: リトライロジック
デプロイ直後に新タスクが起動中でも最大 20 回 × 15 秒待機して取得できるようにする。

## マージ後の手順

PR マージ → `workflow_dispatch` で `force_deploy=true` で再デプロイ（`terraform apply` 不要）

🤖 Generated with [Claude Code](https://claude.com/claude-code)