### PR TITLE
refactor: レスポンス用 DTO とマッパーを Presentation 層に分離

### DIFF
--- a/apps/api/src/__tests__/unit/mappers/expenseMapper.test.ts
+++ b/apps/api/src/__tests__/unit/mappers/expenseMapper.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { toExpenseDto } from '../../../presentation/mappers/expenseMapper';
+import type { Expense } from '../../../domain/models/Expense';
+
+const baseExpense: Expense = {
+    id: 'ulid-001',
+    amount: 1000,
+    balanceType: 0,
+    userId: 'user-001',
+    categoryId: 2,
+    content: '食費メモ',
+    date: '2026-05-08',
+    createdDate: new Date('2026-05-08T10:00:00.000Z'),
+    updatedDate: new Date('2026-05-08T11:00:00.000Z'),
+    deletedDate: null,
+};
+
+describe('toExpenseDto', () => {
+    it('Expense ドメインモデルを DTO に変換する', () => {
+        const dto = toExpenseDto(baseExpense);
+
+        expect(dto.id).toBe('ulid-001');
+        expect(dto.amount).toBe(1000);
+        expect(dto.balanceType).toBe(0);
+        expect(dto.userId).toBe('user-001');
+        expect(dto.categoryId).toBe(2);
+        expect(dto.content).toBe('食費メモ');
+        expect(dto.date).toBe('2026-05-08');
+        expect(dto.createdDate).toBe('2026-05-08T10:00:00.000Z');
+        expect(dto.updatedDate).toBe('2026-05-08T11:00:00.000Z');
+        expect(dto.deletedDate).toBeNull();
+    });
+
+    it('deletedDate が存在するとき、ISO 文字列に変換される', () => {
+        const expense: Expense = {
+            ...baseExpense,
+            deletedDate: new Date('2026-05-09T00:00:00.000Z'),
+        };
+
+        const dto = toExpenseDto(expense);
+
+        expect(dto.deletedDate).toBe('2026-05-09T00:00:00.000Z');
+    });
+
+    it('content が null のとき、null のまま返す', () => {
+        const expense: Expense = { ...baseExpense, content: null };
+
+        const dto = toExpenseDto(expense);
+
+        expect(dto.content).toBeNull();
+    });
+
+    it('balanceType=1（収入）のとき、正しく変換される', () => {
+        const expense: Expense = { ...baseExpense, balanceType: 1 };
+
+        const dto = toExpenseDto(expense);
+
+        expect(dto.balanceType).toBe(1);
+    });
+});

--- a/apps/api/src/presentation/dto/ExpenseDto.ts
+++ b/apps/api/src/presentation/dto/ExpenseDto.ts
@@ -1,0 +1,13 @@
+/** レスポンス用 Expense DTO */
+export type ExpenseDto = {
+    id: string;
+    amount: number;
+    balanceType: 0 | 1;
+    userId: string;
+    categoryId: number;
+    content: string | null;
+    date: string;
+    createdDate: string;
+    updatedDate: string;
+    deletedDate: string | null;
+};

--- a/apps/api/src/presentation/mappers/expenseMapper.ts
+++ b/apps/api/src/presentation/mappers/expenseMapper.ts
@@ -1,0 +1,18 @@
+import type { Expense } from '../../domain/models/Expense';
+import type { ExpenseDto } from '../dto/ExpenseDto';
+
+/** Expense ドメインモデルをレスポンス用 DTO に変換する */
+export function toExpenseDto(e: Expense): ExpenseDto {
+    return {
+        id: e.id,
+        amount: e.amount,
+        balanceType: e.balanceType,
+        userId: e.userId,
+        categoryId: e.categoryId,
+        content: e.content,
+        date: e.date,
+        createdDate: e.createdDate.toISOString(),
+        updatedDate: e.updatedDate.toISOString(),
+        deletedDate: e.deletedDate?.toISOString() ?? null,
+    };
+}

--- a/apps/api/src/presentation/routes/expense.ts
+++ b/apps/api/src/presentation/routes/expense.ts
@@ -1,7 +1,6 @@
 import type { CreateExpenseInput, UpdateExpenseInput } from '@budget/common';
 import { createRoute, z } from '@hono/zod-openapi';
 import type { RouteServices } from '../../app';
-import type { Expense } from '../../domain/models/Expense';
 import { createOpenAPIApp } from '../../lib/openapi-app';
 import {
     CreateExpenseBodySchema,
@@ -11,22 +10,7 @@ import {
     UpdateExpenseBodySchema,
 } from '../../openapi/schemas';
 import { createAuthMiddleware } from '../middleware/auth';
-
-/** Date フィールドを ISO 文字列に変換してレスポンス用 DTO を生成する */
-function serializeExpense(e: Expense) {
-    return {
-        id: e.id,
-        amount: e.amount,
-        balanceType: e.balanceType,
-        userId: e.userId,
-        categoryId: e.categoryId,
-        content: e.content,
-        date: e.date,
-        createdDate: e.createdDate.toISOString(),
-        updatedDate: e.updatedDate.toISOString(),
-        deletedDate: e.deletedDate?.toISOString() ?? null,
-    };
-}
+import { toExpenseDto } from '../mappers/expenseMapper';
 
 // ─── レスポンス用複合スキーマ ─────────────────────────────────────
 
@@ -164,7 +148,7 @@ export function createExpenseRoutes({
 
     app.openapi(getExpensesRoute, async (c) => {
         const expenses = await expenseRepository.findAll();
-        return c.json({ expense: expenses.map(serializeExpense) }, 200);
+        return c.json({ expense: expenses.map(toExpenseDto) }, 200);
     });
 
     app.openapi(getExpenseRoute, async (c) => {
@@ -173,20 +157,20 @@ export function createExpenseRoutes({
         if (!expense) {
             return c.json({ result: 'error' as const, message: 'リソースが見つかりません' }, 404);
         }
-        return c.json({ expense: serializeExpense(expense) }, 200);
+        return c.json({ expense: toExpenseDto(expense) }, 200);
     });
 
     app.openapi(createExpenseRoute, async (c) => {
         const { newData } = c.req.valid('json');
         const expense = await createExpenseUseCase.execute(newData as CreateExpenseInput);
-        return c.json({ expense: serializeExpense(expense) }, 200);
+        return c.json({ expense: toExpenseDto(expense) }, 200);
     });
 
     app.openapi(updateExpenseRoute, async (c) => {
         const { id } = c.req.valid('param');
         const { updateData } = c.req.valid('json');
         const expense = await updateExpenseUseCase.execute(id, updateData as UpdateExpenseInput);
-        return c.json({ expense: serializeExpense(expense) }, 200);
+        return c.json({ expense: toExpenseDto(expense) }, 200);
     });
 
     app.openapi(deleteExpenseRoute, async (c) => {


### PR DESCRIPTION
## Summary

- `presentation/dto/ExpenseDto.ts` に `ExpenseDto` 型を新設し、レスポンス形状を明示的に定義
- `presentation/mappers/expenseMapper.ts` に `toExpenseDto` 関数を抽出（旧 `serializeExpense` を削除）
- `presentation/routes/expense.ts` のインライン変換を `toExpenseDto` に置換し、ルートファイルの責務を Route/Handler 定義のみに絞った
- `src/__tests__/unit/mappers/expenseMapper.test.ts` にマッパー単体テスト 4 件を追加

Closes #100

## Test plan

- [x] `toExpenseDto` の単体テスト（正常系・deletedDate あり/なし・content null・balanceType=1）
- [x] `pnpm test:unit` 全件パス（109 tests）
- [x] `pnpm test:integration` 全件パス（25 tests）
- [x] tsc --noEmit / lint / openapi-sync すべてクリア

## チェックリスト

- [x] 既存の動作を変えず、変換ロジックのみを移動（リファクタリング）
- [x] 新規ファイルは Presentation 層（dto/mappers）に配置し、Onion Architecture に準拠
- [x] `any` 不使用、型注釈あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)