### PR TITLE
chore: スクラムボード自動同期 GitHub Actions ワークフローを追加

### DIFF
--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,0 +1,149 @@
+name: Sync Project Board
+
+# ──────────────────────────────────────────────────────────────────
+# スクラムボードの自動ステータス管理
+#
+# トリガーと遷移先:
+#   Issue opened          → Status: Backlog（プロジェクトへ自動追加）
+#   PR opened/reopened    → リンク Issue の Status: In Review
+#   PR closed (not merged)→ リンク Issue の Status: Sprint Backlog（差し戻し）
+#   PR merged             → リンク Issue の Status: Done
+#
+# 必要なシークレット:
+#   PROJECT_TOKEN: project スコープを持つ Personal Access Token (classic)
+#   Settings → Secrets and variables → Actions → New repository secret
+# ──────────────────────────────────────────────────────────────────
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened, reopened, ready_for_review, closed]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          PROJECT_ID: "PVT_kwHOA-qlQM4BWtuo"
+          STATUS_FIELD_ID: "PVTSSF_lAHOA-qlQM4BWtuozhR_pd4"
+          # Status 選択肢 ID（GitHub Project の Settings → Fields → Status で確認可能）
+          STATUS_BACKLOG: "59fe9f7b"
+          STATUS_SPRINT_BACKLOG: "54a6b3ab"
+          STATUS_IN_REVIEW: "4935d554"
+          STATUS_DONE: "5a3dd530"
+        with:
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          script: |
+            const projectId    = process.env.PROJECT_ID;
+            const fieldId      = process.env.STATUS_FIELD_ID;
+            const OPT_BACKLOG        = process.env.STATUS_BACKLOG;
+            const OPT_SPRINT_BACKLOG = process.env.STATUS_SPRINT_BACKLOG;
+            const OPT_IN_REVIEW      = process.env.STATUS_IN_REVIEW;
+            const OPT_DONE           = process.env.STATUS_DONE;
+
+            // ── ヘルパー: Issue を Project に追加し、アイテム ID を返す ──────────
+            async function addIssueToProject(issueNodeId) {
+              const res = await github.graphql(`
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                    item { id }
+                  }
+                }`, { projectId, contentId: issueNodeId });
+              return res.addProjectV2ItemById.item.id;
+            }
+
+            // ── ヘルパー: Project 内の Issue アイテム ID を検索 ──────────────────
+            async function findProjectItemId(issueNumber) {
+              const res = await github.graphql(`
+                query($projectId: ID!) {
+                  node(id: $projectId) {
+                    ... on ProjectV2 {
+                      items(first: 100) {
+                        nodes {
+                          id
+                          content {
+                            ... on Issue { number }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }`, { projectId });
+              const item = res.node.items.nodes.find(
+                n => n.content?.number === issueNumber
+              );
+              return item?.id ?? null;
+            }
+
+            // ── ヘルパー: Status を更新 ──────────────────────────────────────────
+            async function setStatus(itemId, optionId) {
+              await github.graphql(`
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) { projectV2Item { id } }
+                }`, { projectId, itemId, fieldId, optionId });
+            }
+
+            // ── ヘルパー: PR body からリンク Issue 番号を抽出 ───────────────────
+            function extractLinkedIssues(body) {
+              if (!body) return [];
+              const pattern = /(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+              const numbers = [];
+              let match;
+              while ((match = pattern.exec(body)) !== null) {
+                numbers.push(parseInt(match[1], 10));
+              }
+              return [...new Set(numbers)];
+            }
+
+            // ── Issue opened: プロジェクトに追加して Backlog に設定 ──────────────
+            if (context.eventName === 'issues' && context.payload.action === 'opened') {
+              const issue = context.payload.issue;
+              console.log(`Issue #${issue.number} opened → adding to project as Backlog`);
+              const itemId = await addIssueToProject(issue.node_id);
+              await setStatus(itemId, OPT_BACKLOG);
+              console.log(`#${issue.number} → Backlog`);
+            }
+
+            // ── PR opened/reopened/ready_for_review: リンク Issue → In Review ───
+            if (
+              context.eventName === 'pull_request' &&
+              ['opened', 'reopened', 'ready_for_review'].includes(context.payload.action)
+            ) {
+              const pr = context.payload.pull_request;
+              const issues = extractLinkedIssues(pr.body);
+              console.log(`PR #${pr.number} opened → linked issues: ${issues}`);
+              for (const num of issues) {
+                const itemId = await findProjectItemId(num);
+                if (itemId) {
+                  await setStatus(itemId, OPT_IN_REVIEW);
+                  console.log(`#${num} → In Review`);
+                } else {
+                  console.log(`#${num} not found in project, skipping`);
+                }
+              }
+            }
+
+            // ── PR closed: マージ → Done、差し戻し → Sprint Backlog ─────────────
+            if (context.eventName === 'pull_request' && context.payload.action === 'closed') {
+              const pr = context.payload.pull_request;
+              const merged = pr.merged;
+              const issues = extractLinkedIssues(pr.body);
+              const targetOption = merged ? OPT_DONE : OPT_SPRINT_BACKLOG;
+              const label = merged ? 'Done' : 'Sprint Backlog (reverted)';
+              console.log(`PR #${pr.number} closed (merged=${merged}) → linked issues: ${issues}`);
+              for (const num of issues) {
+                const itemId = await findProjectItemId(num);
+                if (itemId) {
+                  await setStatus(itemId, targetOption);
+                  console.log(`#${num} → ${label}`);
+                }
+              }
+            }


### PR DESCRIPTION
## Summary

- Issue/PR のライフサイクルに応じて Project Board の Status を自動更新する GitHub Actions ワークフローを追加
- PR body の `Closes #NNN` キーワードでリンクされた Issue を自動検出して Status を移動

## 自動遷移ルール

| トリガー | 遷移先 |
|---------|--------|
| Issue opened | Backlog（プロジェクトへ自動追加） |
| PR opened / reopened | リンク Issue → In Review |
| PR merged | リンク Issue → Done |
| PR closed（マージなし） | リンク Issue → Sprint Backlog（差し戻し） |

## 有効化に必要な手順（1回のみ）

`project` スコープの PAT を `PROJECT_TOKEN` シークレットとして登録する必要があります。

1. https://github.com/settings/tokens → Generate new token (classic)
2. スコープ: `project` にチェック
3. Settings → Secrets and variables → Actions → New repository secret
   - Name: `PROJECT_TOKEN`
   - Value: 発行したトークン

🤖 Generated with [Claude Code](https://claude.com/claude-code)