### PR TITLE
feature: 支出・収入レコードの編集機能を追加する

### DIFF
--- a/apps/api/src/__tests__/unit/controllers/UpdateExpenseUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/controllers/UpdateExpenseUseCase.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateExpenseUseCase } from '../../../application/use-cases/UpdateExpenseUseCase';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import type { Expense } from '../../../domain/models/Expense';
+import type { UpdateExpenseInput } from '@budget/common';
+import { NotFoundError } from '../../../shared/errors/DomainException';
+
+const mockExpense: Expense = {
+    id: 'expense-01',
+    amount: 1000,
+    balanceType: 0,
+    userId: 'user-1',
+    categoryId: 1,
+    date: '2024-01-01',
+    content: 'テスト',
+    createdDate: new Date('2024-01-01'),
+    updatedDate: new Date('2024-01-01'),
+    deletedDate: null,
+};
+
+const updatedExpense: Expense = {
+    ...mockExpense,
+    amount: 2000,
+    date: '2024-02-01',
+    content: '更新後',
+    updatedDate: new Date('2024-02-01'),
+};
+
+const mockExpenseRepository: IExpenseRepository = {
+    findAll: vi.fn(),
+    findByUserId: vi.fn(),
+    findById: vi.fn().mockResolvedValue(mockExpense),
+    save: vi.fn().mockResolvedValue(updatedExpense),
+    remove: vi.fn(),
+};
+
+describe('UpdateExpenseUseCase', () => {
+    let useCase: UpdateExpenseUseCase;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(mockExpenseRepository.findById).mockResolvedValue(mockExpense);
+        vi.mocked(mockExpenseRepository.save).mockResolvedValue(updatedExpense);
+        useCase = new UpdateExpenseUseCase(mockExpenseRepository);
+    });
+
+    const validInput: UpdateExpenseInput = {
+        amount: 2000,
+        balanceType: 0,
+        date: '2024-02-01',
+        content: '更新後',
+    };
+
+    describe('execute()', () => {
+        it('正常系: 有効なデータで支出を更新する', async () => {
+            const result = await useCase.execute('expense-01', validInput);
+
+            expect(result).toEqual(updatedExpense);
+            expect(mockExpenseRepository.findById).toHaveBeenCalledWith('expense-01');
+            expect(mockExpenseRepository.save).toHaveBeenCalledTimes(1);
+        });
+
+        it('正常系: content が null でも更新できる', async () => {
+            const result = await useCase.execute('expense-01', { ...validInput, content: null });
+            expect(result).toEqual(updatedExpense);
+        });
+
+        it('正常系: userId は既存エンティティから引き継がれる', async () => {
+            await useCase.execute('expense-01', validInput);
+
+            const savedArg = vi.mocked(mockExpenseRepository.save).mock.calls[0][0];
+            expect(savedArg.userId).toBe(mockExpense.userId);
+        });
+
+        it('正常系: createdDate は既存エンティティから引き継がれる', async () => {
+            await useCase.execute('expense-01', validInput);
+
+            const savedArg = vi.mocked(mockExpenseRepository.save).mock.calls[0][0];
+            expect(savedArg.createdDate).toEqual(mockExpense.createdDate);
+        });
+
+        it('異常系: 存在しない ID を指定すると NotFoundError をthrow', async () => {
+            vi.mocked(mockExpenseRepository.findById).mockResolvedValue(null);
+
+            await expect(useCase.execute('not-exist', validInput)).rejects.toBeInstanceOf(NotFoundError);
+        });
+
+        it('異常系: リポジトリが例外をthrowした場合は伝播する', async () => {
+            vi.mocked(mockExpenseRepository.save).mockRejectedValue(new Error('DB error'));
+
+            await expect(useCase.execute('expense-01', validInput)).rejects.toThrow('DB error');
+        });
+    });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,37 +1,38 @@
 import { OpenAPIHono } from '@hono/zod-openapi';
 import { secureHeaders } from 'hono/secure-headers';
-import type { IBudgetRepository } from './domain/repositories/IBudgetRepository';
-import type { IExpenseRepository } from './domain/repositories/IExpenseRepository';
-import type { IUserRepository } from './domain/repositories/IUserRepository';
-import type { IRefreshTokenRepository } from './domain/repositories/IRefreshTokenRepository';
-import type { ISecurityAnswerRepository } from './domain/repositories/ISecurityAnswerRepository';
-import type { IPasswordResetTokenRepository } from './domain/repositories/IPasswordResetTokenRepository';
 import type { TokenService } from './application/auth/TokenService';
+import { TokenService as TokenServiceImpl } from './application/auth/TokenService';
+import type { GetRecoveryQuestionUseCase } from './application/use-cases/auth/GetRecoveryQuestionUseCase';
+import type { GetSecurityQuestionsUseCase } from './application/use-cases/auth/GetSecurityQuestionsUseCase';
+import type { RegisterUserUseCase } from './application/use-cases/auth/RegisterUserUseCase';
+import type { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
+import type { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
 import type { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
 import type { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
-import type { RegisterUserUseCase } from './application/use-cases/auth/RegisterUserUseCase';
-import type { GetSecurityQuestionsUseCase } from './application/use-cases/auth/GetSecurityQuestionsUseCase';
-import type { GetRecoveryQuestionUseCase } from './application/use-cases/auth/GetRecoveryQuestionUseCase';
-import type { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
-import type { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
+import type { UpdateExpenseUseCase } from './application/use-cases/UpdateExpenseUseCase';
 import type { CheckUserNameUseCase } from './application/use-cases/user/CheckUserNameUseCase';
-import type { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
-import type { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
 import type { CreateUserUseCase } from './application/use-cases/user/CreateUserUseCase';
-import type { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
 import type { DeleteUserUseCase } from './application/use-cases/user/DeleteUserUseCase';
-import type { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
+import type { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
+import type { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
+import type { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
 import type { GetExpenditureAnalysisUseCase } from './application/use-cases/xday/GetExpenditureAnalysisUseCase';
-import { TokenService as TokenServiceImpl } from './application/auth/TokenService';
-import { DomainException } from './shared/errors/DomainException';
+import type { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
 import { buildServices } from './container';
+import type { IBudgetRepository } from './domain/repositories/IBudgetRepository';
+import type { IExpenseRepository } from './domain/repositories/IExpenseRepository';
+import type { IPasswordResetTokenRepository } from './domain/repositories/IPasswordResetTokenRepository';
+import type { IRefreshTokenRepository } from './domain/repositories/IRefreshTokenRepository';
+import type { ISecurityAnswerRepository } from './domain/repositories/ISecurityAnswerRepository';
+import type { IUserRepository } from './domain/repositories/IUserRepository';
 import { createAuthRoutes } from './presentation/routes/auth';
 import { createBudgetRoutes } from './presentation/routes/budget';
 import { createExpenseRoutes } from './presentation/routes/expense';
-import { createUserRoutes } from './presentation/routes/user';
-import { createRecoveryRoutes } from './presentation/routes/recovery';
 import { createExportRoutes } from './presentation/routes/export';
+import { createRecoveryRoutes } from './presentation/routes/recovery';
+import { createUserRoutes } from './presentation/routes/user';
 import { createXDayRoutes } from './presentation/routes/xday';
+import { DomainException } from './shared/errors/DomainException';
 
 export type AppDeps = {
     userRepository: IUserRepository;
@@ -55,6 +56,7 @@ export type RouteServices = {
     expenseRepository: IExpenseRepository;
     // Expense
     createExpenseUseCase: CreateExpenseUseCase;
+    updateExpenseUseCase: UpdateExpenseUseCase;
     // Export
     exportUseCase: ExportUserDataUseCase;
     // Recovery / Registration

--- a/apps/api/src/application/use-cases/UpdateExpenseUseCase.ts
+++ b/apps/api/src/application/use-cases/UpdateExpenseUseCase.ts
@@ -1,0 +1,33 @@
+import type { UpdateExpenseInput } from '@budget/common';
+import { Expense } from '../../domain/models/Expense';
+import type { IExpenseRepository } from '../../domain/repositories/IExpenseRepository';
+import { NotFoundError } from '../../shared/errors/DomainException';
+
+export type { UpdateExpenseInput };
+
+export class UpdateExpenseUseCase {
+    constructor(private readonly expenseRepository: IExpenseRepository) {}
+
+    async execute(id: string, input: UpdateExpenseInput): Promise<Expense> {
+        const existing = await this.expenseRepository.findById(id);
+        if (!existing) {
+            throw new NotFoundError(`支出が見つかりません: ${id}`);
+        }
+
+        // 既存エンティティの不変フィールドを保持しつつ更新フィールドを上書き
+        const updated = Expense.reconstruct({
+            id: existing.id,
+            userId: existing.userId,
+            createdDate: existing.createdDate,
+            deletedDate: existing.deletedDate,
+            amount: input.amount,
+            balanceType: input.balanceType,
+            categoryId: input.categoryId ?? existing.categoryId,
+            content: input.content ?? null,
+            date: input.date,
+            updatedDate: new Date(),
+        });
+
+        return this.expenseRepository.save(updated);
+    }
+}

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -1,28 +1,29 @@
-import { prisma } from './infrastructure/persistence/prisma-client';
-import { PrismaBudgetRepository } from './infrastructure/persistence/PrismaBudgetRepository';
-import { PrismaExpenseRepository } from './infrastructure/persistence/PrismaExpenseRepository';
-import { PrismaRefreshTokenRepository } from './infrastructure/persistence/PrismaRefreshTokenRepository';
-import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
-import { PrismaSecurityAnswerRepository } from './infrastructure/persistence/PrismaSecurityAnswerRepository';
-import { PrismaPasswordResetTokenRepository } from './infrastructure/persistence/PrismaPasswordResetTokenRepository';
-import { BcryptPasswordHasher } from './infrastructure/security/BcryptPasswordHasher';
 import type { AppDeps, RouteServices } from './app';
 import type { TokenService } from './application/auth/TokenService';
+import { GetRecoveryQuestionUseCase } from './application/use-cases/auth/GetRecoveryQuestionUseCase';
+import { GetSecurityQuestionsUseCase } from './application/use-cases/auth/GetSecurityQuestionsUseCase';
+import { RegisterUserUseCase } from './application/use-cases/auth/RegisterUserUseCase';
+import { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
+import { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
 import { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
 import { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
-import { RegisterUserUseCase } from './application/use-cases/auth/RegisterUserUseCase';
-import { GetSecurityQuestionsUseCase } from './application/use-cases/auth/GetSecurityQuestionsUseCase';
-import { GetRecoveryQuestionUseCase } from './application/use-cases/auth/GetRecoveryQuestionUseCase';
-import { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
-import { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
+import { UpdateExpenseUseCase } from './application/use-cases/UpdateExpenseUseCase';
 import { CheckUserNameUseCase } from './application/use-cases/user/CheckUserNameUseCase';
-import { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
-import { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
 import { CreateUserUseCase } from './application/use-cases/user/CreateUserUseCase';
-import { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
 import { DeleteUserUseCase } from './application/use-cases/user/DeleteUserUseCase';
-import { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
+import { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
+import { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
+import { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
 import { GetExpenditureAnalysisUseCase } from './application/use-cases/xday/GetExpenditureAnalysisUseCase';
+import { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
+import { PrismaBudgetRepository } from './infrastructure/persistence/PrismaBudgetRepository';
+import { PrismaExpenseRepository } from './infrastructure/persistence/PrismaExpenseRepository';
+import { PrismaPasswordResetTokenRepository } from './infrastructure/persistence/PrismaPasswordResetTokenRepository';
+import { PrismaRefreshTokenRepository } from './infrastructure/persistence/PrismaRefreshTokenRepository';
+import { PrismaSecurityAnswerRepository } from './infrastructure/persistence/PrismaSecurityAnswerRepository';
+import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
+import { prisma } from './infrastructure/persistence/prisma-client';
+import { BcryptPasswordHasher } from './infrastructure/security/BcryptPasswordHasher';
 
 /**
  * 本番用依存関係コンテナ。
@@ -53,6 +54,7 @@ export function buildServices(deps: AppDeps, tokenService: TokenService): RouteS
         expenseRepository: deps.expenseRepository,
         // Expense
         createExpenseUseCase: new CreateExpenseUseCase(deps.expenseRepository, deps.userRepository),
+        updateExpenseUseCase: new UpdateExpenseUseCase(deps.expenseRepository),
         // Export
         exportUseCase: new ExportUserDataUseCase(deps.expenseRepository),
         // Recovery / Registration

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -113,6 +113,30 @@ export const CreateExpenseBodySchema = z
     })
     .openapi('CreateExpenseBody');
 
+export const UpdateExpenseBodySchema = z
+    .object({
+        updateData: z
+            .object({
+                amount: z
+                    .number({ invalid_type_error: '金額は数値で入力してください' })
+                    .int('金額は整数で入力してください')
+                    .min(1, '金額は1以上の値を入力してください')
+                    .openapi({ description: '金額（円）', example: 1500 }),
+                balanceType: z
+                    .union([z.literal(0), z.literal(1)], {
+                        errorMap: () => ({ message: '種別を選択してください' }),
+                    })
+                    .openapi({ description: '収支区分: 0=支出, 1=収入', example: 0 }),
+                date: z.string().min(1, '日付を入力してください').openapi({
+                    description: '日付 (YYYY-MM-DD)',
+                    example: '2024-03-15',
+                }),
+                content: z.string().nullable().optional().openapi({ description: '備考', example: '昼食代' }),
+            })
+            .openapi({ description: '更新データ' }),
+    })
+    .openapi('UpdateExpenseBody');
+
 export const IdParamSchema = z.object({
     id: z.string().openapi({ description: 'リソース ID (ULID)', example: '01ARZ3NDEKTSV4RRFFQ69G5FAV' }),
 });

--- a/apps/api/src/presentation/routes/expense.ts
+++ b/apps/api/src/presentation/routes/expense.ts
@@ -1,15 +1,16 @@
+import type { CreateExpenseInput, UpdateExpenseInput } from '@budget/common';
 import { createRoute, z } from '@hono/zod-openapi';
-import type { CreateExpenseInput } from '@budget/common';
-import { createAuthMiddleware } from '../middleware/auth';
-import { createOpenAPIApp } from '../../lib/openapi-app';
-import type { Expense } from '../../domain/models/Expense';
 import type { RouteServices } from '../../app';
+import type { Expense } from '../../domain/models/Expense';
+import { createOpenAPIApp } from '../../lib/openapi-app';
 import {
     CreateExpenseBodySchema,
     ErrorResponseSchema,
     ExpenseResponseSchema,
     IdParamSchema,
+    UpdateExpenseBodySchema,
 } from '../../openapi/schemas';
+import { createAuthMiddleware } from '../middleware/auth';
 
 /** Date フィールドを ISO 文字列に変換してレスポンス用 DTO を生成する */
 function serializeExpense(e: Expense) {
@@ -109,7 +110,7 @@ const updateExpenseRoute = createRoute({
     security: [{ bearerAuth: [] }],
     request: {
         params: IdParamSchema,
-        body: { content: { 'application/json': { schema: CreateExpenseBodySchema } }, required: true },
+        body: { content: { 'application/json': { schema: UpdateExpenseBodySchema } }, required: true },
     },
     responses: {
         200: {
@@ -148,7 +149,12 @@ const deleteExpenseRoute = createRoute({
 
 // ─── Handler 実装 ────────────────────────────────────────────────
 
-export function createExpenseRoutes({ tokenService, expenseRepository, createExpenseUseCase }: RouteServices) {
+export function createExpenseRoutes({
+    tokenService,
+    expenseRepository,
+    createExpenseUseCase,
+    updateExpenseUseCase,
+}: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
 
@@ -177,8 +183,9 @@ export function createExpenseRoutes({ tokenService, expenseRepository, createExp
     });
 
     app.openapi(updateExpenseRoute, async (c) => {
-        const { newData } = c.req.valid('json');
-        const expense = await createExpenseUseCase.execute(newData as CreateExpenseInput);
+        const { id } = c.req.valid('param');
+        const { updateData } = c.req.valid('json');
+        const expense = await updateExpenseUseCase.execute(id, updateData as UpdateExpenseInput);
         return c.json({ expense: serializeExpense(expense) }, 200);
     });
 

--- a/apps/web/src/__tests__/actions/expense.test.ts
+++ b/apps/web/src/__tests__/actions/expense.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ApiError } from '../../lib/api/client'
+
+vi.mock('../../lib/api/client', () => ({
+    ApiError: class ApiError extends Error {
+        constructor(public readonly status: number, message: string) {
+            super(message)
+            this.name = 'ApiError'
+        }
+    },
+    serverFetch: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+    revalidatePath: vi.fn(),
+}))
+
+import { createExpenseAction, updateExpenseAction } from '../../lib/actions/expense'
+import { serverFetch } from '../../lib/api/client'
+
+// ─── createExpenseAction ──────────────────────────────────────────
+
+describe('createExpenseAction', () => {
+    const initialState = { error: null, success: false }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('バリデーションエラー: amount が 0 のとき fieldErrors を返す', async () => {
+        const formData = new FormData()
+        formData.set('amount', '0')
+        formData.set('balanceType', '0')
+        formData.set('userId', 'user1')
+        formData.set('date', '2024-01-01')
+
+        const result = await createExpenseAction(initialState, formData)
+
+        expect(result.fieldErrors?.amount).toBeDefined()
+        expect(serverFetch).not.toHaveBeenCalled()
+    })
+
+    it('バリデーションエラー: date が空のとき fieldErrors を返す', async () => {
+        const formData = new FormData()
+        formData.set('amount', '1000')
+        formData.set('balanceType', '0')
+        formData.set('userId', 'user1')
+        formData.set('date', '')
+
+        const result = await createExpenseAction(initialState, formData)
+
+        expect(result.fieldErrors?.date).toBeDefined()
+        expect(serverFetch).not.toHaveBeenCalled()
+    })
+
+    it('正常系: 有効なデータで支出を登録し success を返す', async () => {
+        vi.mocked(serverFetch).mockResolvedValue({})
+
+        const formData = new FormData()
+        formData.set('amount', '1000')
+        formData.set('balanceType', '0')
+        formData.set('userId', 'user1')
+        formData.set('date', '2024-01-01')
+
+        const result = await createExpenseAction(initialState, formData)
+
+        expect(result.success).toBe(true)
+        expect(result.error).toBeNull()
+    })
+
+    it('API が 403 を返すとき認証エラーメッセージを返す', async () => {
+        vi.mocked(serverFetch).mockRejectedValue(new ApiError(403, 'Forbidden'))
+
+        const formData = new FormData()
+        formData.set('amount', '1000')
+        formData.set('balanceType', '0')
+        formData.set('userId', 'user1')
+        formData.set('date', '2024-01-01')
+
+        const result = await createExpenseAction(initialState, formData)
+
+        expect(result.error).toBe('認証が必要です')
+        expect(result.success).toBe(false)
+    })
+})
+
+// ─── updateExpenseAction ──────────────────────────────────────────
+
+describe('updateExpenseAction', () => {
+    const initialState = { error: null, success: false }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('バリデーションエラー: amount が 0 のとき fieldErrors を返す', async () => {
+        const formData = new FormData()
+        formData.set('amount', '0')
+        formData.set('balanceType', '0')
+        formData.set('date', '2024-01-01')
+
+        const result = await updateExpenseAction('expense-01', initialState, formData)
+
+        expect(result.fieldErrors?.amount).toBeDefined()
+        expect(serverFetch).not.toHaveBeenCalled()
+    })
+
+    it('バリデーションエラー: date が空のとき fieldErrors を返す', async () => {
+        const formData = new FormData()
+        formData.set('amount', '1000')
+        formData.set('balanceType', '0')
+        formData.set('date', '')
+
+        const result = await updateExpenseAction('expense-01', initialState, formData)
+
+        expect(result.fieldErrors?.date).toBeDefined()
+        expect(serverFetch).not.toHaveBeenCalled()
+    })
+
+    it('正常系: 有効なデータで支出を更新し success を返す', async () => {
+        vi.mocked(serverFetch).mockResolvedValue({})
+
+        const formData = new FormData()
+        formData.set('amount', '2000')
+        formData.set('balanceType', '0')
+        formData.set('date', '2024-02-01')
+
+        const result = await updateExpenseAction('expense-01', initialState, formData)
+
+        expect(result.success).toBe(true)
+        expect(result.error).toBeNull()
+        expect(serverFetch).toHaveBeenCalledWith(
+            '/api/expense/expense-01',
+            expect.objectContaining({ method: 'PUT' }),
+        )
+    })
+
+    it('API が 403 を返すとき認証エラーメッセージを返す', async () => {
+        vi.mocked(serverFetch).mockRejectedValue(new ApiError(403, 'Forbidden'))
+
+        const formData = new FormData()
+        formData.set('amount', '2000')
+        formData.set('balanceType', '0')
+        formData.set('date', '2024-02-01')
+
+        const result = await updateExpenseAction('expense-01', initialState, formData)
+
+        expect(result.error).toBe('認証が必要です')
+        expect(result.success).toBe(false)
+    })
+
+    it('API が 404 を返すとき「見つかりません」メッセージを返す', async () => {
+        vi.mocked(serverFetch).mockRejectedValue(new ApiError(404, 'Not Found'))
+
+        const formData = new FormData()
+        formData.set('amount', '2000')
+        formData.set('balanceType', '0')
+        formData.set('date', '2024-02-01')
+
+        const result = await updateExpenseAction('expense-01', initialState, formData)
+
+        expect(result.error).toBe('支出が見つかりません')
+        expect(result.success).toBe(false)
+    })
+})

--- a/apps/web/src/components/expense/ExpenseEditModal.tsx
+++ b/apps/web/src/components/expense/ExpenseEditModal.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { X } from "lucide-react";
+import { updateExpenseAction } from "@/lib/actions/expense";
+import type { UpdateExpenseActionState } from "@/lib/actions/expense";
+import type { ExpenseResponse } from "@/lib/api/types";
+
+type Props = {
+  expense: ExpenseResponse;
+  onClose: () => void;
+};
+
+const initialState: UpdateExpenseActionState = { error: null, success: false };
+
+export function ExpenseEditModal({ expense, onClose }: Props) {
+  const boundAction = updateExpenseAction.bind(null, expense.id);
+  const [state, formAction, isPending] = useActionState(boundAction, initialState);
+
+  // 更新成功時にモーダルを閉じる
+  useEffect(() => {
+    if (state.success) {
+      onClose();
+    }
+  }, [state.success, onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+      onClick={onClose}
+    >
+      <div
+        className="relative w-full max-w-sm rounded-2xl bg-white p-6 shadow-xl"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="閉じる"
+          className="absolute right-4 top-4 flex h-7 w-7 items-center justify-center rounded-full text-[#1c1410]/40 hover:bg-[#f5ebe0] hover:text-[#1c1410]"
+        >
+          <X size={16} />
+        </button>
+
+        <h2 className="mb-5 text-base font-bold text-[#1c1410]">支出を編集</h2>
+
+        <form action={formAction} className="flex flex-col gap-4">
+          {/* 種別 */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-bold text-[#1c1410]/60">種別</label>
+            <select
+              name="balanceType"
+              defaultValue={String(expense.balanceType)}
+              className="rounded-xl border border-[#e8c8b0] bg-[#fdf8f5] px-3 py-2 text-sm text-[#1c1410] focus:outline-none focus:ring-2 focus:ring-[#c8956c]"
+            >
+              <option value="0">支出</option>
+              <option value="1">収入</option>
+            </select>
+            {state.fieldErrors?.balanceType && (
+              <p className="text-xs text-red-500">{state.fieldErrors.balanceType[0]}</p>
+            )}
+          </div>
+
+          {/* 金額 */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-bold text-[#1c1410]/60">金額（円）</label>
+            <input
+              type="number"
+              name="amount"
+              defaultValue={expense.amount}
+              min={1}
+              className="rounded-xl border border-[#e8c8b0] bg-[#fdf8f5] px-3 py-2 text-sm text-[#1c1410] focus:outline-none focus:ring-2 focus:ring-[#c8956c]"
+            />
+            {state.fieldErrors?.amount && (
+              <p className="text-xs text-red-500">{state.fieldErrors.amount[0]}</p>
+            )}
+          </div>
+
+          {/* 日付 */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-bold text-[#1c1410]/60">日付</label>
+            <input
+              type="date"
+              name="date"
+              defaultValue={expense.date}
+              className="rounded-xl border border-[#e8c8b0] bg-[#fdf8f5] px-3 py-2 text-sm text-[#1c1410] focus:outline-none focus:ring-2 focus:ring-[#c8956c]"
+            />
+            {state.fieldErrors?.date && (
+              <p className="text-xs text-red-500">{state.fieldErrors.date[0]}</p>
+            )}
+          </div>
+
+          {/* 備考 */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-bold text-[#1c1410]/60">備考（任意）</label>
+            <input
+              type="text"
+              name="content"
+              defaultValue={expense.content ?? ""}
+              className="rounded-xl border border-[#e8c8b0] bg-[#fdf8f5] px-3 py-2 text-sm text-[#1c1410] focus:outline-none focus:ring-2 focus:ring-[#c8956c]"
+            />
+          </div>
+
+          {state.error && (
+            <p className="text-xs text-red-500">{state.error}</p>
+          )}
+
+          <button
+            type="submit"
+            disabled={isPending}
+            className="mt-1 w-full rounded-xl bg-[#c8956c] py-2.5 text-sm font-bold text-white transition-opacity hover:opacity-80 disabled:opacity-50"
+          >
+            {isPending ? "更新中..." : "更新する"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/expense/ExpenseList.tsx
+++ b/apps/web/src/components/expense/ExpenseList.tsx
@@ -1,12 +1,18 @@
+"use client";
+
+import { useState } from "react";
 import { deleteExpenseAction } from "@/lib/actions/expense";
 import type { ExpenseResponse } from "@/lib/api/types";
-import { X } from "lucide-react";
+import { Pencil, X } from "lucide-react";
+import { ExpenseEditModal } from "./ExpenseEditModal";
 
 type Props = {
   expenses: ExpenseResponse[];
 };
 
 export function ExpenseList({ expenses }: Props) {
+  const [editTarget, setEditTarget] = useState<ExpenseResponse | null>(null);
+
   if (expenses.length === 0) {
     return (
       <p className="py-12 text-center text-sm font-medium text-[#1c1410]/40">
@@ -16,50 +22,67 @@ export function ExpenseList({ expenses }: Props) {
   }
 
   return (
-    <ul className="divide-y divide-[#e8c8b0]">
-      {expenses.map((expense) => {
-        const isOutgo = expense.balanceType === 0;
-        const deleteAction = deleteExpenseAction.bind(null, expense.id);
-        return (
-          <li key={expense.id} className="flex items-center justify-between gap-4 py-3">
-            <div className="flex flex-col gap-0.5">
-              <span className="text-xs font-bold text-[#1c1410]/40">
-                {expense.date}
-              </span>
-              {expense.content && (
-                <span className="text-sm font-medium text-[#1c1410]">
-                  {expense.content}
+    <>
+      <ul className="divide-y divide-[#e8c8b0]">
+        {expenses.map((expense) => {
+          const isOutgo = expense.balanceType === 0;
+          const deleteAction = deleteExpenseAction.bind(null, expense.id);
+          return (
+            <li key={expense.id} className="flex items-center justify-between gap-4 py-3">
+              <div className="flex flex-col gap-0.5">
+                <span className="text-xs font-bold text-[#1c1410]/40">
+                  {expense.date}
                 </span>
-              )}
-            </div>
-            <div className="flex items-center gap-3">
-              <div className="flex flex-col items-end gap-0.5">
-                <span
-                  className="text-xs font-bold"
-                  style={{ color: isOutgo ? "var(--color-expense)" : "var(--color-income)" }}
-                >
-                  {isOutgo ? "支出" : "収入"}
-                </span>
-                <span
-                  className="text-base font-extrabold tabular-nums"
-                  style={{ color: isOutgo ? "var(--color-expense)" : "var(--color-income)" }}
-                >
-                  {isOutgo ? "-" : "+"}¥{expense.amount.toLocaleString()}
-                </span>
+                {expense.content && (
+                  <span className="text-sm font-medium text-[#1c1410]">
+                    {expense.content}
+                  </span>
+                )}
               </div>
-              <form action={deleteAction}>
+              <div className="flex items-center gap-3">
+                <div className="flex flex-col items-end gap-0.5">
+                  <span
+                    className="text-xs font-bold"
+                    style={{ color: isOutgo ? "var(--color-expense)" : "var(--color-income)" }}
+                  >
+                    {isOutgo ? "支出" : "収入"}
+                  </span>
+                  <span
+                    className="text-base font-extrabold tabular-nums"
+                    style={{ color: isOutgo ? "var(--color-expense)" : "var(--color-income)" }}
+                  >
+                    {isOutgo ? "-" : "+"}¥{expense.amount.toLocaleString()}
+                  </span>
+                </div>
                 <button
-                  type="submit"
-                  aria-label="削除"
-                  className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f87171] hover:bg-[#fee2e2] hover:text-[#f87171]"
+                  type="button"
+                  aria-label="編集"
+                  onClick={() => setEditTarget(expense)}
+                  className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#c8956c] hover:bg-[#fdf8f5] hover:text-[#c8956c]"
                 >
-                  <X size={12} />
+                  <Pencil size={12} />
                 </button>
-              </form>
-            </div>
-          </li>
-        );
-      })}
-    </ul>
+                <form action={deleteAction}>
+                  <button
+                    type="submit"
+                    aria-label="削除"
+                    className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f87171] hover:bg-[#fee2e2] hover:text-[#f87171]"
+                  >
+                    <X size={12} />
+                  </button>
+                </form>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+
+      {editTarget && (
+        <ExpenseEditModal
+          expense={editTarget}
+          onClose={() => setEditTarget(null)}
+        />
+      )}
+    </>
   );
 }

--- a/apps/web/src/lib/actions/expense.ts
+++ b/apps/web/src/lib/actions/expense.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { serverFetch, ApiError } from "../api/client";
-import { createExpenseSchema } from "@budget/common";
+import { createExpenseSchema, updateExpenseSchema } from "@budget/common";
 import type { GetExpenseResponse } from "../api/types";
 
 export type ExpenseFieldErrors = {
@@ -52,6 +52,59 @@ export async function createExpenseAction(
   }
 
   // ホームページの XDayDisplay も再計算するため "/" も revalidate する
+  revalidatePath("/");
+  revalidatePath("/expenses");
+  return { error: null, success: true };
+}
+
+export type UpdateExpenseFieldErrors = {
+  amount?: string[];
+  balanceType?: string[];
+  date?: string[];
+};
+
+export type UpdateExpenseActionState = {
+  error: string | null;
+  fieldErrors?: UpdateExpenseFieldErrors;
+  success: boolean;
+};
+
+/** 支出を更新する Server Action */
+export async function updateExpenseAction(
+  id: string,
+  _prev: UpdateExpenseActionState,
+  formData: FormData,
+): Promise<UpdateExpenseActionState> {
+  const raw = {
+    amount: Number(formData.get("amount")),
+    balanceType: Number(formData.get("balanceType")) as 0 | 1,
+    date: String(formData.get("date") ?? ""),
+    content: formData.get("content") ? String(formData.get("content")) : null,
+  };
+
+  const result = updateExpenseSchema.safeParse(raw);
+  if (!result.success) {
+    const fieldErrors = result.error.flatten().fieldErrors as UpdateExpenseFieldErrors;
+    return { error: null, fieldErrors, success: false };
+  }
+
+  try {
+    await serverFetch<GetExpenseResponse>(`/api/expense/${id}`, {
+      method: "PUT",
+      body: JSON.stringify({ updateData: result.data }),
+    });
+  } catch (err) {
+    if (err instanceof ApiError) {
+      if (err.status === 403) {
+        return { error: "認証が必要です", success: false };
+      }
+      if (err.status === 404) {
+        return { error: "支出が見つかりません", success: false };
+      }
+    }
+    return { error: "支出の更新に失敗しました", success: false };
+  }
+
   revalidatePath("/");
   revalidatePath("/expenses");
   return { error: null, success: true };

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -214,6 +214,44 @@ components:
           description: 支出データ
       required:
         - newData
+    UpdateExpenseBody:
+      type: object
+      properties:
+        updateData:
+          type: object
+          properties:
+            amount:
+              type: integer
+              minimum: 1
+              description: 金額（円）
+              example: 1500
+            balanceType:
+              anyOf:
+                - type: number
+                  enum:
+                    - 0
+                - type: number
+                  enum:
+                    - 1
+              description: "収支区分: 0=支出, 1=収入"
+              example: 0
+            date:
+              type: string
+              minLength: 1
+              description: 日付 (YYYY-MM-DD)
+              example: 2024-03-15
+            content:
+              type: string
+              nullable: true
+              description: 備考
+              example: 昼食代
+          required:
+            - amount
+            - balanceType
+            - date
+          description: 更新データ
+      required:
+        - updateData
     BudgetResponse:
       type: object
       properties:
@@ -896,7 +934,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateExpenseBody"
+              $ref: "#/components/schemas/UpdateExpenseBody"
       responses:
         "200":
           description: 更新成功

--- a/packages/common/src/schemas/expense.ts
+++ b/packages/common/src/schemas/expense.ts
@@ -14,3 +14,17 @@ export const createExpenseSchema = z.object({
 })
 
 export type CreateExpenseSchema = z.infer<typeof createExpenseSchema>
+
+export const updateExpenseSchema = z.object({
+  amount: z
+    .number({ invalid_type_error: '金額は数値で入力してください' })
+    .int('金額は整数で入力してください')
+    .min(1, '金額は1以上の値を入力してください'),
+  balanceType: z.union([z.literal(0), z.literal(1)], {
+    errorMap: () => ({ message: '種別を選択してください' }),
+  }),
+  date: z.string().min(1, '日付を入力してください'),
+  content: z.string().nullable().optional(),
+})
+
+export type UpdateExpenseSchema = z.infer<typeof updateExpenseSchema>

--- a/packages/common/src/types/expense.ts
+++ b/packages/common/src/types/expense.ts
@@ -32,3 +32,12 @@ export interface CreateExpenseInput {
     content?: string | null
     date: string
 }
+
+/** UpdateExpenseUseCase への入力 DTO */
+export interface UpdateExpenseInput {
+    amount: number
+    balanceType: BalanceType
+    categoryId?: number
+    content?: string | null
+    date: string
+}


### PR DESCRIPTION
## Summary

- `UpdateExpenseUseCase` を新規作成し、`updateExpenseRoute` の壊れたハンドラを修正（`createExpenseUseCase` の誤呼び出しを解消）
- `UpdateExpenseBodySchema` を OpenAPI スキーマに追加し、`PUT /expense/{id}` の入力型を `CreateExpenseBodySchema` から分離
- `updateExpenseAction` Server Action を追加し、フロントエンドから PUT リクエストを送信できるようにした
- `ExpenseEditModal` コンポーネントを新規作成し、`ExpenseList` に編集ボタン + モーダルを統合

## Test plan

- [x] `UpdateExpenseUseCase` 単体テスト（6件）: 正常系 / 存在しない ID / リポジトリ例外
- [x] `updateExpenseAction` テスト（5件）: バリデーションエラー / 正常系 / API エラー（403, 404）
- [x] `createExpenseAction` テスト（4件）: 既存アクションのカバレッジ追加
- [x] 全 unit テスト 59件パス（web）/ 13件パス（common）

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)