### PR TITLE
fix: expenses ページの userId をクッキーから取得するよう修正

### DIFF
--- a/apps/web/src/app/expenses/page.tsx
+++ b/apps/web/src/app/expenses/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
+import { cookies } from "next/headers";
 import { getExpenses } from "@/lib/api/expense";
 import { ExpenseList } from "@/components/expense/ExpenseList";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
@@ -65,9 +66,9 @@ async function ExpenseListSection() {
   );
 }
 
-export default function ExpensesPage() {
-  // TODO: セッションからuserIdを取得する（現在はゲストIDをプレースホルダーとして使用）
-  const userId = "Guest";
+export default async function ExpensesPage() {
+  const cookieStore = await cookies();
+  const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
   return (
     <div className="flex min-h-screen flex-col bg-[#fffdf5]">


### PR DESCRIPTION
## Summary
- `/expenses/page.tsx` で `userId = "Guest"` にハードコードされていた問題を修正
- 他のページ (`/`, `/calendar`, `/report`) と同じパターンで `cookies()` → `user_id` クッキーから取得するよう変更
- `ExpensesPage` を `async function` に変更

## Test plan
- [ ] 既存ユニットテスト全件パス確認（CI）
- [ ] ログイン済みユーザーで `/expenses` にアクセスし、ヘッダーにユーザー名が表示されること

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)