### PR TITLE
fix: カテゴリが常に食費/給料として保存される不具合を修正する (#153)

### DIFF
--- a/apps/web/src/__tests__/actions/expense.test.ts
+++ b/apps/web/src/__tests__/actions/expense.test.ts
@@ -31,6 +31,7 @@ describe('createExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '0')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('userId', 'user1')
         formData.set('date', '2024-01-01')
 
@@ -44,6 +45,7 @@ describe('createExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '1000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('userId', 'user1')
         formData.set('date', '')
 
@@ -59,6 +61,7 @@ describe('createExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '1000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '2')
         formData.set('userId', 'user1')
         formData.set('date', '2024-01-01')
 
@@ -68,12 +71,33 @@ describe('createExpenseAction', () => {
         expect(result.error).toBeNull()
     })
 
+    it('正常系: 選択した categoryId が API リクエストに含まれる', async () => {
+        vi.mocked(serverFetch).mockResolvedValue({})
+
+        const formData = new FormData()
+        formData.set('amount', '1000')
+        formData.set('balanceType', '0')
+        formData.set('categoryId', '3')
+        formData.set('userId', 'user1')
+        formData.set('date', '2024-01-01')
+
+        await createExpenseAction(initialState, formData)
+
+        expect(serverFetch).toHaveBeenCalledWith(
+            '/api/expense',
+            expect.objectContaining({
+                body: expect.stringContaining('"categoryId":3'),
+            }),
+        )
+    })
+
     it('API が 403 を返すとき認証エラーメッセージを返す', async () => {
         vi.mocked(serverFetch).mockRejectedValue(new ApiError(403, 'Forbidden'))
 
         const formData = new FormData()
         formData.set('amount', '1000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('userId', 'user1')
         formData.set('date', '2024-01-01')
 
@@ -97,6 +121,7 @@ describe('updateExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '0')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('date', '2024-01-01')
 
         const result = await updateExpenseAction('expense-01', initialState, formData)
@@ -109,6 +134,7 @@ describe('updateExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '1000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('date', '')
 
         const result = await updateExpenseAction('expense-01', initialState, formData)
@@ -123,6 +149,7 @@ describe('updateExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '2000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '4')
         formData.set('date', '2024-02-01')
 
         const result = await updateExpenseAction('expense-01', initialState, formData)
@@ -135,12 +162,32 @@ describe('updateExpenseAction', () => {
         )
     })
 
+    it('正常系: 選択した categoryId が API リクエストに含まれる', async () => {
+        vi.mocked(serverFetch).mockResolvedValue({})
+
+        const formData = new FormData()
+        formData.set('amount', '2000')
+        formData.set('balanceType', '0')
+        formData.set('categoryId', '5')
+        formData.set('date', '2024-02-01')
+
+        await updateExpenseAction('expense-01', initialState, formData)
+
+        expect(serverFetch).toHaveBeenCalledWith(
+            '/api/expense/expense-01',
+            expect.objectContaining({
+                body: expect.stringContaining('"categoryId":5'),
+            }),
+        )
+    })
+
     it('API が 403 を返すとき認証エラーメッセージを返す', async () => {
         vi.mocked(serverFetch).mockRejectedValue(new ApiError(403, 'Forbidden'))
 
         const formData = new FormData()
         formData.set('amount', '2000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('date', '2024-02-01')
 
         const result = await updateExpenseAction('expense-01', initialState, formData)
@@ -155,6 +202,7 @@ describe('updateExpenseAction', () => {
         const formData = new FormData()
         formData.set('amount', '2000')
         formData.set('balanceType', '0')
+        formData.set('categoryId', '1')
         formData.set('date', '2024-02-01')
 
         const result = await updateExpenseAction('expense-01', initialState, formData)

--- a/apps/web/src/lib/actions/expense.ts
+++ b/apps/web/src/lib/actions/expense.ts
@@ -8,6 +8,7 @@ import type { GetExpenseResponse } from "../api/types";
 export type ExpenseFieldErrors = {
   amount?: string[];
   balanceType?: string[];
+  categoryId?: string[];
   date?: string[];
   userId?: string[];
 };
@@ -26,6 +27,7 @@ export async function createExpenseAction(
   const raw = {
     amount: Number(formData.get("amount")),
     balanceType: Number(formData.get("balanceType")) as 0 | 1,
+    categoryId: Number(formData.get("categoryId") ?? 0),
     userId: String(formData.get("userId") ?? ""),
     date: String(formData.get("date") ?? ""),
     content: formData.get("content") ? String(formData.get("content")) : null,
@@ -78,6 +80,7 @@ export async function updateExpenseAction(
   const raw = {
     amount: Number(formData.get("amount")),
     balanceType: Number(formData.get("balanceType")) as 0 | 1,
+    categoryId: Number(formData.get("categoryId") ?? 0),
     date: String(formData.get("date") ?? ""),
     content: formData.get("content") ? String(formData.get("content")) : null,
   };

--- a/packages/common/src/__tests__/schemas/expense.test.ts
+++ b/packages/common/src/__tests__/schemas/expense.test.ts
@@ -5,6 +5,7 @@ describe('createExpenseSchema', () => {
     const validInput = {
         amount: 1000,
         balanceType: 0 as const,
+        categoryId: 1,
         userId: 'user-1',
         date: '2024-01-01',
         content: 'テスト支出',
@@ -12,6 +13,11 @@ describe('createExpenseSchema', () => {
 
     it('正常系: 有効なデータで成功する', () => {
         const result = createExpenseSchema.safeParse(validInput)
+        expect(result.success).toBe(true)
+    })
+
+    it('正常系: categoryId が 0（未分類）のとき、成功する', () => {
+        const result = createExpenseSchema.safeParse({ ...validInput, categoryId: 0 })
         expect(result.success).toBe(true)
     })
 
@@ -47,6 +53,11 @@ describe('createExpenseSchema', () => {
         if (!result.success) {
             expect(result.error.issues[0].message).toBe('種別を選択してください')
         }
+    })
+
+    it('異常系: categoryId が負数のとき、エラーになる', () => {
+        const result = createExpenseSchema.safeParse({ ...validInput, categoryId: -1 })
+        expect(result.success).toBe(false)
     })
 
     it('異常系: userIdが空文字ならエラー', () => {

--- a/packages/common/src/schemas/expense.ts
+++ b/packages/common/src/schemas/expense.ts
@@ -8,6 +8,10 @@ export const createExpenseSchema = z.object({
   balanceType: z.union([z.literal(0), z.literal(1)], {
     errorMap: () => ({ message: '種別を選択してください' }),
   }),
+  categoryId: z
+    .number({ invalid_type_error: 'カテゴリIDは数値で入力してください' })
+    .int()
+    .min(0),
   userId: z.string().min(1, 'ユーザーIDが必要です'),
   date: z.string().min(1, '日付を入力してください'),
   content: z.string().nullable().optional(),
@@ -23,6 +27,11 @@ export const updateExpenseSchema = z.object({
   balanceType: z.union([z.literal(0), z.literal(1)], {
     errorMap: () => ({ message: '種別を選択してください' }),
   }),
+  categoryId: z
+    .number({ invalid_type_error: 'カテゴリIDは数値で入力してください' })
+    .int()
+    .min(0)
+    .optional(),
   date: z.string().min(1, '日付を入力してください'),
   content: z.string().nullable().optional(),
 })


### PR DESCRIPTION
## 概要

`createExpenseSchema` / `updateExpenseSchema` に `categoryId` が未定義だったため、
フォームで選択したカテゴリが Server Action でバリデーション後に脱落し、
BE のフォールバック値（`categoryId ?? 1` = 食費/給料）で常に保存されていた。

Closes #153

## 変更内容

- `packages/common/src/schemas/expense.ts`: `createExpenseSchema` に `categoryId`（必須・`int().min(0)`）を追加。`updateExpenseSchema` に `categoryId`（optional）を追加
- `apps/web/src/lib/actions/expense.ts`: `createExpenseAction` / `updateExpenseAction` の `raw` に `formData.get("categoryId")` を追加。`ExpenseFieldErrors` に `categoryId` を追加
- テスト更新: `categoryId` を含む正常系、`categoryId` が API リクエスト本文に含まれることの検証、`categoryId` 負数の異常系を追加

## 影響範囲

- `packages/common`: スキーマ変更（後方互換あり — BE の `CreateExpenseInput.categoryId` は元から `optional`）
- `apps/web`: Server Action の formData 読み取り追加のみ
- `apps/api`: 変更なし（元々 `categoryId` を受け取る実装になっていた）

## テスト内容

- unit-test 93件パス（web: +2件、common: +2件）

## スクリーンショット

該当なし（BE ロジック修正のみ）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし — ロジック修正のみ）