### PR TITLE
fix: /api/health エンドポイントを追加（ECS ヘルスチェック対応）

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -65,6 +65,9 @@ export function createApp(deps: AppDeps) {
         bearerFormat: 'JWT',
     });
 
+    // ECS ヘルスチェック用エンドポイント（認証不要）
+    app.get('/api/health', (c) => c.json({ status: 'ok' }));
+
     app.route('/api', createAuthRoutes(deps, tokenService));
     app.route('/api', createExpenseRoutes(deps, tokenService));
     app.route('/api', createBudgetRoutes(deps, tokenService));


### PR DESCRIPTION
## Summary
- ECS タスク定義のヘルスチェック `wget -qO- http://localhost:3001/api/health` が 404 を返し、コンテナが exit 137 (SIGKILL) で終了し続けていた
- Hono アプリに `/api/health` エンドポイントが存在しなかったことが原因
- `app.get('/api/health', ...)` を追加し、認証不要で `{ status: 'ok' }` を返すようにした

## Test plan
- [ ] ECS タスクがヘルスチェックを通過して RUNNING 状態で安定すること
- [ ] CloudFront URL が HTTP 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)