### PR TITLE
fix: セキュリティスキャンエラーを適切な方法で対処

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -151,6 +151,8 @@ jobs:
           exit-code: "1"
           ignore-unfixed: true
           trivyignores: .trivyignore
+          # CI ランナーのシステム npm 内部依存はプロジェクト管理外のため除外
+          skip-dirs: usr/local/lib/node_modules/npm
 
       - name: Upload scan results to GitHub Security
         if: always()

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,40 +5,9 @@
 #   このファイルに記載する CVE は「修正不可 or 実際には悪用不可」であることを
 #   確認した上で、根拠コメントと合わせて管理する。
 #   定期的に見直し、修正版が利用可能になり次第 override に移行すること。
+#
+# ノート:
+#   CI ランナーのシステム npm 内部依存（usr/local/lib/node_modules/npm）は
+#   pr-checks.yml の Trivy skip-dirs で除外済み。
+#   プロジェクト依存の脆弱性は pnpm.overrides（package.json）で対処すること。
 # ============================================================
-
-# ─── tar (node-tar) — Node.js 同梱の npm 内部依存 ────────────────────────────
-#
-# 影響パッケージ : tar@6.2.1（npm に同梱。プロジェクトの直接/推移的依存ではない）
-# 修正バージョン : 7.5.x（メジャーバージョンアップ。npm 側の対応待ち）
-# 悪用条件       : 攻撃者が制御する tar アーカイブを本アプリが展開する必要がある
-# 判断           : 家計管理ツールは tar アーカイブを扱わないため実質的な攻撃面なし
-#
-CVE-2026-31802
-CVE-2026-29786
-CVE-2026-26960
-CVE-2026-24842
-CVE-2026-23950
-CVE-2026-23745
-
-# ─── minimatch / glob / diff / cross-spawn / brace-expansion — npm 内部依存 ──
-#
-# 影響パッケージ : 以下はすべて usr/local/lib/node_modules/npm/node_modules/ 配下
-#                 （Node.js に同梱された npm CLI の内部依存。プロジェクトの直接/推移的依存ではない）
-# 修正方法       : npm 本体のバージョンアップが必要。プロジェクト側では対応不可
-# 悪用条件       : 攻撃者が制御する glob パターン・diff・ファイル名を npm CLI が処理する必要がある
-# 判断           : 本アプリは npm CLI を実行時に使用しない（ビルド時のみ）。実質的な攻撃面なし
-#
-# minimatch — ReDoS (CVE-2026-27904, CVE-2026-27903, CVE-2026-26996)
-CVE-2026-27904
-CVE-2026-27903
-CVE-2026-26996
-# glob — Command Injection via malicious filenames (CVE-2025-64756)
-CVE-2025-64756
-# diff (jsdiff) — DoS in parsePatch/applyPatch (CVE-2026-24001)
-CVE-2026-24001
-# cross-spawn — ReDoS (CVE-2024-21538)
-CVE-2024-21538
-# brace-expansion — ReDoS / zero-step DoS (CVE-2025-5889, CVE-2026-33750)
-CVE-2025-5889
-CVE-2026-33750

--- a/.trivyignore
+++ b/.trivyignore
@@ -20,3 +20,25 @@ CVE-2026-26960
 CVE-2026-24842
 CVE-2026-23950
 CVE-2026-23745
+
+# ─── minimatch / glob / diff / cross-spawn / brace-expansion — npm 内部依存 ──
+#
+# 影響パッケージ : 以下はすべて usr/local/lib/node_modules/npm/node_modules/ 配下
+#                 （Node.js に同梱された npm CLI の内部依存。プロジェクトの直接/推移的依存ではない）
+# 修正方法       : npm 本体のバージョンアップが必要。プロジェクト側では対応不可
+# 悪用条件       : 攻撃者が制御する glob パターン・diff・ファイル名を npm CLI が処理する必要がある
+# 判断           : 本アプリは npm CLI を実行時に使用しない（ビルド時のみ）。実質的な攻撃面なし
+#
+# minimatch — ReDoS (CVE-2026-27904, CVE-2026-27903, CVE-2026-26996)
+CVE-2026-27904
+CVE-2026-27903
+CVE-2026-26996
+# glob — Command Injection via malicious filenames (CVE-2025-64756)
+CVE-2025-64756
+# diff (jsdiff) — DoS in parsePatch/applyPatch (CVE-2026-24001)
+CVE-2026-24001
+# cross-spawn — ReDoS (CVE-2024-21538)
+CVE-2024-21538
+# brace-expansion — ReDoS / zero-step DoS (CVE-2025-5889, CVE-2026-33750)
+CVE-2025-5889
+CVE-2026-33750

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   "pnpm": {
     "overrides": {
       "axios": "1.14.0",
-      "cross-spawn": ">=7.0.5"
+      "cross-spawn": ">=7.0.5",
+      "postcss": ">=8.5.10"
     },
     "onlyBuiltDependencies": [
       "lefthook",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   axios: 1.14.0
   cross-spawn: '>=7.0.5'
+  postcss: '>=8.5.10'
 
 importers:
 
@@ -4750,12 +4751,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
-
-  postcss@8.5.8:
-    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -7932,7 +7929,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
-      postcss: 8.5.8
+      postcss: 8.5.14
       tailwindcss: 4.2.2
 
   '@techteamer/ocsp@1.0.1':
@@ -9207,7 +9204,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -9240,7 +9237,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -9254,7 +9251,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10603,7 +10600,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.12
       caniuse-lite: 1.0.30001782
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(react@19.2.4)
@@ -10972,13 +10969,7 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.8:
+  postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -11914,7 +11905,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -11932,7 +11923,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.8
+      postcss: 8.5.14
       rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
       tinyglobby: 0.2.15
     optionalDependencies:


### PR DESCRIPTION
## Summary

- `postcss` を `pnpm.overrides` で `>=8.5.10` に強制（XSS 脆弱性 GHSA-qx2v-qp2m-jg93）
- Trivy に `skip-dirs` を追加して CI ランナーのシステム npm を除外
- `.trivyignore` の不要な CVE 列挙を削除し、対処方針をコメントに整理

## 変更の考え方

| 問題 | 誤った対処（旧） | 正しい対処（新） |
|------|----------------|----------------|
| プロジェクト依存の脆弱性 (postcss) | .trivyignore で抑制 | `pnpm.overrides` でバージョン強制 |
| システム npm 内部の脆弱性 | .trivyignore に CVE を列挙 | `skip-dirs` でパスを除外 |

`.trivyignore` はあくまで「修正不可能かつ悪用不可能であることを確認した CVE の最終手段」として位置付け、安易な抑制を避ける。

## Test plan

- [x] `pnpm audit --prod` が 0 件になることをローカルで確認
- [ ] PR checks の Security Scan (FS) がパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)