### PR TITLE
fix: CF_ORIGIN_SECRET ミドルウェアで /api/health をバイパスして ECS ヘルスチェックを通過させる

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -50,6 +50,11 @@ export function createApp(deps: AppDeps) {
     const cfOriginSecret = process.env.CF_ORIGIN_SECRET;
     if (cfOriginSecret) {
         app.use('*', async (c, next) => {
+            // ECS ヘルスチェック（wget からの内部アクセス）は X-CF-Origin-Secret を持たないためスキップ
+            if (c.req.path === '/api/health') {
+                await next();
+                return;
+            }
             const receivedSecret = c.req.header('X-CF-Origin-Secret');
             if (receivedSecret !== cfOriginSecret) {
                 return c.json({ result: 'error', message: 'Forbidden' }, 403);


### PR DESCRIPTION
## 根本原因

CF_ORIGIN_SECRET ミドルウェアが `app.use('*', ...)` で全リクエストに適用されているが、
ECS タスク内の wget によるヘルスチェックは `X-CF-Origin-Secret` ヘッダーを持たないため 403 を返していた。

busybox wget は HTTP 4xx/5xx で exit 1 を返すため、health check コマンド (`wget -qO- http://localhost:3001/api/health || exit 1`) が失敗し、api コンテナが exit 137 (SIGKILL) で終了し続けていた。

PR #66 で `/api/health` エンドポイントを追加したが、CF ミドルウェアが手前で 403 を返しているため到達できていなかった。

## 修正内容

CF ミドルウェア内で `/api/health` パスのみ検証をスキップする条件を追加した。

```typescript
if (c.req.path === '/api/health') {
    await next();
    return;
}
```

## Test plan
- [ ] ECS タスクがヘルスチェックを通過して RUNNING 状態で安定すること
- [ ] CloudFront URL が HTTP 200 を返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)