### PR TITLE
fix: sg-web の description 変更を取り消し（terraform destroy 回避）

### DIFF
--- a/infra/modules/sg/main.tf
+++ b/infra/modules/sg/main.tf
@@ -14,7 +14,7 @@
 
 resource "aws_security_group" "web" {
   name        = "${var.name_prefix}-sg-web"
-  description = "CloudFront and Internet to ECS Web (80, 443, 3000)"
+  description = "CloudFront and Internet to ECS Web (80, 443)"
   vpc_id      = var.vpc_id
 
   ingress {


### PR DESCRIPTION
## 問題

PR #62 で sg-web に description 変更を含めてしまった。
AWS Security Group の `description` は immutable なため、変更すると
`-/+` (destroy → create) となり、実行中タスクの ENI 参照が切れる恐れがある。

## 修正内容

description を元の値 `"CloudFront and Internet to ECS Web (80, 443)"` に戻す。
ingress ルール（ポート 3000）の追加は維持するため、実質的な動作変更はなし。

## 適用後の terraform plan

`~ update in-place` のみになり destroy が発生しなくなる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)