### PR TITLE
chore: スプリントプランニングをAIに完全委任できるようラベル付与フローを更新する

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -71,19 +71,28 @@
 
 #### `スプリントプランニングをして`
 
-1. `.github/sprint-protocol.md` のセクション 2「スプリントの定義」と セクション 7「スプリントプランニング」を読み込む
-2. `gh issue list --state open --label "sprint-backlog" --json number,title,body,labels` でスプリント候補 PBI を取得する
-3. 各 PBI の複雑度・依存関係を調べ、1作業日（1スプリント）で完了可能かを評価する
+1. `.github/sprint-protocol.md` のセクション 2・7 を読み込む
+2. **全オープン Issue** を取得して候補を選定する（ラベルの有無は問わない）
+   ```
+   gh issue list --state open --json number,title,body,labels,assignees --limit 50
+   ```
+3. 以下の基準で優先度を評価し、1作業日（1スプリント）で完了可能な PBI を最大3件選ぶ：
+   - `priority: P0/P1` を最優先
+   - `size: XS/S` を優先（1日で完了しやすい）
+   - 依存関係（他 Issue が前提になっていないか）を確認
    - 完了不可と判断した PBI は分割案を提示する
-4. 優先度順にスプリント対象 PBI リストを提示し、ユーザーの承認を求める
-5. 承認後、対象 PBI に `in-progress` ラベルを付与する（GitHub Actions がタイムスタンプを自動記録する）
+4. 選定した PBI と選定理由をユーザーに提示し、承認を求める
+5. **承認後**、対象 PBI に `sprint-backlog` ラベルを付与する
+6. 続けて実装を開始する場合は `in-progress` ラベルも付与する（GitHub Actions がタイムスタンプを自動記録）
 
 #### `スプリントを進めて`（メインループ）
 
 以下のループを、作業可能な PBI がなくなるまで繰り返す：
 
-1. **PBI 選択**: `gh issue list --state open --label "in-progress"` で実行対象 Issue を特定する
-   - `in-progress` ラベルがない場合は `sprint-backlog` ラベルの最優先 Issue を選択し、ユーザーに確認する
+1. **PBI 選択**: 以下の順で実行対象 Issue を特定する
+   - `in-progress` ラベルがある Issue → そのまま着手
+   - なければ `sprint-backlog` ラベルの最優先 Issue → `in-progress` に変更して着手
+   - どちらもなければ全 Issue から自動選定（`スプリントプランニングをして` のロジックで1件選んでラベルを付与）し、ユーザーに報告してから着手
 2. **ブランチ作成**: 必須プロセスの `/branch` 手順を実行する（`git fetch origin main` → `merge --ff-only` → `git checkout -b feature/issue-{番号}-{説明}`）
 3. **翻訳**: `/translate` — Issue の内容を「ユーザーの意図 → 技術課題 → 修正対象ファイル」へ翻訳し、理解を言語化する
 4. **影響調査**: `/search` — 関連ファイル・型定義・依存関係を調査する


### PR DESCRIPTION
## 概要

`スプリントプランニングをして` / `スプリントを進めて` コマンドを、
ユーザーが事前にラベルを付けなくても動作するよう更新しました。

## 変更内容

### `.claude/CLAUDE.md`

**`スプリントプランニングをして` の変更点**
- 従来: `sprint-backlog` ラベルがついた Issue のみを対象
- 変更後: 全オープン Issue を取得し、AI が priority / size / 依存関係で選定
- 承認後に `sprint-backlog` ラベルを AI が付与するフローに変更

**`スプリントを進めて` の変更点**
- `in-progress` も `sprint-backlog` もない場合のフォールバックを追加
- 全 Issue から自動選定してラベルを付与し、ユーザーに報告してから着手

## 影響範囲

- `.claude/CLAUDE.md` のみの変更。アプリケーションコードへの影響なし

## テスト内容

- lint / type-check / build / unit-test: 全件パス

## ✅ 規約・設計チェック

- [x] ユビキタス言語を遵守しているか — ドキュメントのみの変更、該当なし
- [x] 境界を跨ぐ不正な依存はないか — 該当なし
- [x] ID（ulid）の生成・利用箇所は適切か — 該当なし
- [x] マジックナンバーを排除し、定数化されているか — 該当なし
- [x] UI/UX 変更がある場合、スクリーンショットを添付しているか — UI 変更なし（該当なし）