### PR TITLE
feature: モバイル向けボトムナビゲーションバーを実装する

### DIFF
--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getExpenses } from "@/lib/api/expense";
 import { ApiError } from "@/lib/api/client";
-import { Header } from "@/components/layout/Header";
+import { AppShell } from "@/components/layout/AppShell";
 import { TodayReport } from "@/components/report/TodayReport";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
 import { MonthlyCalendar } from "@/components/calendar/MonthlyCalendar";
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
   title: "カレンダー | 家計管理",
 };
 
-async function CalendarContent() {
+async function CalendarContent({ userId }: { userId: string }) {
   let expenses;
   try {
     const data = await getExpenses();
@@ -25,31 +25,28 @@ async function CalendarContent() {
     throw err;
   }
 
+  return (
+    <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 bg-[#fffdf5]">
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_3fr]">
+        {/* 左カラム：今日のレポート + 入力フォーム */}
+        <div className="flex flex-col gap-4">
+          <TodayReport expenses={expenses} />
+          <ExpenseCreateForm userId={userId} />
+        </div>
+
+        {/* 右カラム：月次カレンダー */}
+        <MonthlyCalendar expenses={expenses} />
+      </div>
+    </main>
+  );
+}
+
+export default async function CalendarPage() {
   const cookieStore = await cookies();
   const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
   return (
-    <>
-      <Header userName={userId} />
-      <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 bg-[#fffdf5]">
-        <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_3fr]">
-          {/* 左カラム：今日のレポート + 入力フォーム */}
-          <div className="flex flex-col gap-4">
-            <TodayReport expenses={expenses} />
-            <ExpenseCreateForm userId={userId} />
-          </div>
-
-          {/* 右カラム：月次カレンダー */}
-          <MonthlyCalendar expenses={expenses} />
-        </div>
-      </main>
-    </>
-  );
-}
-
-export default function CalendarPage() {
-  return (
-    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
+    <AppShell userName={userId}>
       <Suspense
         fallback={
           <div className="flex flex-1 items-center justify-center text-sm font-medium text-[#1c1410]/40">
@@ -57,8 +54,8 @@ export default function CalendarPage() {
           </div>
         }
       >
-        <CalendarContent />
+        <CalendarContent userId={userId} />
       </Suspense>
-    </div>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/expenses/new/page.tsx
+++ b/apps/web/src/app/expenses/new/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
-import { Header } from "@/components/layout/Header";
+import { AppShell } from "@/components/layout/AppShell";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
 
 export const metadata: Metadata = {
@@ -22,11 +22,10 @@ export default async function ExpenseNewPage({ searchParams }: Props) {
   const defaultDate = date && /^\d{4}-\d{2}-\d{2}$/.test(date) ? date : undefined;
 
   return (
-    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
-      <Header userName={userId} />
+    <AppShell userName={userId}>
       <main className="mx-auto w-full max-w-lg flex-1 px-4 py-8">
         <ExpenseCreateForm userId={userId} defaultDate={defaultDate} />
       </main>
-    </div>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/expenses/page.tsx
+++ b/apps/web/src/app/expenses/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { getExpenses } from "@/lib/api/expense";
 import { ExpenseList } from "@/components/expense/ExpenseList";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
-import { Header } from "@/components/layout/Header";
+import { AppShell } from "@/components/layout/AppShell";
 import { ApiError } from "@/lib/api/client";
 import { redirect } from "next/navigation";
 
@@ -71,8 +71,7 @@ export default async function ExpensesPage() {
   const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
   return (
-    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
-      <Header userName={userId} />
+    <AppShell userName={userId}>
       <div className="mx-auto w-full max-w-2xl flex-1 px-4 py-8">
         <h1 className="mb-6 text-2xl font-extrabold text-[#1c1410]">支出一覧</h1>
 
@@ -90,7 +89,7 @@ export default async function ExpensesPage() {
         <ExpenseListSection />
       </Suspense>
       </div>
-    </div>
+    </AppShell>
   );
 
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getExpenses } from "@/lib/api/expense";
 import { ApiError } from "@/lib/api/client";
-import { Header } from "@/components/layout/Header";
+import { AppShell } from "@/components/layout/AppShell";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
 import { XDayDisplay } from "@/components/dashboard/XDayDisplay";
 import { MonthlyOverviewCard } from "@/components/dashboard/MonthlyOverviewCard";
@@ -51,7 +51,7 @@ function computeXDayInputs(expenses: { balanceType: number; amount: number; date
   return { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays };
 }
 
-async function DashboardContent() {
+async function DashboardContent({ userId }: { userId: string }) {
   let expenses;
   try {
     const data = await getExpenses();
@@ -63,56 +63,53 @@ async function DashboardContent() {
     throw err;
   }
 
-  const cookieStore = await cookies();
-  const userId = cookieStore.get("user_id")?.value ?? "Guest";
-
   const { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays } =
     computeXDayInputs(expenses);
 
   return (
-    <>
-      <Header userName={userId} />
-      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-4 bg-[#fffdf5]">
-        {/*
-          Mobile (default): stacked single column
-            1. 今月の収支サマリー（現状把握）
-            2. クイック入力（スクロールなしで操作可能）
-            3. 家計の寿命（中心指標）
-            4. 最近の記録5件
+    <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-4 bg-[#fffdf5]">
+      {/*
+        Mobile (default): stacked single column
+          1. 今月の収支サマリー（現状把握）
+          2. クイック入力（スクロールなしで操作可能）
+          3. 家計の寿命（中心指標）
+          4. 最近の記録5件
 
-          Desktop (lg): 2-column
-            Left: 今月の収支 + 家計の寿命
-            Right: クイック入力 + 最近の記録
-        */}
-        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
-          {/* 左カラム（desktop）/ 先頭2カード（mobile） */}
-          <div className="flex flex-col gap-4">
-            <MonthlyOverviewCard expenses={expenses} />
-            <div className="lg:block">
-              <XDayDisplay
-                todayExpense={todayExpense}
-                yesterdayExpense={yesterdayExpense}
-                zeroStreakDays={zeroStreakDays}
-                avgDailyExpense={avgDailyExpense}
-                recordedDays={recordedDays}
-              />
-            </div>
-          </div>
-
-          {/* 右カラム（desktop）/ 後続2カード（mobile） */}
-          <div className="flex flex-col gap-4">
-            <ExpenseCreateForm userId={userId} />
-            <RecentExpenseList expenses={expenses} />
+        Desktop (lg): 2-column
+          Left: 今月の収支 + 家計の寿命
+          Right: クイック入力 + 最近の記録
+      */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
+        {/* 左カラム（desktop）/ 先頭2カード（mobile） */}
+        <div className="flex flex-col gap-4">
+          <MonthlyOverviewCard expenses={expenses} />
+          <div className="lg:block">
+            <XDayDisplay
+              todayExpense={todayExpense}
+              yesterdayExpense={yesterdayExpense}
+              zeroStreakDays={zeroStreakDays}
+              avgDailyExpense={avgDailyExpense}
+              recordedDays={recordedDays}
+            />
           </div>
         </div>
-      </main>
-    </>
+
+        {/* 右カラム（desktop）/ 後続2カード（mobile） */}
+        <div className="flex flex-col gap-4">
+          <ExpenseCreateForm userId={userId} />
+          <RecentExpenseList expenses={expenses} />
+        </div>
+      </div>
+    </main>
   );
 }
 
-export default function HomePage() {
+export default async function HomePage() {
+  const cookieStore = await cookies();
+  const userId = cookieStore.get("user_id")?.value ?? "Guest";
+
   return (
-    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
+    <AppShell userName={userId}>
       <Suspense
         fallback={
           <div className="flex flex-1 items-center justify-center text-sm font-medium text-[#1c1410]/40">
@@ -120,8 +117,8 @@ export default function HomePage() {
           </div>
         }
       >
-        <DashboardContent />
+        <DashboardContent userId={userId} />
       </Suspense>
-    </div>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/report/page.tsx
+++ b/apps/web/src/app/report/page.tsx
@@ -6,7 +6,7 @@ import { getBudgets } from "@/lib/api/budget";
 import { deleteBudgetAction } from "@/lib/actions/budget";
 import { getCategoryById, OUTGO_CATEGORIES } from "@/lib/constants/categories";
 import { PeriodSelector } from "@/components/report/PeriodSelector";
-import { Header } from "@/components/layout/Header";
+import { AppShell } from "@/components/layout/AppShell";
 import type { BudgetResponse } from "@/lib/api/budget";
 
 export const metadata: Metadata = {
@@ -254,8 +254,7 @@ export default async function ReportPage({
   const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
   return (
-    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
-      <Header userName={userId} />
+    <AppShell userName={userId}>
       <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-2xl font-extrabold text-[#1c1410]">
@@ -278,6 +277,6 @@ export default async function ReportPage({
           <ReportSection period={period} />
         </Suspense>
       </main>
-    </div>
+    </AppShell>
   );
 }

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { DataExportSection } from "@/components/settings/DataExportSection";
-import { Header } from "@/components/layout/Header";
+import { AppShell } from "@/components/layout/AppShell";
 import { cookies } from "next/headers";
 
 export const metadata: Metadata = { title: "設定 | 家計管理" };
@@ -10,12 +10,11 @@ export default async function SettingsPage() {
     const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
     return (
-        <div className="flex min-h-screen flex-col bg-[#fffdf5]">
-            <Header userName={userId} />
+        <AppShell userName={userId}>
             <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
                 <h1 className="mb-6 text-2xl font-extrabold text-[#1c1410]">設定</h1>
                 <DataExportSection />
             </main>
-        </div>
+        </AppShell>
     );
 }

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -1,0 +1,23 @@
+import { Header } from "./Header";
+import { BottomNav } from "./BottomNav";
+
+type Props = {
+  userName?: string;
+  children: React.ReactNode;
+};
+
+/**
+ * 認証済みページ共通ラッパー
+ * - デスクトップ: トップヘッダー
+ * - モバイル: ボトムナビゲーション + コンテンツ下部パディング
+ */
+export function AppShell({ userName, children }: Props) {
+  return (
+    <div className="flex min-h-screen flex-col bg-[#fffdf5]">
+      <Header userName={userName} />
+      {/* モバイルのボトムナビ分の余白 */}
+      <div className="flex-1 pb-16 md:pb-0">{children}</div>
+      <BottomNav />
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Calendar, BarChart2, Settings, Plus, X } from "lucide-react";
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+type NavItem = {
+  label: string;
+  href: string;
+  icon: React.ElementType;
+};
+
+const NAV_ITEMS: NavItem[] = [
+  { label: "ホーム", href: "/", icon: Home },
+  { label: "カレンダー", href: "/calendar", icon: Calendar },
+  { label: "レポート", href: "/report", icon: BarChart2 },
+  { label: "設定", href: "/settings", icon: Settings },
+];
+
+export function BottomNav() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [fabOpen, setFabOpen] = useState(false);
+
+  const isActive = (href: string) =>
+    href === "/" ? pathname === "/" : pathname.startsWith(href);
+
+  // ナビ項目を中央のFABで2つに分割
+  const leftItems = NAV_ITEMS.slice(0, 2);
+  const rightItems = NAV_ITEMS.slice(2);
+
+  function handleFabSelect(type: "expense" | "income") {
+    setFabOpen(false);
+    router.push(`/expenses/new?type=${type}`);
+  }
+
+  return (
+    <>
+      {/* FAB展開時のオーバーレイ */}
+      {fabOpen && (
+        <div
+          className="fixed inset-0 z-30 bg-[#1c1410]/50"
+          onClick={() => setFabOpen(false)}
+        >
+          {/* 選択メニュー */}
+          <div
+            className="absolute bottom-24 left-1/2 flex -translate-x-1/2 flex-col items-center gap-3"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              onClick={() => handleFabSelect("income")}
+              className="rounded-2xl px-8 py-3 text-sm font-bold text-white shadow-lg transition-transform active:scale-95"
+              style={{ background: "var(--color-income, #4caf82)" }}
+            >
+              収入を記録
+            </button>
+            <button
+              type="button"
+              onClick={() => handleFabSelect("expense")}
+              className="rounded-2xl px-8 py-3 text-sm font-bold text-white shadow-lg transition-transform active:scale-95"
+              style={{ background: "var(--color-expense, #e05c5c)" }}
+            >
+              支出を記録
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* ボトムナビゲーションバー（モバイルのみ表示） */}
+      <nav
+        className="fixed bottom-0 left-0 right-0 z-40 flex items-center border-t border-[#1c1410]/10 bg-white md:hidden"
+        style={{ height: 64, paddingBottom: "env(safe-area-inset-bottom, 0px)" }}
+        aria-label="メインナビゲーション"
+      >
+        {/* 左2項目 */}
+        {leftItems.map((item) => (
+          <BottomNavItem
+            key={item.href}
+            item={item}
+            active={isActive(item.href)}
+          />
+        ))}
+
+        {/* 中央FABボタン */}
+        <div className="flex flex-1 items-center justify-center">
+          <button
+            type="button"
+            aria-label={fabOpen ? "メニューを閉じる" : "記録する"}
+            aria-expanded={fabOpen}
+            onClick={() => setFabOpen(!fabOpen)}
+            className="relative -top-3 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
+            style={{
+              background: "var(--color-brand-primary, #f08030)",
+              boxShadow: "0 4px 16px rgba(240,128,48,0.4)",
+            }}
+          >
+            {fabOpen ? (
+              <X size={22} className="text-white" />
+            ) : (
+              <Plus size={22} className="text-white" />
+            )}
+          </button>
+        </div>
+
+        {/* 右2項目 */}
+        {rightItems.map((item) => (
+          <BottomNavItem
+            key={item.href}
+            item={item}
+            active={isActive(item.href)}
+          />
+        ))}
+      </nav>
+    </>
+  );
+}
+
+function BottomNavItem({
+  item,
+  active,
+}: {
+  item: NavItem;
+  active: boolean;
+}) {
+  const Icon = item.icon;
+  return (
+    <Link
+      href={item.href}
+      className="flex flex-1 flex-col items-center justify-center gap-0.5 py-2 transition-colors"
+      style={{ color: active ? "var(--color-brand-primary, #f08030)" : "rgba(28,20,16,0.4)" }}
+    >
+      <Icon size={22} />
+      <span className="text-[10px] font-semibold">{item.label}</span>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary

- `BottomNav` コンポーネントを新規作成（`md` 未満のみ表示）
  - ホーム / カレンダー / [FAB] / レポート / 設定 の5タブ構成
  - 中央 FAB をタップすると「支出を記録 / 収入を記録」のオーバーレイメニューを表示
  - アクティブタブをブランドカラー（`#f08030`）でハイライト
  - `safe-area-inset-bottom` 対応（iPhone ノッチ等）
- `AppShell` コンポーネントを新規作成（`Header` + `BottomNav` の共通ラッパー）
  - モバイルで `pb-16` を付与してコンテンツがボトムバーに隠れないよう調整
- 全認証済みページ（6ページ）を `AppShell` に切り替え
- home / calendar は `Header` をページレベルに引き上げて Suspense 境界を整理

## Test plan

- [ ] モバイルサイズ（375px）でボトムナビが表示されること
- [ ] デスクトップ（md以上）でボトムナビが非表示になること
- [ ] FABタップで支出/収入メニューが表示され、選択時に `/expenses/new?type=...` へ遷移すること
- [ ] アクティブページのアイコン・ラベルがオレンジ色になること
- [ ] コンテンツがボトムバーに隠れないこと
- [ ] 既存ユニットテスト 59件全件パス（確認済み）

Closes #119

🤖 Generated with [Claude Code](https://claude.ai/claude-code)