### PR TITLE
fix: api Dockerfile の runner ステージに packages/common/package.json を追加

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -65,6 +65,8 @@ COPY --from=builder /repo/packages/common/node_modules ./packages/common/node_mo
 COPY --from=builder /repo/apps/api/build ./apps/api/build
 COPY --from=builder /repo/apps/api/prisma ./apps/api/prisma
 COPY --from=builder /repo/apps/api/scripts ./apps/api/scripts
+# package.json が必要: Node.js が "main": "dist/index.js" を参照してモジュールを解決するため
+COPY --from=builder /repo/packages/common/package.json ./packages/common/package.json
 COPY --from=builder /repo/packages/common/dist ./packages/common/dist
 
 USER honoapi


### PR DESCRIPTION
## 原因

api コンテナが起動直後に `Cannot find module '@budget/common'` (exit code 1) で STOPPED になっていた。

pnpm workspace では `@budget/common` が以下のシンボリックリンクで解決される:
```
node_modules/@budget/common → ../../packages/common
```

runner ステージでは `packages/common/dist/` はコピーされていたが、
Node.js がエントリポイントを特定するために必要な `packages/common/package.json`
（`"main": "dist/index.js"` を定義）がコピーされていなかった。

## 修正内容

```dockerfile
COPY --from=builder /repo/packages/common/package.json ./packages/common/package.json
```
を追加。

## 影響

api コンテナが正常起動するようになる。
これが 504 の実質的な根本原因（api が即時 STOPPED → ECS タスクが不安定 → CloudFront が到達できない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)