### PR TITLE
feature: セッション切れ時のUX改善（returnTo リダイレクト + トースト通知）

### DIFF
--- a/apps/web/src/__tests__/actions/auth.test.ts
+++ b/apps/web/src/__tests__/actions/auth.test.ts
@@ -44,7 +44,7 @@ describe('guestLoginAction', () => {
     it('body なしで /api/guest-login を呼ぶ（credentials は API 側で管理）', async () => {
         vi.mocked(serverFetch).mockResolvedValue(TOKEN_RESPONSE)
 
-        await guestLoginAction()
+        await guestLoginAction(new FormData())
 
         expect(serverFetch).toHaveBeenCalledWith('/api/guest-login', { method: 'POST' })
     })
@@ -52,15 +52,26 @@ describe('guestLoginAction', () => {
     it('ログイン成功後に / へリダイレクトする', async () => {
         vi.mocked(serverFetch).mockResolvedValue(TOKEN_RESPONSE)
 
-        await guestLoginAction()
+        await guestLoginAction(new FormData())
 
         expect(redirect).toHaveBeenCalledWith('/')
+    })
+
+    it('returnTo が / 始まりのとき、そのパスへリダイレクトする', async () => {
+        vi.mocked(serverFetch).mockResolvedValue(TOKEN_RESPONSE)
+
+        const formData = new FormData()
+        formData.set('returnTo', '/report')
+
+        await guestLoginAction(formData)
+
+        expect(redirect).toHaveBeenCalledWith('/report')
     })
 
     it('API エラー時は ApiError をスローする', async () => {
         vi.mocked(serverFetch).mockRejectedValue(new ApiError(500, 'Something broken'))
 
-        await expect(guestLoginAction()).rejects.toBeInstanceOf(ApiError)
+        await expect(guestLoginAction(new FormData())).rejects.toBeInstanceOf(ApiError)
     })
 })
 
@@ -112,6 +123,45 @@ describe('loginAction', () => {
         const formData = new FormData()
         formData.set('userId', 'user1')
         formData.set('password', 'pass')
+
+        await loginAction(initialState, formData)
+
+        expect(redirect).toHaveBeenCalledWith('/')
+    })
+
+    it('returnTo が / 始まりのとき、そのパスへリダイレクトする', async () => {
+        vi.mocked(serverFetch).mockResolvedValue(TOKEN_RESPONSE)
+
+        const formData = new FormData()
+        formData.set('userId', 'user1')
+        formData.set('password', 'pass')
+        formData.set('returnTo', '/expenses')
+
+        await loginAction(initialState, formData)
+
+        expect(redirect).toHaveBeenCalledWith('/expenses')
+    })
+
+    it('returnTo が外部URL（/ 始まりでない）のとき、/ へフォールバックする', async () => {
+        vi.mocked(serverFetch).mockResolvedValue(TOKEN_RESPONSE)
+
+        const formData = new FormData()
+        formData.set('userId', 'user1')
+        formData.set('password', 'pass')
+        formData.set('returnTo', 'https://evil.example.com/phishing')
+
+        await loginAction(initialState, formData)
+
+        expect(redirect).toHaveBeenCalledWith('/')
+    })
+
+    it('returnTo が空のとき、/ へリダイレクトする', async () => {
+        vi.mocked(serverFetch).mockResolvedValue(TOKEN_RESPONSE)
+
+        const formData = new FormData()
+        formData.set('userId', 'user1')
+        formData.set('password', 'pass')
+        formData.set('returnTo', '')
 
         await loginAction(initialState, formData)
 

--- a/apps/web/src/__tests__/components/LoginForm.test.tsx
+++ b/apps/web/src/__tests__/components/LoginForm.test.tsx
@@ -90,4 +90,43 @@ describe('LoginForm', () => {
         const button = screen.getByRole('button', { name: 'ログイン中...' })
         expect(button).toBeDisabled()
     })
+
+    it('returnTo が渡されたとき、hidden input に returnTo 値がセットされる', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        const { container } = render(<LoginForm returnTo="/expenses" />)
+
+        const hiddenInput = container.querySelector('input[name="returnTo"]')
+        expect(hiddenInput).not.toBeNull()
+        expect(hiddenInput).toHaveValue('/expenses')
+    })
+
+    it('returnTo が渡されたとき、セッション切れトーストが表示される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<LoginForm returnTo="/expenses" />)
+
+        expect(screen.getByRole('alert')).toBeInTheDocument()
+        expect(screen.getByText(/セッションが切れました/)).toBeInTheDocument()
+    })
+
+    it('returnTo が未指定のとき、セッション切れトーストが表示されない', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<LoginForm />)
+
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
 })

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -5,6 +5,11 @@ export const metadata: Metadata = {
   title: "ログイン | 家計管理",
 };
 
-export default function LoginPage() {
-  return <LoginForm />;
+type Props = {
+  searchParams: Promise<{ returnTo?: string }>;
+};
+
+export default async function LoginPage({ searchParams }: Props) {
+  const { returnTo } = await searchParams;
+  return <LoginForm returnTo={returnTo} />;
 }

--- a/apps/web/src/components/login/LoginForm.tsx
+++ b/apps/web/src/components/login/LoginForm.tsx
@@ -7,6 +7,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
 import { SecurityBadges } from "@/components/common/SecurityBadges";
+import { SessionExpiredToast } from "./SessionExpiredToast";
 
 const initialState: LoginState = { error: null };
 
@@ -38,7 +39,11 @@ function NotificationBanner() {
   return null;
 }
 
-export function LoginForm() {
+type Props = {
+  returnTo?: string;
+};
+
+export function LoginForm({ returnTo }: Props) {
   const [state, formAction, isPending] = useActionState(loginAction, initialState);
 
   return (
@@ -81,7 +86,12 @@ export function LoginForm() {
           <NotificationBanner />
         </Suspense>
 
+        {returnTo && <SessionExpiredToast />}
+
         <form action={formAction} className="flex flex-col gap-4">
+          {returnTo && (
+            <input type="hidden" name="returnTo" value={returnTo} />
+          )}
           <div className="flex flex-col gap-1">
             <label htmlFor="userId" className="text-sm font-semibold text-[#1c1410]">
               ユーザー名
@@ -139,6 +149,9 @@ export function LoginForm() {
 
         <div className="mt-4 border-t border-[#e8c8b0] pt-4 space-y-3">
           <form action={guestLoginAction}>
+            {returnTo && (
+              <input type="hidden" name="returnTo" value={returnTo} />
+            )}
             <button type="submit" className="btn-ghost w-full">
               ゲストユーザーでログイン
             </button>

--- a/apps/web/src/components/login/SessionExpiredToast.tsx
+++ b/apps/web/src/components/login/SessionExpiredToast.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { X } from "lucide-react";
+
+export function SessionExpiredToast() {
+  const [visible, setVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(false), 5000);
+    return () => clearTimeout(timer);
+  }, []);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      role="alert"
+      className="mb-4 flex items-start justify-between gap-2 rounded-xl border border-[#fbbf24]/40 bg-[#fef3c7] px-3 py-2 text-sm font-medium text-[#1c1410]"
+    >
+      <span>セッションが切れました。再度ログインしてください。</span>
+      <button
+        type="button"
+        aria-label="閉じる"
+        onClick={() => setVisible(false)}
+        className="shrink-0 text-[#1c1410]/50 hover:text-[#1c1410]"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/lib/actions/auth.ts
+++ b/apps/web/src/lib/actions/auth.ts
@@ -97,16 +97,21 @@ export async function loginAction(
     return { error: "サーバーに接続できませんでした" };
   }
 
-  redirect("/");
+  // returnTo が / 始まりの場合のみ使用（オープンリダイレクト対策）
+  const returnTo = String(formData.get("returnTo") ?? "");
+  redirect(returnTo.startsWith("/") ? returnTo : "/");
 }
 
 /** ゲストログイン Server Action */
-export async function guestLoginAction(): Promise<void> {
+export async function guestLoginAction(formData: FormData): Promise<void> {
   const res = await serverFetch<LoginResponse & TokenPair>("/api/guest-login", {
     method: "POST",
   });
   await setTokenCookies({ ...res, userId: res.userId });
-  redirect("/");
+
+  // returnTo が / 始まりの場合のみ使用（オープンリダイレクト対策）
+  const returnTo = String(formData.get("returnTo") ?? "");
+  redirect(returnTo.startsWith("/") ? returnTo : "/");
 }
 
 /** ログアウト Server Action */

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -74,8 +74,9 @@ export async function middleware(request: NextRequest) {
     }
   }
 
-  // トークンなし / 無効 → ログイン画面へ
-  return NextResponse.redirect(new URL("/login", request.url));
+  // トークンなし / 無効 → ログイン画面へ（returnTo でセッション切れを伝える）
+  const returnTo = encodeURIComponent(request.nextUrl.pathname + request.nextUrl.search);
+  return NextResponse.redirect(new URL(`/login?returnTo=${returnTo}`, request.url));
 }
 
 export const config = {


### PR DESCRIPTION
## Summary

- **middleware**: セッション切れ時に `/login?returnTo=<元のパス>` へリダイレクト
- **loginAction**: `returnTo` が `/` 始まりの場合のみ遷移先として使用（オープンリダイレクト対策）
- **guestLoginAction**: `FormData` を受け取り `returnTo` に対応
- **LoginForm**: `returnTo` prop → hidden input でフォームに埋め込み
- **SessionExpiredToast**: `returnTo` がある場合のみ表示するアラートトースト（5秒で自動消去）
- **login/page.tsx**: `searchParams.returnTo` を `LoginForm` へ伝播

## セキュリティ

`returnTo` は必ず `/` 始まりのパスであることを検証。外部URLへのリダイレクトを防止。

## Test plan

- [x] `pnpm test:unit` 全66件パス確認済み（+7件追加）
- [x] `loginAction`: returnTo あり・空・外部URL の各ケース
- [x] `guestLoginAction`: returnTo ありケース
- [x] `LoginForm`: hidden input 存在確認・トースト表示・非表示

Closes #112

https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2)_