### PR TITLE
design: Sandbox 全体のシャドウをフラット方針に統一する (#135)

### DIFF
--- a/apps/sandbox/src/index.css
+++ b/apps/sandbox/src/index.css
@@ -32,9 +32,14 @@
   --radius-xl: 24px;
   --radius-full: 9999px;
 
-  /* シャドウ */
-  --shadow-card: 0 1px 4px rgba(28, 20, 16, 0.06), 0 4px 16px rgba(28, 20, 16, 0.06);
-  --shadow-pop-sm: 2px 2px 0 rgba(28, 20, 16, 0.9);
+  /* ボーダー（フラット方針 — カード・入力欄はボーダーのみ） */
+  --border-default: rgba(28, 20, 16, 0.12);
+  --border-strong: rgba(28, 20, 16, 0.30);
+
+  /* シャドウ（浮遊要素のみ hard shadow を使用。--shadow-card は廃止） */
+  --shadow-pop-sm: 1px 1px 0 #1c1410;
+  --shadow-pop: 2px 2px 0 #1c1410;
+  --shadow-pop-lg: 3px 3px 0 #1c1410;
 }
 
 body {

--- a/apps/sandbox/src/pages/BottomNavPrototype.tsx
+++ b/apps/sandbox/src/pages/BottomNavPrototype.tsx
@@ -12,7 +12,7 @@ export function BottomNavPrototype() {
     <div className="flex flex-col items-center" style={{ background: 'var(--color-surface-default)', minHeight: '100svh' }}>
       {/* 戻るリンク（デスクトップ用） */}
       <div className="w-full max-w-sm px-4 pt-4 pb-2">
-        <Link to="/" className="flex items-center gap-1.5 text-xs text-[#1c1410]/50 hover:text-[#f08030] transition-colors">
+        <Link to="/" className="flex items-center gap-1.5 text-xs text-[#1c1410]/50 hover:text-[var(--color-brand-primary)] transition-colors">
           <ArrowLeft size={14} />
           Gallery に戻る
         </Link>
@@ -51,8 +51,8 @@ export function BottomNavPrototype() {
                 <button
                   key={item.label}
                   type="button"
-                  className="rounded-2xl px-6 py-3 text-sm font-bold text-white shadow-lg"
-                  style={{ background: item.color }}
+                  className="rounded-2xl border-2 border-[#1c1410] px-6 py-3 text-sm font-bold text-white"
+                  style={{ background: item.color, boxShadow: 'var(--shadow-pop)' }}
                   onClick={() => setFabOpen(false)}
                 >
                   {item.label}
@@ -75,8 +75,8 @@ export function BottomNavPrototype() {
             type="button"
             aria-label="記録する"
             onClick={() => setFabOpen(!fabOpen)}
-            className="relative -top-4 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
-            style={{ background: 'var(--color-brand-primary)', boxShadow: '0 4px 16px rgba(240,128,48,0.45)' }}
+            className="relative -top-4 flex h-14 w-14 items-center justify-center rounded-full border-2 border-[#1c1410] transition-transform active:scale-95"
+            style={{ background: 'var(--color-brand-primary)', boxShadow: 'var(--shadow-pop)' }}
           >
             {fabOpen
               ? <X size={22} className="text-white" />
@@ -120,10 +120,7 @@ function HomeContent() {
   return (
     <div className="flex flex-col gap-4">
       {/* 今月サマリーカード */}
-      <div
-        className="rounded-2xl bg-white p-4"
-        style={{ boxShadow: 'var(--shadow-card)' }}
-      >
+      <div className="rounded-2xl border border-[#1c1410]/12 bg-white p-4">
         <p className="text-xs font-bold text-[#1c1410]/50">今月の支出</p>
         <p className="mt-1 text-3xl font-extrabold tabular-nums" style={{ color: 'var(--color-expense)' }}>
           ¥42,800
@@ -135,7 +132,7 @@ function HomeContent() {
       </div>
 
       {/* 最近の記録 */}
-      <div className="rounded-2xl bg-white p-4" style={{ boxShadow: 'var(--shadow-card)' }}>
+      <div className="rounded-2xl border border-[#1c1410]/12 bg-white p-4">
         <p className="text-xs font-bold text-[#1c1410]/50 mb-3">最近の記録</p>
         {[
           { label: 'スーパー', amount: -3200, date: '今日' },

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -54,8 +54,7 @@ export function Gallery() {
             <Link
               key={p.path}
               to={p.path}
-              className="group flex items-center gap-4 rounded-2xl bg-white p-4 transition-shadow hover:shadow-md"
-              style={{ boxShadow: 'var(--shadow-card)' }}
+              className="group flex items-center gap-4 rounded-2xl border border-[#1c1410]/12 bg-white p-4 transition-colors hover:border-[#1c1410]/30"
             >
               <div
                 className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl"
@@ -74,7 +73,7 @@ export function Gallery() {
               </div>
               <ArrowRight
                 size={16}
-                className="shrink-0 text-[#1c1410]/30 transition-colors group-hover:text-[#f08030]"
+                className="shrink-0 text-[#1c1410]/30 transition-colors group-hover:text-[var(--color-brand-primary)]"
               />
             </Link>
           )


### PR DESCRIPTION
## 概要

Sandbox のデザインをフラット方針に統一する。ソフトシャドウ（`--shadow-card`）を廃止し、カード類はボーダーのみ、浮遊要素（FAB・オーバーレイボタン）はハードシャドウ（`var(--shadow-pop)`）で統一した。

Closes #135

## 変更内容

- `apps/sandbox/src/index.css`: `--shadow-card` を削除。`--border-default`・`--border-strong`・`--shadow-pop-sm`・`--shadow-pop`・`--shadow-pop-lg` を追加・整備
- `apps/sandbox/src/pages/BottomNavPrototype.tsx`: HomeContent カードの `boxShadow: var(--shadow-card)` をボーダーに置換。FAB・オーバーレイボタンに `border-2 border-[#1c1410]` + `var(--shadow-pop)` を適用
- `apps/sandbox/src/pages/Gallery.tsx`: プロトタイプカードの `boxShadow` を削除し `border border-[#1c1410]/12 hover:border-[#1c1410]/30` に変更。アクセントカラーのハードコードを CSS 変数に統一

## 影響範囲

Sandbox アプリのみ（`apps/sandbox/`）。本番アプリ（`apps/web/`・`apps/api/`）への影響なし。

## テスト内容

- lint / type-check / unit-test（91件）すべてパス
- integration-test（25件）パス

## スクリーンショット

> UI/UX の変更を含むため、マージ前にレビュー担当者が実際の画面を確認してください。
> ローカルで `pnpm --filter sandbox dev` を起動し、変更箇所を確認することを推奨します。

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- Sandbox のビジュアル変更を含むため、マージ前にレビュー担当者がローカルで確認してください -->