### PR TITLE
fix: sg-web にポート 3000 のインバウンドルールを追加

### DIFF
--- a/infra/modules/sg/main.tf
+++ b/infra/modules/sg/main.tf
@@ -14,7 +14,7 @@
 
 resource "aws_security_group" "web" {
   name        = "${var.name_prefix}-sg-web"
-  description = "CloudFront and Internet to ECS Web (80, 443)"
+  description = "CloudFront and Internet to ECS Web (80, 443, 3000)"
   vpc_id      = var.vpc_id
 
   ingress {
@@ -29,6 +29,16 @@ resource "aws_security_group" "web" {
     description = "HTTPS from anywhere"
     from_port   = 443
     to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    # CloudFront のカスタムオリジンは http_port = 3000 でこのポートに接続する。
+    # CloudFront はグローバルに分散したエッジから接続するため 0.0.0.0/0 が必要。
+    description = "Next.js from CloudFront (http_port = 3000)"
+    from_port   = 3000
+    to_port     = 3000
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
## 原因

CloudFront のカスタムオリジンは `http_port = 3000` で ECS タスク（Next.js）に
接続するが、`sg-web` が 80/443 しか許可していなかったため 504 Gateway Timeout
が発生していた。

```
CloudFront → ECS public IP:3000 → sg-web がブロック → タイムアウト → 504
```

## 修正内容

`sg-web` にポート 3000 のインバウンドルールを追加。

CloudFront はグローバルなエッジロケーション（任意 IP）から接続するため
`0.0.0.0/0` の許可が必要。

## 適用手順

マージ後に `terraform apply -target=module.sg` を実行してセキュリティグループを更新すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)