### PR TITLE
fix: ECS web コンテナのヘルスチェックを hostname -i に変更

### DIFF
--- a/infra/modules/ecs/main.tf
+++ b/infra/modules/ecs/main.tf
@@ -101,8 +101,9 @@ resource "aws_ecs_task_definition" "web" {
 
       healthCheck = {
         # curl -sf: -s(silent) -f(fail on HTTP error)
-        # 127.0.0.1 を明示して IPv4 強制（localhost は Alpine で ::1 に解決される場合がある）
-        command     = ["CMD-SHELL", "curl -sf http://127.0.0.1:3000/health"]
+        # Next.js 16 standalone は HOSTNAME=0.0.0.0 でもコンテナ実 IP (eth0) にのみ bind するため、
+        # 127.0.0.1 では接続不可。hostname -i でコンテナの実 IP を取得して使用する。
+        command     = ["CMD-SHELL", "curl -sf http://$(hostname -i):3000/health"]
         interval    = 30
         timeout     = 10
         retries     = 3


### PR DESCRIPTION
## 問題

ECS の web コンテナが約4分ごとにヘルスチェック失敗でクラッシュループし、タスクが再起動するたびに Public IP が変わって CloudFront から 504 になっていた。

## 原因

Next.js 16 standalone サーバーは \`HOSTNAME=0.0.0.0\` を設定しても **コンテナの eth0 実 IP にのみ bind** する（loopback には bind しない）。

そのため \`curl -sf http://127.0.0.1:3000/health\` が connection refused となり、ヘルスチェックが常に UNHEALTHY になっていた。

```
外部からのアクセス（Public IP）→ 200 OK  ← サーバーは動いている
コンテナ内の 127.0.0.1:3000   → FAILED   ← loopback に bind していない
```

## 修正

```diff
- command = ["CMD-SHELL", "curl -sf http://127.0.0.1:3000/health"]
+ command = ["CMD-SHELL", "curl -sf http://$(hostname -i):3000/health"]
```

\`hostname -i\` でコンテナの実 IP を動的に取得することで、Next.js が実際に listen している IP に対してヘルスチェックを実行する。

## 確認済み事項

- AWS CLI で task def rev:35 を即時適用 → `web: HEALTHY` に変化
- `(service budget-dev-web) has reached a steady state.` を確認
- `https://d1n9sux6qvf4lx.cloudfront.net/health` → `{"status":"ok"}` 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)