### PR TITLE
refactor: IUserRepository.create から平文パスワード引数を除去

### DIFF
--- a/apps/api/src/application/use-cases/auth/RegisterUserUseCase.ts
+++ b/apps/api/src/application/use-cases/auth/RegisterUserUseCase.ts
@@ -1,4 +1,5 @@
 import { User } from '../../../domain/models/User';
+import type { IPasswordHasher } from '../../../domain/services/IPasswordHasher';
 import type { IUserRepository } from '../../../domain/repositories/IUserRepository';
 import type { ISecurityAnswerRepository } from '../../../domain/repositories/ISecurityAnswerRepository';
 import { ValidationError } from '../../../shared/errors/DomainException';
@@ -19,7 +20,8 @@ interface RegisterInput {
 export class RegisterUserUseCase {
     constructor(
         private readonly userRepository: IUserRepository,
-        private readonly securityAnswerRepository: ISecurityAnswerRepository
+        private readonly securityAnswerRepository: ISecurityAnswerRepository,
+        private readonly passwordHasher: IPasswordHasher
     ) {}
 
     async execute(input: RegisterInput): Promise<User> {
@@ -35,8 +37,9 @@ export class RegisterUserUseCase {
             userName: input.displayName ?? input.userId,
         });
 
-        // インフラ層でパスワードハッシュ化・永続化
-        const saved = await this.userRepository.create(user, input.password);
+        // アプリケーション層でハッシュ化してからリポジトリに渡す
+        const hashedPassword = await this.passwordHasher.hash(input.password);
+        const saved = await this.userRepository.create(user.withPassword(hashedPassword));
 
         // 秘密の質問と回答を保存
         await this.securityAnswerRepository.save(input.userId, input.securityQuestionId, input.securityAnswer);

--- a/apps/api/src/application/use-cases/user/CreateUserUseCase.ts
+++ b/apps/api/src/application/use-cases/user/CreateUserUseCase.ts
@@ -1,10 +1,14 @@
 import type { CreateUserInput } from '@budget/common';
 import { User } from '../../../domain/models/User';
+import type { IPasswordHasher } from '../../../domain/services/IPasswordHasher';
 import type { IUserRepository } from '../../../domain/repositories/IUserRepository';
 import { ValidationError } from '../../../shared/errors/DomainException';
 
 export class CreateUserUseCase {
-    constructor(private readonly userRepository: IUserRepository) {}
+    constructor(
+        private readonly userRepository: IUserRepository,
+        private readonly passwordHasher: IPasswordHasher
+    ) {}
 
     async execute(input: CreateUserInput): Promise<User> {
         // email 重複チェック
@@ -22,6 +26,8 @@ export class CreateUserUseCase {
             role: input.role,
         });
 
-        return this.userRepository.create(user, input.password);
+        // アプリケーション層でハッシュ化してからリポジトリに渡す
+        const hashedPassword = await this.passwordHasher.hash(input.password);
+        return this.userRepository.create(user.withPassword(hashedPassword));
     }
 }

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -5,6 +5,7 @@ import { PrismaRefreshTokenRepository } from './infrastructure/persistence/Prism
 import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
 import { PrismaSecurityAnswerRepository } from './infrastructure/persistence/PrismaSecurityAnswerRepository';
 import { PrismaPasswordResetTokenRepository } from './infrastructure/persistence/PrismaPasswordResetTokenRepository';
+import { BcryptPasswordHasher } from './infrastructure/security/BcryptPasswordHasher';
 import type { AppDeps, RouteServices } from './app';
 import type { TokenService } from './application/auth/TokenService';
 import { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
@@ -43,6 +44,7 @@ export function buildDeps(): AppDeps {
  * UseCase のインスタンス生成はすべてここに集約し、ルートファクトリ内での new を禁止する。
  */
 export function buildServices(deps: AppDeps, tokenService: TokenService): RouteServices {
+    const passwordHasher = new BcryptPasswordHasher();
     return {
         tokenService,
         // リポジトリ直接参照（UseCase未抽出のルート用）
@@ -54,7 +56,7 @@ export function buildServices(deps: AppDeps, tokenService: TokenService): RouteS
         // Export
         exportUseCase: new ExportUserDataUseCase(deps.expenseRepository),
         // Recovery / Registration
-        registerUseCase: new RegisterUserUseCase(deps.userRepository, deps.securityAnswerRepository),
+        registerUseCase: new RegisterUserUseCase(deps.userRepository, deps.securityAnswerRepository, passwordHasher),
         checkUserNameUseCase: new CheckUserNameUseCase(deps.userRepository),
         getSecurityQuestionsUseCase: new GetSecurityQuestionsUseCase(deps.securityAnswerRepository),
         getRecoveryQuestionUseCase: new GetRecoveryQuestionUseCase(deps.userRepository, deps.securityAnswerRepository),
@@ -66,7 +68,7 @@ export function buildServices(deps: AppDeps, tokenService: TokenService): RouteS
         // User management
         getUsersUseCase: new GetUsersUseCase(deps.userRepository),
         getUserByIdUseCase: new GetUserByIdUseCase(deps.userRepository),
-        createUserUseCase: new CreateUserUseCase(deps.userRepository),
+        createUserUseCase: new CreateUserUseCase(deps.userRepository, passwordHasher),
         updateUserUseCase: new UpdateUserUseCase(deps.userRepository),
         deleteUserUseCase: new DeleteUserUseCase(deps.userRepository),
         // XDay

--- a/apps/api/src/domain/models/User.ts
+++ b/apps/api/src/domain/models/User.ts
@@ -84,6 +84,23 @@ export class User {
         return new User(props);
     }
 
+    /**
+     * ハッシュ済みパスワードをセットした新しいインスタンスを返す。
+     * アプリケーション層で IPasswordHasher でハッシュ化してから呼び出す。
+     */
+    withPassword(hashedPassword: string): User {
+        return new User({
+            userId: this.userId,
+            userName: this.userName,
+            password: hashedPassword,
+            email: this.email,
+            role: this.role,
+            status: this.status,
+            createdAt: this.createdAt,
+            updatedAt: this.updatedAt,
+        });
+    }
+
     // ─── バリデーション（ドメイン不変条件） ─────────────────────
     private static validateUserId(userId: string): void {
         if (!/^[a-zA-Z0-9_-]{3,30}$/.test(userId)) {

--- a/apps/api/src/domain/repositories/IUserRepository.ts
+++ b/apps/api/src/domain/repositories/IUserRepository.ts
@@ -13,9 +13,10 @@ export interface IUserRepository {
 
     /**
      * 新規ユーザーを作成する。
-     * plaintextPassword は平文 — ハッシュ化はインフラ層が担う。
+     * user.password にはハッシュ済みパスワードがセットされていること。
+     * ハッシュ化はアプリケーション層（UseCase）の責務。
      */
-    create(user: User, plaintextPassword: string): Promise<User>;
+    create(user: User): Promise<User>;
 
     /**
      * ユーザー情報を更新する。

--- a/apps/api/src/domain/services/IPasswordHasher.ts
+++ b/apps/api/src/domain/services/IPasswordHasher.ts
@@ -1,0 +1,7 @@
+/** パスワードのハッシュ化・検証を抽象化したドメインサービスインターフェース */
+export interface IPasswordHasher {
+    /** 平文パスワードをハッシュ化して返す */
+    hash(plaintext: string): Promise<string>;
+    /** 平文パスワードとハッシュを比較して一致するか検証する */
+    verify(plaintext: string, hashed: string): Promise<boolean>;
+}

--- a/apps/api/src/infrastructure/persistence/PrismaUserRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaUserRepository.ts
@@ -43,14 +43,13 @@ export class PrismaUserRepository implements IUserRepository {
         return record ? toDomain(record) : null;
     }
 
-    async create(user: User, plaintextPassword: string): Promise<User> {
-        const hashed = await bcrypt.hash(plaintextPassword, 10);
+    async create(user: User): Promise<User> {
         const record = await this.prisma.userList.create({
             data: {
                 userId: user.userId,
                 userName: user.userName,
                 email: user.email,
-                password: hashed,
+                password: user.password,
                 role: user.role,
                 status: user.status,
             },

--- a/apps/api/src/infrastructure/security/BcryptPasswordHasher.ts
+++ b/apps/api/src/infrastructure/security/BcryptPasswordHasher.ts
@@ -1,0 +1,17 @@
+import type { IPasswordHasher } from '../../domain/services/IPasswordHasher';
+
+// biome-ignore lint/suspicious/noExplicitAny: bcrypt は CommonJS モジュールのため require を使用
+const bcrypt = require('bcrypt') as {
+    hash: (data: string, rounds: number) => Promise<string>;
+    compare: (data: string, encrypted: string) => Promise<boolean>;
+};
+
+export class BcryptPasswordHasher implements IPasswordHasher {
+    async hash(plaintext: string): Promise<string> {
+        return bcrypt.hash(plaintext, 10);
+    }
+
+    async verify(plaintext: string, hashed: string): Promise<boolean> {
+        return bcrypt.compare(plaintext, hashed);
+    }
+}


### PR DESCRIPTION
## Summary
- `IPasswordHasher` インターフェースを `domain/services/` に追加（ドメイン層への抽象化）
- `BcryptPasswordHasher` を `infrastructure/security/` に実装
- `User.withPassword(hashedPassword)` メソッドを追加（イミュータブルなパスワード設定）
- `IUserRepository.create(user: User)` から `plaintextPassword` 引数を除去
- `CreateUserUseCase` / `RegisterUserUseCase` でハッシュ化してからリポジトリに渡すよう変更
- `container.ts` で `BcryptPasswordHasher` を注入

## Before / After
```typescript
// Before: ドメインインターフェースにインフラ関心事が漏洩
create(user: User, plaintextPassword: string): Promise<User>
// 呼び出し側
await this.userRepository.create(user, input.password)

// After: リポジトリにはハッシュ済みパスワードのみ渡す
create(user: User): Promise<User>
// 呼び出し側（UseCase内でハッシュ化）
const hashedPassword = await this.passwordHasher.hash(input.password);
await this.userRepository.create(user.withPassword(hashedPassword));
```

## Test plan
- [x] ユニットテスト 50 件パス
- [x] 統合テスト 25 件パス（ローカル確認済み）
- [ ] CI 全件パス

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)