### PR TITLE
fix: web ECS サービスに sg-api を追加してサイドカー api の RDS 接続を許可

### DIFF
--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -245,8 +245,12 @@ resource "aws_ecs_service" "web" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets          = var.subnet_ids
-    security_groups  = [var.web_sg_id]
+    subnets = var.subnet_ids
+    security_groups = [
+      var.web_sg_id, # CloudFront → Next.js (port 3000) の受け入れ
+      var.api_sg_id, # サイドカー api → RDS (port 3306) のアクセス許可
+      # sg-rds は sg-api からの接続のみ許可するため、web サービスにも sg-api が必要
+    ]
     # NAT GW なしで ECR / SSM へアクセスするためパブリック IP を付与
     assign_public_ip = true
   }


### PR DESCRIPTION
## 原因

サイドカー構成（web + api が同一 ECS タスク）では api コンテナは
web サービスのネットワーク設定（sg-web）で動作する。

しかし sg-rds は **sg-api からの MySQL (3306) のみ**を許可しているため、
sg-web しか持たないサイドカー api が RDS に接続できず起動に失敗していた。

```
Can't reach database server at budget-dev-db...rds.amazonaws.com:3306
```

## 修正内容

web ECS サービスの `security_groups` に `var.api_sg_id` を追加。

| SG | 役割 |
|-----|------|
| sg-web | CloudFront → Next.js (port 3000) の受け入れ |
| sg-api | サイドカー api → RDS (port 3306) のアクセス許可 |

## 適用手順

マージ後に `terraform apply -target=module.ecs` を実行。
ECS サービスがインプレース更新され、次回タスク起動から新しい SG が有効になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)