### PR TITLE
feat: ヘッダーメニューをモダンなデザインにリニューアルする

### DIFF
--- a/apps/web/src/__tests__/components/Header.test.tsx
+++ b/apps/web/src/__tests__/components/Header.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Header } from '../../components/layout/Header'
+
+vi.mock('@/lib/actions/auth', () => ({
+    logoutAction: vi.fn(),
+}))
+
+vi.mock('next/link', () => ({
+    default: ({
+        href,
+        children,
+        onClick,
+        className,
+    }: {
+        href: string
+        children: React.ReactNode
+        onClick?: () => void
+        className?: string
+    }) => (
+        <a href={href} onClick={onClick} className={className}>
+            {children}
+        </a>
+    ),
+}))
+
+vi.mock('next/navigation', () => ({
+    usePathname: vi.fn().mockReturnValue('/'),
+}))
+
+import { usePathname } from 'next/navigation'
+
+describe('Header', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.mocked(usePathname).mockReturnValue('/')
+    })
+
+    it('正常表示: ロゴ・ナビ・記録するボタンが描画される', () => {
+        render(<Header />)
+
+        expect(screen.getByText('家計簿')).toBeInTheDocument()
+        expect(screen.getByText('ホーム')).toBeInTheDocument()
+        expect(screen.getByText('カレンダー')).toBeInTheDocument()
+        expect(screen.getByText('レポート')).toBeInTheDocument()
+        // 「記録する」は CTA ボタンとデスクトップ・モバイル両方に存在する
+        expect(screen.getAllByText('記録する').length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('userName が渡されたとき、ユーザー名を表示する', () => {
+        render(<Header userName="田中" />)
+
+        expect(screen.getByText('田中さん')).toBeInTheDocument()
+    })
+
+    it('userName が未指定のとき、ユーザー名を表示しない', () => {
+        render(<Header />)
+
+        expect(screen.queryByText('さん')).not.toBeInTheDocument()
+    })
+
+    it('ログアウトボタンが描画される', () => {
+        render(<Header />)
+
+        expect(screen.getAllByRole('button', { name: /ログアウト/ }).length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('現在のパスが / のとき、ホームがアクティブになる', () => {
+        vi.mocked(usePathname).mockReturnValue('/')
+        render(<Header />)
+
+        const homeLink = screen.getByRole('link', { name: /ホーム/ })
+        expect(homeLink.className).toContain('text-[#f18840]')
+    })
+
+    it('現在のパスが /calendar のとき、カレンダーがアクティブになる', () => {
+        vi.mocked(usePathname).mockReturnValue('/calendar')
+        render(<Header />)
+
+        const calendarLink = screen.getByRole('link', { name: /カレンダー/ })
+        expect(calendarLink.className).toContain('text-[#f18840]')
+    })
+
+    it('モバイルメニューボタンを押すとメニューが表示される', () => {
+        render(<Header />)
+
+        // 初期状態ではモバイルメニューは非表示
+        expect(screen.queryByRole('dialog', { name: 'モバイルメニュー' })).not.toBeInTheDocument()
+
+        // ハンバーガーボタンをクリック
+        const menuButton = screen.getByRole('button', { name: 'メニューを開く' })
+        fireEvent.click(menuButton)
+
+        // メニューが表示される
+        expect(screen.getByRole('dialog', { name: 'モバイルメニュー' })).toBeInTheDocument()
+    })
+
+    it('モバイルメニュー表示中に閉じるボタンを押すと非表示になる', () => {
+        render(<Header />)
+
+        const menuButton = screen.getByRole('button', { name: 'メニューを開く' })
+        fireEvent.click(menuButton)
+
+        const closeButton = screen.getByRole('button', { name: 'メニューを閉じる' })
+        fireEvent.click(closeButton)
+
+        expect(screen.queryByRole('dialog', { name: 'モバイルメニュー' })).not.toBeInTheDocument()
+    })
+
+    it('モバイルメニュー内のリンクをクリックするとメニューが閉じる', () => {
+        vi.mocked(usePathname).mockReturnValue('/')
+        render(<Header />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'メニューを開く' }))
+        expect(screen.getByRole('dialog', { name: 'モバイルメニュー' })).toBeInTheDocument()
+
+        // モバイルメニュー内のカレンダーリンクをクリック
+        const dialog = screen.getByRole('dialog', { name: 'モバイルメニュー' })
+        const calendarLink = dialog.querySelector('a[href="/calendar"]')
+        expect(calendarLink).not.toBeNull()
+        fireEvent.click(calendarLink!)
+
+        expect(screen.queryByRole('dialog', { name: 'モバイルメニュー' })).not.toBeInTheDocument()
+    })
+})

--- a/apps/web/src/app/expenses/page.tsx
+++ b/apps/web/src/app/expenses/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import { getExpenses } from "@/lib/api/expense";
 import { ExpenseList } from "@/components/expense/ExpenseList";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
-import { logoutAction } from "@/lib/actions/auth";
+import { Header } from "@/components/layout/Header";
 import { ApiError } from "@/lib/api/client";
 import { redirect } from "next/navigation";
 
@@ -71,20 +71,12 @@ export default function ExpensesPage() {
 
   return (
     <div className="flex min-h-screen flex-col bg-[#fffdf5]">
+      <Header userName={userId} />
       <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-8">
-      <header className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-extrabold text-[#1c1410]">
-          支出一覧
-        </h1>
-        <form action={logoutAction}>
-          <button type="submit" className="btn-ghost text-xs px-3 py-1.5">
-            ログアウト
-          </button>
-        </form>
-      </header>
+        <h1 className="mb-6 text-2xl font-extrabold text-[#1c1410]">支出一覧</h1>
 
-      {/* 新規登録フォーム */}
-      <ExpenseCreateForm userId={userId} />
+        {/* 新規登録フォーム */}
+        <ExpenseCreateForm userId={userId} />
 
       {/* 支出一覧（Server Component + Suspense でストリーミング） */}
       <Suspense
@@ -99,4 +91,5 @@ export default function ExpensesPage() {
       </div>
     </div>
   );
+
 }

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -3,17 +3,20 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { logoutAction } from "@/lib/actions/auth";
+import { Home, Calendar, BarChart2, PenLine, LogOut, Menu, X } from "lucide-react";
+import { useState } from "react";
 
 type NavItem = {
   label: string;
   href: string;
+  icon: React.ElementType;
 };
 
+// 通常ナビゲーション項目（記録するは CTA ボタンとして分離）
 const NAV_ITEMS: NavItem[] = [
-  { label: "ホーム", href: "/" },
-  { label: "カレンダー", href: "/calendar" },
-  { label: "レポート", href: "/report" },
-  { label: "記録する", href: "/expenses/new" },
+  { label: "ホーム", href: "/", icon: Home },
+  { label: "カレンダー", href: "/calendar", icon: Calendar },
+  { label: "レポート", href: "/report", icon: BarChart2 },
 ];
 
 type Props = {
@@ -22,9 +25,13 @@ type Props = {
 
 export function Header({ userName }: Props) {
   const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const isActive = (href: string) =>
+    href === "/" ? pathname === "/" : pathname.startsWith(href);
 
   return (
-    <header className="sticky top-0 z-10 border-b border-[#1c1410]/10 bg-[#fffdf5]">
+    <header className="sticky top-0 z-20 border-b border-[#1c1410]/10 bg-[#fffdf5]/90 backdrop-blur-md">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
         {/* ロゴ */}
         <Link href="/" className="flex items-center gap-2">
@@ -34,31 +41,28 @@ export function Header({ userName }: Props) {
           >
             B
           </span>
-          <span className="text-base font-bold text-[#1c1410]">
-            家計簿
-          </span>
+          <span className="text-base font-bold text-[#1c1410]">家計簿</span>
         </Link>
 
-        {/* ナビゲーション */}
-        <nav className="flex items-center gap-1">
+        {/* デスクトップ: ナビゲーション */}
+        <nav className="hidden md:flex items-center gap-1" aria-label="メインナビゲーション">
           {NAV_ITEMS.map((item) => {
-            const isActive =
-              item.href === "/"
-                ? pathname === "/"
-                : pathname.startsWith(item.href);
+            const active = isActive(item.href);
+            const Icon = item.icon;
             return (
               <Link
                 key={item.href}
                 href={item.href}
                 className={[
-                  "relative px-3 py-2 text-sm font-semibold transition-colors rounded-lg",
-                  isActive
+                  "relative flex items-center gap-1.5 px-3 py-2 text-sm font-semibold transition-colors rounded-lg",
+                  active
                     ? "text-[#f18840] bg-[#fff6ee]"
-                    : "text-[#1c1410] hover:text-[#f18840] hover:bg-[#fff6ee]",
+                    : "text-[#1c1410]/70 hover:text-[#f18840] hover:bg-[#fff6ee]",
                 ].join(" ")}
               >
+                <Icon size={15} />
                 {item.label}
-                {isActive && (
+                {active && (
                   <span className="absolute -bottom-0.5 left-3 right-3 h-0.5 rounded-full bg-[#f18840]" />
                 )}
               </Link>
@@ -66,20 +70,88 @@ export function Header({ userName }: Props) {
           })}
         </nav>
 
-        {/* ユーザー情報 + ログアウト */}
-        <div className="flex items-center gap-3">
+        {/* デスクトップ: 右側エリア */}
+        <div className="hidden md:flex items-center gap-2">
+          <Link href="/expenses/new" className="btn-candy text-sm px-4 py-2">
+            <PenLine size={14} />
+            記録する
+          </Link>
           {userName && (
             <span className="text-sm font-medium text-[#1c1410]/50">
               {userName}さん
             </span>
           )}
           <form action={logoutAction}>
-            <button type="submit" className="btn-ghost text-xs px-3 py-1.5">
+            <button type="submit" className="btn-ghost text-xs px-3 py-1.5 gap-1.5">
+              <LogOut size={13} />
               ログアウト
             </button>
           </form>
         </div>
+
+        {/* モバイル: 右側エリア */}
+        <div className="flex md:hidden items-center gap-2">
+          <Link href="/expenses/new" className="btn-candy text-xs px-3 py-1.5">
+            <PenLine size={13} />
+            記録する
+          </Link>
+          <button
+            type="button"
+            aria-label={mobileOpen ? "メニューを閉じる" : "メニューを開く"}
+            aria-expanded={mobileOpen}
+            className="flex h-9 w-9 items-center justify-center rounded-lg text-[#1c1410] transition-colors hover:bg-[#fff6ee]"
+            onClick={() => setMobileOpen(!mobileOpen)}
+          >
+            {mobileOpen ? <X size={20} /> : <Menu size={20} />}
+          </button>
+        </div>
       </div>
+
+      {/* モバイル: ドロップダウンメニュー */}
+      {mobileOpen && (
+        <div
+          className="md:hidden border-t border-[#1c1410]/10 bg-[#fffdf5] px-4 py-3"
+          role="dialog"
+          aria-label="モバイルメニュー"
+        >
+          <nav className="flex flex-col gap-1">
+            {NAV_ITEMS.map((item) => {
+              const active = isActive(item.href);
+              const Icon = item.icon;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={() => setMobileOpen(false)}
+                  className={[
+                    "flex items-center gap-3 rounded-xl px-3 py-3 text-sm font-semibold transition-colors",
+                    active
+                      ? "bg-[#fff6ee] text-[#f18840]"
+                      : "text-[#1c1410] hover:bg-[#fff6ee] hover:text-[#f18840]",
+                  ].join(" ")}
+                >
+                  <Icon size={18} />
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+
+          <div className="mt-2 flex items-center justify-between border-t border-[#1c1410]/8 pt-3">
+            {userName && (
+              <span className="text-sm font-medium text-[#1c1410]/50">
+                {userName}さん
+              </span>
+            )}
+            <form action={logoutAction}>
+              <button type="submit" className="btn-ghost text-xs px-3 py-1.5 gap-1.5">
+                <LogOut size={13} />
+                ログアウト
+              </button>
+            </form>
+          </div>
+        </div>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
## Summary
- アイコン追加: ホーム/カレンダー/レポートのナビ項目に `lucide-react` アイコンを付与
- 記録するを CTA ボタンへ昇格: 通常ナビから分離し、デスクトップ/モバイル両方にオレンジの `btn-candy` ボタンとして表示
- モバイルハンバーガーメニュー追加: `md:` ブレークポイントで切り替え、スライドダウンのドロップダウンナビを実装
- すりガラス効果: `bg-[#fffdf5]/90 + backdrop-blur-md` でヘッダーに奥行きを付与
- `/expenses` ページのインラインヘッダーを共通 `Header` コンポーネントに統一（不整合解消）
- `Header.test.tsx` を新規作成（正常表示・アクティブ状態・モバイルメニュー開閉 等9ケース）

## Test plan
- [ ] 型チェック・ユニットテスト（50件）パス
- [ ] CI 全ジョブパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)