### PR TITLE
refactor: API 通信をサーバーサイド集約・ポートを 5000 に統一

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -43,26 +43,6 @@ export function createApp(deps: AppDeps) {
     // X-Content-Type-Options, X-Frame-Options, Referrer-Policy 等を付与
     app.use('*', secureHeaders());
 
-    // ─── Layer 2: Origin Shield 検証 ─────────────────────────────────────────────
-    // CloudFront がカスタムヘッダー X-CF-Origin-Secret を付与して転送する。
-    // ヘッダーが存在しない（= ECS タスク IP への直接アクセス）場合は 403 で遮断する。
-    // 本番環境のみ適用（ローカル開発・テストは環境変数未設定のため無効）
-    const cfOriginSecret = process.env.CF_ORIGIN_SECRET;
-    if (cfOriginSecret) {
-        app.use('*', async (c, next) => {
-            // ECS ヘルスチェック（wget からの内部アクセス）は X-CF-Origin-Secret を持たないためスキップ
-            if (c.req.path === '/api/health') {
-                await next();
-                return;
-            }
-            const receivedSecret = c.req.header('X-CF-Origin-Secret');
-            if (receivedSecret !== cfOriginSecret) {
-                return c.json({ result: 'error', message: 'Forbidden' }, 403);
-            }
-            await next();
-        });
-    }
-
     // JWT Bearer 認証スキームをレジストリに登録（createRoute の security: [{ bearerAuth: [] }] と対応）
     app.openAPIRegistry.registerComponent('securitySchemes', 'bearerAuth', {
         type: 'http',

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -10,7 +10,7 @@ import { prisma } from './infrastructure/persistence/prisma-client';
 import { buildDeps } from './container';
 import { createApp } from './app';
 
-const port = Number(process.env.PORT ?? 3001);
+const port = Number(process.env.PORT ?? 5000);
 
 async function main(): Promise<void> {
     // Prisma 接続確認（DB に疎通できなければ早期終了）

--- a/apps/api/src/openapi/spec.ts
+++ b/apps/api/src/openapi/spec.ts
@@ -27,6 +27,6 @@ export function generateOpenAPIDocument(): any {
             title: '家計簿管理ツール API',
             description: '支出（Expense）の登録・管理を行う REST API。JWT Bearer 認証が必要。',
         },
-        servers: [{ url: 'http://localhost:3001', description: 'ローカル開発' }],
+        servers: [{ url: 'http://localhost:5000', description: 'ローカル開発' }],
     });
 }

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,5 @@
 import type { NextConfig } from "next";
 
-const API_URL = process.env.API_URL ?? "http://localhost:3001";
-
 const nextConfig: NextConfig = {
   // コンテナデプロイ用: standalone モードで最小ランタイムを出力
   output: "standalone",
@@ -29,16 +27,6 @@ const nextConfig: NextConfig = {
             value: "camera=(), microphone=(), geolocation=()",
           },
         ],
-      },
-    ];
-  },
-
-  /** /api/* を Hono バックエンドへプロキシする（開発: localhost:3001、本番: ECS API タスク） */
-  async rewrites() {
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${API_URL}/api/:path*`,
       },
     ];
   },

--- a/apps/web/src/app/api/export/expenses/route.ts
+++ b/apps/web/src/app/api/export/expenses/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { cookies } from "next/headers";
+
+const INTERNAL_API_URL = process.env.INTERNAL_API_URL ?? "http://localhost:5000";
+
+/**
+ * 支出データエクスポート（認証必須）。
+ * ブラウザからのファイルダウンロードリクエストを受け取り、
+ * JWT を付与して内部 API へ転送する Route Handler。
+ */
+export async function GET(request: NextRequest) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get("access_token")?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: "Unauthorized" }, { status: 401 });
+  }
+
+  const format = request.nextUrl.searchParams.get("format") ?? "json";
+
+  const res = await fetch(
+    `${INTERNAL_API_URL}/api/export/expenses?format=${encodeURIComponent(format)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: format === "csv" ? "text/csv" : "application/json",
+      },
+    },
+  );
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({ message: "エクスポートに失敗しました" }));
+    return NextResponse.json(body, { status: res.status });
+  }
+
+  // レスポンスヘッダー（Content-Disposition 等）をそのまま転送
+  const headers = new Headers();
+  const contentType = res.headers.get("Content-Type");
+  const contentDisposition = res.headers.get("Content-Disposition");
+  if (contentType) headers.set("Content-Type", contentType);
+  if (contentDisposition) headers.set("Content-Disposition", contentDisposition);
+
+  return new NextResponse(res.body, { status: res.status, headers });
+}

--- a/apps/web/src/app/api/register/check-username/route.ts
+++ b/apps/web/src/app/api/register/check-username/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+const INTERNAL_API_URL = process.env.INTERNAL_API_URL ?? "http://localhost:5000";
+
+/**
+ * ユーザー名の使用可否確認（認証不要）。
+ * ブラウザからの直接 fetch を受け取り、内部 API へ転送する Route Handler。
+ * UserNameInput コンポーネントのリアルタイム重複チェックで使用。
+ */
+export async function GET(request: NextRequest) {
+  const userId = request.nextUrl.searchParams.get("userId");
+  if (!userId) {
+    return NextResponse.json({ available: false }, { status: 400 });
+  }
+
+  const res = await fetch(
+    `${INTERNAL_API_URL}/api/register/check-username?userId=${encodeURIComponent(userId)}`,
+  );
+
+  const data = await res.json();
+  return NextResponse.json(data, { status: res.status });
+}

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -1,6 +1,6 @@
 import { cookies } from "next/headers";
 
-const API_BASE = process.env.API_URL ?? "http://localhost:3001";
+const API_BASE = process.env.INTERNAL_API_URL ?? "http://localhost:5000";
 
 export class ApiError extends Error {
   constructor(

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -35,7 +35,7 @@ export async function middleware(request: NextRequest) {
   // リフレッシュトークンがあれば /api/refresh を試みる
   if (refreshToken) {
     try {
-      const apiBase = process.env.API_URL ?? "http://localhost:3001";
+      const apiBase = process.env.INTERNAL_API_URL ?? "http://localhost:5000";
       const refreshRes = await fetch(`${apiBase}/api/refresh`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/infra/modules/cloudfront/main.tf
+++ b/infra/modules/cloudfront/main.tf
@@ -4,12 +4,14 @@
 # 構成:
 #   - CloudFront ディストリビューション（HTTPS 終端）
 #   - オリジン: ECS web タスクの Public IP（scripts/update-cloudfront-origin.sh で自動更新）
-#   - Origin Shield: カスタムヘッダー X-CF-Origin-Secret を付与し、
-#     Hono 側で検証することで CloudFront 経由以外の直接アクセスを遮断する
+#   - Origin Shield: カスタムヘッダー X-CF-Origin-Secret を付与（将来の Next.js middleware 検証用に維持）
 #   - キャッシュポリシー:
 #     - /_next/static/*: 長期キャッシュ（イミュータブルアセット）
-#     - /api/*: キャッシュ無効化（バックエンド API は常に通過）
 #     - /*: デフォルト（TTL 0、SSR レスポンス対応）
+#
+# /api/* behavior を廃止した理由:
+#   全 API 通信を Next.js サーバーサイドに集約（localhost:5000 への直接呼び出し）。
+#   ブラウザから /api/* を直接叩かなくなったため専用 behavior は不要。
 #
 # ALB を使わない理由:
 #   ALB は月 $16〜 かかるため、CloudFront → ECS Public IP の直接接続で代替。
@@ -45,7 +47,7 @@ resource "aws_cloudfront_distribution" "main" {
       origin_ssl_protocols   = ["TLSv1.2"]
     }
 
-    # Origin Shield: このヘッダーがない直接アクセスを Hono ミドルウェアで拒絶する
+    # Origin Shield: Next.js middleware での直接アクセス検証用（将来利用）
     custom_header {
       name  = "X-CF-Origin-Secret"
       value = data.aws_ssm_parameter.cf_origin_secret.value
@@ -95,29 +97,6 @@ resource "aws_cloudfront_distribution" "main" {
     min_ttl     = 0
     default_ttl = 86400    # 1日
     max_ttl     = 31536000 # 1年
-  }
-
-  # ─── /api/*: キャッシュ無効（Hono API は常にオリジンへ通過） ──────────────────
-  ordered_cache_behavior {
-    path_pattern           = "/api/*"
-    target_origin_id       = local.origin_id
-    viewer_protocol_policy = "redirect-to-https"
-    allowed_methods        = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods         = ["GET", "HEAD"]
-    compress               = true
-
-    forwarded_values {
-      query_string = true
-      cookies {
-        forward = "all"
-      }
-      headers = ["Authorization", "Content-Type", "Accept"]
-    }
-
-    # API は常にオリジンへ通過
-    min_ttl     = 0
-    default_ttl = 0
-    max_ttl     = 0
   }
 
   # ─── HTTPS 設定 ───────────────────────────────────────────────────────────────

--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -44,7 +44,7 @@ resource "aws_cloudwatch_log_group" "api" {
 #
 # web と api を同一 Fargate タスクに同居させ、localhost で通信する。
 # - web (Next.js)  : port 3000 — CloudFront がオリジンとして参照
-# - api (Hono)     : port 3001 — web から http://localhost:3001 で呼び出す
+# - api (Hono)     : port 5000 — web から http://localhost:5000 で呼び出す（タスク内部通信）
 #
 # deploy.yml の deploy-ecs ジョブが CI/CD でイメージを差し替えるため、
 # lifecycle.ignore_changes = [task_definition] で Terraform 側の上書きを防ぐ。
@@ -75,14 +75,10 @@ resource "aws_ecs_task_definition" "web" {
         {
           name  = "NODE_ENV"
           value = "production"
-        }
-      ]
-
-      # NEXT_PUBLIC_API_URL は同一タスク内 localhost を指す
-      secrets = [
+        },
         {
-          name      = "NEXT_PUBLIC_API_URL"
-          valueFrom = "${var.ssm_prefix}/api_url"
+          name  = "INTERNAL_API_URL"
+          value = "http://localhost:5000"
         }
       ]
 
@@ -96,11 +92,9 @@ resource "aws_ecs_task_definition" "web" {
       }
 
       healthCheck = {
-        # node コマンドで直接 HTTP 接続を確認する（wget の HTTP ステータス判定が不安定なため）
-        # / への任意のレスポンス（2xx/3xx/4xx）で OK とし、接続失敗や 5xx のみ NG とする
-        command     = ["CMD-SHELL", "node -e \"require('http').get('http://localhost:3000/',r=>{r.resume();r.on('end',()=>process.exit(r.statusCode<500?0:1))}).on('error',()=>process.exit(1))\""]
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
         interval    = 30
-        timeout     = 10
+        timeout     = 5
         retries     = 3
         startPeriod = 60
       }
@@ -114,7 +108,7 @@ resource "aws_ecs_task_definition" "web" {
 
       portMappings = [
         {
-          containerPort = 3001
+          containerPort = 5000
           protocol      = "tcp"
         }
       ]
@@ -126,7 +120,7 @@ resource "aws_ecs_task_definition" "web" {
         },
         {
           name  = "PORT"
-          value = "3001"
+          value = "5000"
         }
       ]
 
@@ -138,10 +132,6 @@ resource "aws_ecs_task_definition" "web" {
         {
           name      = "JWT_SECRET"
           valueFrom = "${var.ssm_prefix}/jwt_secret"
-        },
-        {
-          name      = "CF_ORIGIN_SECRET"
-          valueFrom = "${var.ssm_prefix}/cf_origin_secret"
         }
       ]
 
@@ -155,7 +145,7 @@ resource "aws_ecs_task_definition" "web" {
       }
 
       healthCheck = {
-        command     = ["CMD-SHELL", "wget -qO- http://localhost:3001/api/health || exit 1"]
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:5000/api/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3
@@ -183,7 +173,7 @@ resource "aws_ecs_task_definition" "api" {
 
       portMappings = [
         {
-          containerPort = 3001
+          containerPort = 5000
           protocol      = "tcp"
         }
       ]
@@ -195,7 +185,7 @@ resource "aws_ecs_task_definition" "api" {
         },
         {
           name  = "PORT"
-          value = "3001"
+          value = "5000"
         }
       ]
 
@@ -208,12 +198,6 @@ resource "aws_ecs_task_definition" "api" {
         {
           name      = "JWT_SECRET"
           valueFrom = "${var.ssm_prefix}/jwt_secret"
-        },
-        # Layer 2: Origin Shield 検証用シークレット
-        # CloudFront が X-CF-Origin-Secret ヘッダーで送出する値と一致した場合のみリクエストを通過させる
-        {
-          name      = "CF_ORIGIN_SECRET"
-          valueFrom = "${var.ssm_prefix}/cf_origin_secret"
         }
       ]
 
@@ -227,7 +211,7 @@ resource "aws_ecs_task_definition" "api" {
       }
 
       healthCheck = {
-        command     = ["CMD-SHELL", "wget -qO- http://localhost:3001/api/health || exit 1"]
+        command     = ["CMD-SHELL", "wget -qO- http://localhost:5000/api/health || exit 1"]
         interval    = 30
         timeout     = 5
         retries     = 3

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -7,7 +7,7 @@
  * ```ts
  * import { createApiClient } from '@budget/api-client';
  *
- * const client = createApiClient('http://localhost:3001');
+ * const client = createApiClient('http://localhost:5000');
  * const { data } = await client.GET('/api/expense');
  * // data は { expense: ExpenseResponse[] } として型付けされる
  * ```
@@ -28,7 +28,7 @@ export const API_PATHS = {
 /**
  * openapi-fetch ベースの型安全 API クライアントを生成する。
  *
- * @param baseUrl - API のベース URL（例: 'http://localhost:3001'）
+ * @param baseUrl - API のベース URL（例: 'http://localhost:5000'）
  * @param init - fetch のデフォルトオプション（Cookie などを追加する場合）
  */
 export function createApiClient(baseUrl: string, init?: RequestInit) {

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -4,7 +4,7 @@ info:
   title: 家計簿管理ツール API
   description: 支出（Expense）の登録・管理を行う REST API。JWT Bearer 認証が必要。
 servers:
-  - url: http://localhost:3001
+  - url: http://localhost:5000
     description: ローカル開発
 components:
   securitySchemes:


### PR DESCRIPTION
## Summary

- **CF_ORIGIN_SECRET ミドルウェア削除**: web コンテナからの localhost 呼び出しをすべて 403 でブロックしていた根本原因を除去
- **API ポートを 3001 → 5000 に統一**: `index.ts` / `spec.ts` / ECS タスク定義 / OpenAPI スペック
- **Next.js rewrites プロキシ削除 + Route Handler 追加**: ブラウザから API を直接叩かない構成に変更
  - `/api/register/check-username` — ユーザー名重複チェック（認証不要）
  - `/api/export/expenses` — ファイルダウンロード（JWT 付与）
- **環境変数を `NEXT_PUBLIC_API_URL` → `INTERNAL_API_URL` に変更**: ビルド時焼き込みを廃止し、ECS ランタイム注入に統一
- **CloudFront の `/api/*` behavior 削除**: ブラウザから API を直接参照しなくなったため不要
- **ECS web コンテナのヘルスチェック修正**: `node -e "..."` → `wget -qO- http://localhost:3000/health`（Alpine 環境での不安定な動作を解消）
- **ECS タスク定義から `CF_ORIGIN_SECRET` / `NEXT_PUBLIC_API_URL` の SSM secret 参照を削除**

## Background

本番環境で CloudFront が 504 を返し続けていた根本原因は 2 つ:

1. `CF_ORIGIN_SECRET` ミドルウェアが Next.js サーバーサイドからの `localhost:3001` 呼び出しを 403 でブロック（ヘッダーなしのため）
2. `NEXT_PUBLIC_API_URL` は `next build` 時に焼き込まれるため、ECS 実行時に SSM から注入しても無効

## Test plan

- [ ] ローカルで `pnpm dev` → ログイン・支出登録・エクスポートが正常動作することを確認
- [ ] ECS デプロイ後、`update-cloudfront-origin.sh` で CF オリジンを更新し、CloudFront URL で 200 が返ることを確認
- [ ] ECS タスクの両コンテナ（web/api）が HEALTHY になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)