### PR TITLE
refactor: UseCase のインスタンス生成を DI コンテナに集約する

### DIFF
--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -6,8 +6,25 @@ import type { IUserRepository } from './domain/repositories/IUserRepository';
 import type { IRefreshTokenRepository } from './domain/repositories/IRefreshTokenRepository';
 import type { ISecurityAnswerRepository } from './domain/repositories/ISecurityAnswerRepository';
 import type { IPasswordResetTokenRepository } from './domain/repositories/IPasswordResetTokenRepository';
-import { TokenService } from './application/auth/TokenService';
+import type { TokenService } from './application/auth/TokenService';
+import type { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
+import type { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
+import type { RegisterUserUseCase } from './application/use-cases/auth/RegisterUserUseCase';
+import type { GetSecurityQuestionsUseCase } from './application/use-cases/auth/GetSecurityQuestionsUseCase';
+import type { GetRecoveryQuestionUseCase } from './application/use-cases/auth/GetRecoveryQuestionUseCase';
+import type { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
+import type { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
+import type { CheckUserNameUseCase } from './application/use-cases/user/CheckUserNameUseCase';
+import type { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
+import type { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
+import type { CreateUserUseCase } from './application/use-cases/user/CreateUserUseCase';
+import type { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
+import type { DeleteUserUseCase } from './application/use-cases/user/DeleteUserUseCase';
+import type { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
+import type { GetExpenditureAnalysisUseCase } from './application/use-cases/xday/GetExpenditureAnalysisUseCase';
+import { TokenService as TokenServiceImpl } from './application/auth/TokenService';
 import { DomainException } from './shared/errors/DomainException';
+import { buildServices } from './container';
 import { createAuthRoutes } from './presentation/routes/auth';
 import { createBudgetRoutes } from './presentation/routes/budget';
 import { createExpenseRoutes } from './presentation/routes/expense';
@@ -25,6 +42,39 @@ export type AppDeps = {
     passwordResetTokenRepository: IPasswordResetTokenRepository;
 };
 
+/**
+ * ルートファクトリが受け取るサービス群の型。
+ * UseCase のインスタンス生成は container.ts::buildServices() に集約する。
+ * リポジトリ直接参照は UseCase 未抽出のルート（auth / budget）用の暫定的な措置。
+ */
+export type RouteServices = {
+    tokenService: TokenService;
+    // UseCase 未抽出のルートが直接リポジトリを参照する箇所（暫定）
+    userRepository: IUserRepository;
+    budgetRepository: IBudgetRepository;
+    expenseRepository: IExpenseRepository;
+    // Expense
+    createExpenseUseCase: CreateExpenseUseCase;
+    // Export
+    exportUseCase: ExportUserDataUseCase;
+    // Recovery / Registration
+    registerUseCase: RegisterUserUseCase;
+    checkUserNameUseCase: CheckUserNameUseCase;
+    getSecurityQuestionsUseCase: GetSecurityQuestionsUseCase;
+    getRecoveryQuestionUseCase: GetRecoveryQuestionUseCase;
+    verifyRecoveryAnswerUseCase: VerifyRecoveryAnswerUseCase;
+    resetPasswordUseCase: ResetPasswordUseCase;
+    // User management
+    getUsersUseCase: GetUsersUseCase;
+    getUserByIdUseCase: GetUserByIdUseCase;
+    createUserUseCase: CreateUserUseCase;
+    updateUserUseCase: UpdateUserUseCase;
+    deleteUserUseCase: DeleteUserUseCase;
+    // XDay
+    getXDayUseCase: GetXDayUseCase;
+    getAnalysisUseCase: GetExpenditureAnalysisUseCase;
+};
+
 /** Hono context の型変数定義（認証済みルートで userId を参照するために使用） */
 export type HonoEnv = {
     Variables: {
@@ -35,7 +85,10 @@ export type HonoEnv = {
 export function createApp(deps: AppDeps) {
     const privateKeyPem = process.env.JWT_PRIVATE_KEY?.replace(/\\n/g, '\n') ?? '';
     const publicKeyPem = process.env.JWT_PUBLIC_KEY?.replace(/\\n/g, '\n') ?? '';
-    const tokenService = new TokenService(privateKeyPem, publicKeyPem, deps.refreshTokenRepository);
+    const tokenService = new TokenServiceImpl(privateKeyPem, publicKeyPem, deps.refreshTokenRepository);
+
+    // UseCase のインスタンス生成を container に委譲し、ルート層での new を禁止する
+    const services = buildServices(deps, tokenService);
 
     const app = new OpenAPIHono<HonoEnv>();
 
@@ -53,13 +106,13 @@ export function createApp(deps: AppDeps) {
     // ECS ヘルスチェック用エンドポイント（認証不要）
     app.get('/api/health', (c) => c.json({ status: 'ok' }));
 
-    app.route('/api', createAuthRoutes(deps, tokenService));
-    app.route('/api', createExpenseRoutes(deps, tokenService));
-    app.route('/api', createBudgetRoutes(deps, tokenService));
-    app.route('/api', createUserRoutes(deps, tokenService));
-    app.route('/api', createRecoveryRoutes(deps));
-    app.route('/api', createExportRoutes(deps, tokenService));
-    app.route('/api', createXDayRoutes(deps, tokenService));
+    app.route('/api', createAuthRoutes(services));
+    app.route('/api', createExpenseRoutes(services));
+    app.route('/api', createBudgetRoutes(services));
+    app.route('/api', createUserRoutes(services));
+    app.route('/api', createRecoveryRoutes(services));
+    app.route('/api', createExportRoutes(services));
+    app.route('/api', createXDayRoutes(services));
 
     app.onError((err, c) => {
         if (err instanceof DomainException) {

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -5,7 +5,23 @@ import { PrismaRefreshTokenRepository } from './infrastructure/persistence/Prism
 import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
 import { PrismaSecurityAnswerRepository } from './infrastructure/persistence/PrismaSecurityAnswerRepository';
 import { PrismaPasswordResetTokenRepository } from './infrastructure/persistence/PrismaPasswordResetTokenRepository';
-import type { AppDeps } from './app';
+import type { AppDeps, RouteServices } from './app';
+import type { TokenService } from './application/auth/TokenService';
+import { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
+import { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
+import { RegisterUserUseCase } from './application/use-cases/auth/RegisterUserUseCase';
+import { GetSecurityQuestionsUseCase } from './application/use-cases/auth/GetSecurityQuestionsUseCase';
+import { GetRecoveryQuestionUseCase } from './application/use-cases/auth/GetRecoveryQuestionUseCase';
+import { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
+import { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
+import { CheckUserNameUseCase } from './application/use-cases/user/CheckUserNameUseCase';
+import { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
+import { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
+import { CreateUserUseCase } from './application/use-cases/user/CreateUserUseCase';
+import { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
+import { DeleteUserUseCase } from './application/use-cases/user/DeleteUserUseCase';
+import { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
+import { GetExpenditureAnalysisUseCase } from './application/use-cases/xday/GetExpenditureAnalysisUseCase';
 
 /**
  * 本番用依存関係コンテナ。
@@ -19,5 +35,42 @@ export function buildDeps(): AppDeps {
         refreshTokenRepository: new PrismaRefreshTokenRepository(prisma),
         securityAnswerRepository: new PrismaSecurityAnswerRepository(prisma),
         passwordResetTokenRepository: new PrismaPasswordResetTokenRepository(prisma),
+    };
+}
+
+/**
+ * ルート層に渡すサービス群を構築する。
+ * UseCase のインスタンス生成はすべてここに集約し、ルートファクトリ内での new を禁止する。
+ */
+export function buildServices(deps: AppDeps, tokenService: TokenService): RouteServices {
+    return {
+        tokenService,
+        // リポジトリ直接参照（UseCase未抽出のルート用）
+        userRepository: deps.userRepository,
+        budgetRepository: deps.budgetRepository,
+        expenseRepository: deps.expenseRepository,
+        // Expense
+        createExpenseUseCase: new CreateExpenseUseCase(deps.expenseRepository, deps.userRepository),
+        // Export
+        exportUseCase: new ExportUserDataUseCase(deps.expenseRepository),
+        // Recovery / Registration
+        registerUseCase: new RegisterUserUseCase(deps.userRepository, deps.securityAnswerRepository),
+        checkUserNameUseCase: new CheckUserNameUseCase(deps.userRepository),
+        getSecurityQuestionsUseCase: new GetSecurityQuestionsUseCase(deps.securityAnswerRepository),
+        getRecoveryQuestionUseCase: new GetRecoveryQuestionUseCase(deps.userRepository, deps.securityAnswerRepository),
+        verifyRecoveryAnswerUseCase: new VerifyRecoveryAnswerUseCase(
+            deps.securityAnswerRepository,
+            deps.passwordResetTokenRepository
+        ),
+        resetPasswordUseCase: new ResetPasswordUseCase(deps.userRepository, deps.passwordResetTokenRepository),
+        // User management
+        getUsersUseCase: new GetUsersUseCase(deps.userRepository),
+        getUserByIdUseCase: new GetUserByIdUseCase(deps.userRepository),
+        createUserUseCase: new CreateUserUseCase(deps.userRepository),
+        updateUserUseCase: new UpdateUserUseCase(deps.userRepository),
+        deleteUserUseCase: new DeleteUserUseCase(deps.userRepository),
+        // XDay
+        getXDayUseCase: new GetXDayUseCase(deps.expenseRepository),
+        getAnalysisUseCase: new GetExpenditureAnalysisUseCase(deps.expenseRepository),
     };
 }

--- a/apps/api/src/presentation/routes/auth.ts
+++ b/apps/api/src/presentation/routes/auth.ts
@@ -1,8 +1,7 @@
 import { createRoute } from '@hono/zod-openapi';
 import { createOpenAPIApp } from '../../lib/openapi-app';
 import { createAuthMiddleware } from '../middleware/auth';
-import type { TokenService } from '../../application/auth/TokenService';
-import type { AppDeps } from '../../app';
+import type { RouteServices } from '../../app';
 import {
     ErrorResponseSchema,
     LogoutRequestSchema,
@@ -120,8 +119,7 @@ const logoutRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createAuthRoutes(deps: AppDeps, tokenService: TokenService) {
-    const { userRepository } = deps;
+export function createAuthRoutes({ tokenService, userRepository }: RouteServices) {
     const app = createOpenAPIApp();
     const auth = createAuthMiddleware(tokenService);
 

--- a/apps/api/src/presentation/routes/budget.ts
+++ b/apps/api/src/presentation/routes/budget.ts
@@ -1,9 +1,8 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { createAuthMiddleware } from '../middleware/auth';
 import { createOpenAPIApp } from '../../lib/openapi-app';
-import type { TokenService } from '../../application/auth/TokenService';
 import type { Budget } from '../../domain/models/Budget';
-import type { AppDeps } from '../../app';
+import type { RouteServices } from '../../app';
 import {
     BudgetResponseSchema,
     CreateBudgetBodySchema,
@@ -148,8 +147,7 @@ const deleteBudgetRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createBudgetRoutes(deps: AppDeps, tokenService: TokenService) {
-    const { budgetRepository } = deps;
+export function createBudgetRoutes({ tokenService, budgetRepository }: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
 

--- a/apps/api/src/presentation/routes/expense.ts
+++ b/apps/api/src/presentation/routes/expense.ts
@@ -1,11 +1,9 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import type { CreateExpenseInput } from '@budget/common';
-import { CreateExpenseUseCase } from '../../application/use-cases/CreateExpenseUseCase';
 import { createAuthMiddleware } from '../middleware/auth';
 import { createOpenAPIApp } from '../../lib/openapi-app';
-import type { TokenService } from '../../application/auth/TokenService';
 import type { Expense } from '../../domain/models/Expense';
-import type { AppDeps } from '../../app';
+import type { RouteServices } from '../../app';
 import {
     CreateExpenseBodySchema,
     ErrorResponseSchema,
@@ -150,9 +148,7 @@ const deleteExpenseRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createExpenseRoutes(deps: AppDeps, tokenService: TokenService) {
-    const { expenseRepository, userRepository } = deps;
-    const createExpenseUseCase = new CreateExpenseUseCase(expenseRepository, userRepository);
+export function createExpenseRoutes({ tokenService, expenseRepository, createExpenseUseCase }: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
 

--- a/apps/api/src/presentation/routes/export.ts
+++ b/apps/api/src/presentation/routes/export.ts
@@ -1,9 +1,7 @@
 import { createRoute } from '@hono/zod-openapi';
 import { createOpenAPIApp } from '../../lib/openapi-app';
 import { createAuthMiddleware } from '../middleware/auth';
-import type { TokenService } from '../../application/auth/TokenService';
-import type { AppDeps } from '../../app';
-import { ExportUserDataUseCase } from '../../application/use-cases/export/ExportUserDataUseCase';
+import type { RouteServices } from '../../app';
 import { ErrorResponseSchema, ExportQuerySchema } from '../../openapi/schemas';
 import { z } from '@hono/zod-openapi';
 
@@ -34,12 +32,9 @@ const exportExpensesRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createExportRoutes(deps: AppDeps, tokenService: TokenService) {
-    const { expenseRepository } = deps;
+export function createExportRoutes({ tokenService, exportUseCase }: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
-
-    const exportUseCase = new ExportUserDataUseCase(expenseRepository);
 
     app.use('/export/*', auth);
 

--- a/apps/api/src/presentation/routes/recovery.ts
+++ b/apps/api/src/presentation/routes/recovery.ts
@@ -1,12 +1,6 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { createOpenAPIApp } from '../../lib/openapi-app';
-import type { AppDeps } from '../../app';
-import { RegisterUserUseCase } from '../../application/use-cases/auth/RegisterUserUseCase';
-import { GetSecurityQuestionsUseCase } from '../../application/use-cases/auth/GetSecurityQuestionsUseCase';
-import { GetRecoveryQuestionUseCase } from '../../application/use-cases/auth/GetRecoveryQuestionUseCase';
-import { VerifyRecoveryAnswerUseCase } from '../../application/use-cases/auth/VerifyRecoveryAnswerUseCase';
-import { ResetPasswordUseCase } from '../../application/use-cases/auth/ResetPasswordUseCase';
-import { CheckUserNameUseCase } from '../../application/use-cases/user/CheckUserNameUseCase';
+import type { RouteServices } from '../../app';
 import {
     CheckUserNameQuerySchema,
     CheckUserNameResponseSchema,
@@ -150,19 +144,15 @@ const resetPasswordRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createRecoveryRoutes(deps: AppDeps) {
-    const { userRepository, securityAnswerRepository, passwordResetTokenRepository } = deps;
+export function createRecoveryRoutes({
+    registerUseCase,
+    checkUserNameUseCase,
+    getSecurityQuestionsUseCase,
+    getRecoveryQuestionUseCase,
+    verifyRecoveryAnswerUseCase,
+    resetPasswordUseCase,
+}: RouteServices) {
     const app = createOpenAPIApp();
-
-    const registerUseCase = new RegisterUserUseCase(userRepository, securityAnswerRepository);
-    const checkUserNameUseCase = new CheckUserNameUseCase(userRepository);
-    const getSecurityQuestionsUseCase = new GetSecurityQuestionsUseCase(securityAnswerRepository);
-    const getRecoveryQuestionUseCase = new GetRecoveryQuestionUseCase(userRepository, securityAnswerRepository);
-    const verifyRecoveryAnswerUseCase = new VerifyRecoveryAnswerUseCase(
-        securityAnswerRepository,
-        passwordResetTokenRepository
-    );
-    const resetPasswordUseCase = new ResetPasswordUseCase(userRepository, passwordResetTokenRepository);
 
     app.openapi(registerRoute, async (c) => {
         const body = c.req.valid('json');

--- a/apps/api/src/presentation/routes/user.ts
+++ b/apps/api/src/presentation/routes/user.ts
@@ -1,14 +1,8 @@
 import { createRoute, z } from '@hono/zod-openapi';
 import { createAuthMiddleware } from '../middleware/auth';
 import { createOpenAPIApp } from '../../lib/openapi-app';
-import type { TokenService } from '../../application/auth/TokenService';
 import type { User } from '../../domain/models/User';
-import type { AppDeps } from '../../app';
-import { CreateUserUseCase } from '../../application/use-cases/user/CreateUserUseCase';
-import { GetUsersUseCase } from '../../application/use-cases/user/GetUsersUseCase';
-import { GetUserByIdUseCase } from '../../application/use-cases/user/GetUserByIdUseCase';
-import { UpdateUserUseCase } from '../../application/use-cases/user/UpdateUserUseCase';
-import { DeleteUserUseCase } from '../../application/use-cases/user/DeleteUserUseCase';
+import type { RouteServices } from '../../app';
 import {
     CreateUserBodySchema,
     ErrorResponseSchema,
@@ -162,17 +156,16 @@ function serializeUser(user: User) {
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createUserRoutes(deps: AppDeps, tokenService: TokenService) {
-    const { userRepository } = deps;
+export function createUserRoutes({
+    tokenService,
+    getUsersUseCase,
+    getUserByIdUseCase,
+    createUserUseCase,
+    updateUserUseCase,
+    deleteUserUseCase,
+}: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
-
-    // UseCase のインスタンスを生成（すべての操作は UseCase 経由）
-    const getUsersUseCase = new GetUsersUseCase(userRepository);
-    const getUserByIdUseCase = new GetUserByIdUseCase(userRepository);
-    const createUserUseCase = new CreateUserUseCase(userRepository);
-    const updateUserUseCase = new UpdateUserUseCase(userRepository);
-    const deleteUserUseCase = new DeleteUserUseCase(userRepository);
 
     // 全 User ルートに Bearer 認証を適用
     app.use('/user', auth);

--- a/apps/api/src/presentation/routes/xday.ts
+++ b/apps/api/src/presentation/routes/xday.ts
@@ -1,10 +1,7 @@
 import { createRoute } from '@hono/zod-openapi';
 import { createOpenAPIApp } from '../../lib/openapi-app';
 import { createAuthMiddleware } from '../middleware/auth';
-import type { TokenService } from '../../application/auth/TokenService';
-import type { AppDeps } from '../../app';
-import { GetXDayUseCase } from '../../application/use-cases/xday/GetXDayUseCase';
-import { GetExpenditureAnalysisUseCase } from '../../application/use-cases/xday/GetExpenditureAnalysisUseCase';
+import type { RouteServices } from '../../app';
 import {
     ErrorResponseSchema,
     XDayQuerySchema,
@@ -64,13 +61,9 @@ const getAnalysisRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createXDayRoutes(deps: AppDeps, tokenService: TokenService) {
-    const { expenseRepository } = deps;
+export function createXDayRoutes({ tokenService, getXDayUseCase, getAnalysisUseCase }: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
-
-    const getXDayUseCase = new GetXDayUseCase(expenseRepository);
-    const getAnalysisUseCase = new GetExpenditureAnalysisUseCase(expenseRepository);
 
     app.use('/xday', auth);
     app.use('/xday/analysis', auth);


### PR DESCRIPTION
## Summary
- ルートファクトリ内で `new XxxUseCase(...)` していた箇所を廃止
- `container.ts` に `buildServices(deps, tokenService)` を追加し、全 UseCase のインスタンス生成をここに一元化
- `app.ts` に `RouteServices` 型を新設。`createApp()` が `buildServices()` を呼び出してルートへ注入
- ルートファクトリはサービスを受け取るだけで生成責務を持たない構成に変更
- `AppDeps`（リポジトリのみ）はそのまま → テストコードへの変更なし

closes #98

## Test plan
- [ ] 型チェック (`pnpm type-check`) パス
- [ ] ユニットテスト (`pnpm test:unit`) パス — 54件
- [ ] CI 全ジョブ（lint / unit-test / integration-test / security-scan / migration-check / infra-check）パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)