### PR TITLE
fix: web コンテナの ECS ヘルスチェックを /health エンドポイントに変更

### DIFF
--- a/apps/web/src/app/health/route.ts
+++ b/apps/web/src/app/health/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+/** ECS ヘルスチェック用エンドポイント（認証不要・軽量） */
+export function GET() {
+  return NextResponse.json({ status: "ok" });
+}

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -96,7 +96,8 @@ resource "aws_ecs_task_definition" "web" {
       }
 
       healthCheck = {
-        command     = ["CMD-SHELL", "wget -qO- http://localhost:3000/ || exit 1"]
+        # / はServer ComponentでAPIを呼び出すため重い。/health は軽量なRoute Handlerを使用する
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3


### PR DESCRIPTION
## 根本原因

web コンテナのヘルスチェックが `wget http://localhost:3000/` を使っていたが、
root ページは Server Component で API を呼び出す（`getExpenses()`）ため重く、
5 秒のタイムアウトを超えてヘルスチェックが失敗していた。

## 修正内容

1. `apps/web/src/app/health/route.ts` — Next.js Route Handler を追加（`{ status: "ok" }` を即時返却）
2. `infra/modules/ecs/main.tf` — web コンテナの health check を `wget localhost:3000/health` に変更

## デプロイ手順

terraform の `lifecycle { ignore_changes = [task_definition] }` により、タスク定義の変更は terraform apply が必要。
デプロイ後に `terraform apply -target=module.ecs` で新しいタスク定義を反映する。

## Test plan
- [ ] ECS web コンテナが HEALTHY になること
- [ ] ECS api コンテナが HEALTHY のまま維持されること
- [ ] CloudFront URL が HTTP 200 を安定して返すこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)