### PR TITLE
feat: 総資産・月次収入をサーバーサイドに永続化する

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -104,6 +104,19 @@ model UserSecurityAnswer {
   @@map("user_security_answers")
 }
 
+// ユーザー設定（総資産・月次収入）
+model UserSettings {
+  id            String   @id @db.VarChar(26)
+  userId        String   @unique @db.VarChar(255) @map("user_id")
+  totalAssets   Int      @default(0) @map("total_assets")
+  monthlyIncome Int      @default(0) @map("monthly_income")
+  createdAt     DateTime @default(now()) @db.DateTime(6) @map("created_at")
+  updatedAt     DateTime @updatedAt @db.DateTime(6) @map("updated_at")
+
+  @@index([userId], map: "IDX_user_settings_user_id")
+  @@map("user_settings")
+}
+
 // パスワードリセット用一時トークン
 model PasswordResetToken {
   id        String    @id @db.VarChar(26)

--- a/apps/api/src/__tests__/integration/auth.integration.test.ts
+++ b/apps/api/src/__tests__/integration/auth.integration.test.ts
@@ -20,6 +20,7 @@ import { PrismaPasswordResetTokenRepository } from '../../infrastructure/persist
 import { PrismaRefreshTokenRepository } from '../../infrastructure/persistence/PrismaRefreshTokenRepository';
 import { PrismaSecurityAnswerRepository } from '../../infrastructure/persistence/PrismaSecurityAnswerRepository';
 import { PrismaUserRepository } from '../../infrastructure/persistence/PrismaUserRepository';
+import { PrismaUserSettingsRepository } from '../../infrastructure/persistence/PrismaUserSettingsRepository';
 import { testPrisma, resetDatabase, seedTestData } from '../helpers/db';
 import { TestAgent, testRequest } from '../helpers/testClient';
 
@@ -43,6 +44,7 @@ describeIf('Auth 統合テスト（実 DB）', () => {
         refreshTokenRepository: new PrismaRefreshTokenRepository(prisma),
         securityAnswerRepository: new PrismaSecurityAnswerRepository(prisma),
         passwordResetTokenRepository: new PrismaPasswordResetTokenRepository(prisma),
+        userSettingsRepository: new PrismaUserSettingsRepository(prisma),
     });
 
     beforeAll(async () => {

--- a/apps/api/src/__tests__/integration/expense.integration.test.ts
+++ b/apps/api/src/__tests__/integration/expense.integration.test.ts
@@ -22,6 +22,7 @@ import { PrismaPasswordResetTokenRepository } from '../../infrastructure/persist
 import { PrismaRefreshTokenRepository } from '../../infrastructure/persistence/PrismaRefreshTokenRepository';
 import { PrismaSecurityAnswerRepository } from '../../infrastructure/persistence/PrismaSecurityAnswerRepository';
 import { PrismaUserRepository } from '../../infrastructure/persistence/PrismaUserRepository';
+import { PrismaUserSettingsRepository } from '../../infrastructure/persistence/PrismaUserSettingsRepository';
 import { testPrisma, resetDatabase, seedTestData } from '../helpers/db';
 import { TestAgent, testRequest } from '../helpers/testClient';
 
@@ -45,6 +46,7 @@ describeIf('Expense 統合テスト（実 DB）', () => {
         refreshTokenRepository: new PrismaRefreshTokenRepository(prisma),
         securityAnswerRepository: new PrismaSecurityAnswerRepository(prisma),
         passwordResetTokenRepository: new PrismaPasswordResetTokenRepository(prisma),
+        userSettingsRepository: new PrismaUserSettingsRepository(prisma),
     });
 
     afterAll(async () => {

--- a/apps/api/src/__tests__/integration/settings.integration.test.ts
+++ b/apps/api/src/__tests__/integration/settings.integration.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Settings 統合テスト（実 DB 使用）
+ *
+ * 【検証範囲】
+ * - GET  /api/settings: 認証チェック、未設定時のデフォルト値返却
+ * - PUT  /api/settings: 認証チェック、Zod バリデーション、DB への保存と上書き
+ */
+
+import { API_PATHS } from '@budget/api-client';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+import { PrismaClient } from '@prisma/client';
+import { createApp } from '../../app';
+import { PrismaBudgetRepository } from '../../infrastructure/persistence/PrismaBudgetRepository';
+import { PrismaExpenseRepository } from '../../infrastructure/persistence/PrismaExpenseRepository';
+import { PrismaPasswordResetTokenRepository } from '../../infrastructure/persistence/PrismaPasswordResetTokenRepository';
+import { PrismaRefreshTokenRepository } from '../../infrastructure/persistence/PrismaRefreshTokenRepository';
+import { PrismaSecurityAnswerRepository } from '../../infrastructure/persistence/PrismaSecurityAnswerRepository';
+import { PrismaUserRepository } from '../../infrastructure/persistence/PrismaUserRepository';
+import { PrismaUserSettingsRepository } from '../../infrastructure/persistence/PrismaUserSettingsRepository';
+import { testPrisma, resetDatabase, seedTestData } from '../helpers/db';
+import { TestAgent, testRequest } from '../helpers/testClient';
+
+let dbAvailable = false;
+try {
+    await testPrisma.$connect();
+    dbAvailable = true;
+} catch {
+    dbAvailable = false;
+}
+
+const describeIf = dbAvailable ? describe : describe.skip;
+
+describeIf('Settings 統合テスト（実 DB）', () => {
+    const prisma = new PrismaClient();
+    const app = createApp({
+        userRepository: new PrismaUserRepository(prisma),
+        expenseRepository: new PrismaExpenseRepository(prisma),
+        budgetRepository: new PrismaBudgetRepository(prisma),
+        refreshTokenRepository: new PrismaRefreshTokenRepository(prisma),
+        securityAnswerRepository: new PrismaSecurityAnswerRepository(prisma),
+        passwordResetTokenRepository: new PrismaPasswordResetTokenRepository(prisma),
+        userSettingsRepository: new PrismaUserSettingsRepository(prisma),
+    });
+
+    afterAll(async () => {
+        await testPrisma.$disconnect();
+        await prisma.$disconnect();
+    });
+
+    /** ログイン済みエージェントを返すヘルパー */
+    async function loginClient(userId: string): Promise<TestAgent> {
+        const client = new TestAgent(app);
+        await client.login(API_PATHS.LOGIN, { userId, password: 'password123' });
+        return client;
+    }
+
+    beforeEach(async () => {
+        await resetDatabase();
+        // user_settings テーブルも truncate（resetDatabase は budget_list/user_list のみ対象のため）
+        await testPrisma.$executeRawUnsafe('SET FOREIGN_KEY_CHECKS = 0');
+        await testPrisma.$executeRawUnsafe('TRUNCATE TABLE user_settings');
+        await testPrisma.$executeRawUnsafe('SET FOREIGN_KEY_CHECKS = 1');
+    });
+
+    describe('GET /api/settings', () => {
+        it('正常系: 未設定のとき totalAssets=0, monthlyIncome=0 を返す', async () => {
+            const { users } = await seedTestData({ pattern: 'minimal' });
+            const agent = await loginClient(users[0].userId);
+
+            const res = await agent.get('/api/settings');
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ totalAssets: 0, monthlyIncome: 0 });
+        });
+
+        it('認証エラー: Bearer トークンなしで 401 を返す', async () => {
+            const res = await testRequest(app, '/api/settings');
+            expect(res.status).toBe(401);
+        });
+    });
+
+    describe('PUT /api/settings', () => {
+        it('正常系: 設定を保存して返す', async () => {
+            const { users } = await seedTestData({ pattern: 'minimal' });
+            const agent = await loginClient(users[0].userId);
+
+            const res = await agent.put('/api/settings', { totalAssets: 5000000, monthlyIncome: 200000 });
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ totalAssets: 5000000, monthlyIncome: 200000 });
+        });
+
+        it('正常系: 上書き保存できる', async () => {
+            const { users } = await seedTestData({ pattern: 'minimal' });
+            const agent = await loginClient(users[0].userId);
+
+            await agent.put('/api/settings', { totalAssets: 1000000, monthlyIncome: 100000 });
+            const res = await agent.put('/api/settings', { totalAssets: 2000000, monthlyIncome: 0 });
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ totalAssets: 2000000, monthlyIncome: 0 });
+        });
+
+        it('バリデーションエラー: totalAssets が負数のとき 400 を返す', async () => {
+            const { users } = await seedTestData({ pattern: 'minimal' });
+            const agent = await loginClient(users[0].userId);
+
+            const res = await agent.put('/api/settings', { totalAssets: -1, monthlyIncome: 0 });
+            expect(res.status).toBe(400);
+        });
+
+        it('認証エラー: Bearer トークンなしで 401 を返す', async () => {
+            const res = await testRequest(app, '/api/settings', {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ totalAssets: 1000000, monthlyIncome: 0 }),
+            });
+            expect(res.status).toBe(401);
+        });
+    });
+});

--- a/apps/api/src/__tests__/unit/use-cases/GetUserSettingsUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/GetUserSettingsUseCase.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GetUserSettingsUseCase } from '../../../application/use-cases/settings/GetUserSettingsUseCase';
+import type { IUserSettingsRepository } from '../../../domain/repositories/IUserSettingsRepository';
+import type { UserSettings } from '../../../domain/models/UserSettings';
+
+const mockSettings: UserSettings = {
+    id: 'ulid-001',
+    userId: 'user-001',
+    totalAssets: 5000000,
+    monthlyIncome: 200000,
+    createdAt: new Date('2026-05-08T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-08T00:00:00.000Z'),
+};
+
+const mockRepo: IUserSettingsRepository = {
+    findByUserId: vi.fn(),
+    upsert: vi.fn(),
+};
+
+describe('GetUserSettingsUseCase', () => {
+    let useCase: GetUserSettingsUseCase;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useCase = new GetUserSettingsUseCase(mockRepo);
+    });
+
+    it('正常系: 設定が存在するとき UserSettings を返す', async () => {
+        vi.mocked(mockRepo.findByUserId).mockResolvedValue(mockSettings);
+
+        const result = await useCase.execute('user-001');
+
+        expect(result).toEqual(mockSettings);
+        expect(mockRepo.findByUserId).toHaveBeenCalledWith('user-001');
+    });
+
+    it('正常系: 未設定のとき null を返す', async () => {
+        vi.mocked(mockRepo.findByUserId).mockResolvedValue(null);
+
+        const result = await useCase.execute('user-001');
+
+        expect(result).toBeNull();
+    });
+});

--- a/apps/api/src/__tests__/unit/use-cases/UpsertUserSettingsUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/UpsertUserSettingsUseCase.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpsertUserSettingsUseCase } from '../../../application/use-cases/settings/UpsertUserSettingsUseCase';
+import type { IUserSettingsRepository } from '../../../domain/repositories/IUserSettingsRepository';
+import type { UserSettings } from '../../../domain/models/UserSettings';
+import { ValidationError } from '../../../shared/errors/DomainException';
+
+const mockSettings: UserSettings = {
+    id: 'ulid-001',
+    userId: 'user-001',
+    totalAssets: 5000000,
+    monthlyIncome: 200000,
+    createdAt: new Date('2026-05-08T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-08T00:00:00.000Z'),
+};
+
+const mockRepo: IUserSettingsRepository = {
+    findByUserId: vi.fn(),
+    upsert: vi.fn(),
+};
+
+describe('UpsertUserSettingsUseCase', () => {
+    let useCase: UpsertUserSettingsUseCase;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useCase = new UpsertUserSettingsUseCase(mockRepo);
+    });
+
+    it('正常系: 総資産・月次収入を保存できる', async () => {
+        vi.mocked(mockRepo.upsert).mockResolvedValue(mockSettings);
+
+        const result = await useCase.execute({
+            userId: 'user-001',
+            totalAssets: 5000000,
+            monthlyIncome: 200000,
+        });
+
+        expect(result).toEqual(mockSettings);
+        expect(mockRepo.upsert).toHaveBeenCalledWith({
+            userId: 'user-001',
+            totalAssets: 5000000,
+            monthlyIncome: 200000,
+        });
+    });
+
+    it('正常系: 月次収入 0 で保存できる', async () => {
+        vi.mocked(mockRepo.upsert).mockResolvedValue({ ...mockSettings, monthlyIncome: 0 });
+
+        const result = await useCase.execute({
+            userId: 'user-001',
+            totalAssets: 1000000,
+            monthlyIncome: 0,
+        });
+
+        expect(result.monthlyIncome).toBe(0);
+    });
+
+    it('正常系: 総資産 0 で保存できる', async () => {
+        vi.mocked(mockRepo.upsert).mockResolvedValue({ ...mockSettings, totalAssets: 0 });
+
+        const result = await useCase.execute({
+            userId: 'user-001',
+            totalAssets: 0,
+            monthlyIncome: 0,
+        });
+
+        expect(result.totalAssets).toBe(0);
+    });
+
+    it('異常系: 総資産が負数のとき ValidationError をスローする', async () => {
+        await expect(useCase.execute({ userId: 'user-001', totalAssets: -1, monthlyIncome: 0 })).rejects.toThrow(
+            ValidationError
+        );
+    });
+
+    it('異常系: 月次収入が負数のとき ValidationError をスローする', async () => {
+        await expect(useCase.execute({ userId: 'user-001', totalAssets: 0, monthlyIncome: -1 })).rejects.toThrow(
+            ValidationError
+        );
+    });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -16,6 +16,8 @@ import type { DeleteUserUseCase } from './application/use-cases/user/DeleteUserU
 import type { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
 import type { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
 import type { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
+import type { GetUserSettingsUseCase } from './application/use-cases/settings/GetUserSettingsUseCase';
+import type { UpsertUserSettingsUseCase } from './application/use-cases/settings/UpsertUserSettingsUseCase';
 import type { GetExpenditureAnalysisUseCase } from './application/use-cases/xday/GetExpenditureAnalysisUseCase';
 import type { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
 import { buildServices } from './container';
@@ -23,9 +25,11 @@ import type { IBudgetRepository } from './domain/repositories/IBudgetRepository'
 import type { IExpenseRepository } from './domain/repositories/IExpenseRepository';
 import type { IPasswordResetTokenRepository } from './domain/repositories/IPasswordResetTokenRepository';
 import type { IRefreshTokenRepository } from './domain/repositories/IRefreshTokenRepository';
+import type { IUserSettingsRepository } from './domain/repositories/IUserSettingsRepository';
 import type { ISecurityAnswerRepository } from './domain/repositories/ISecurityAnswerRepository';
 import type { IUserRepository } from './domain/repositories/IUserRepository';
 import { createAuthRoutes } from './presentation/routes/auth';
+import { createSettingsRoutes } from './presentation/routes/settings';
 import { createBudgetRoutes } from './presentation/routes/budget';
 import { createExpenseRoutes } from './presentation/routes/expense';
 import { createExportRoutes } from './presentation/routes/export';
@@ -41,6 +45,7 @@ export type AppDeps = {
     refreshTokenRepository: IRefreshTokenRepository;
     securityAnswerRepository: ISecurityAnswerRepository;
     passwordResetTokenRepository: IPasswordResetTokenRepository;
+    userSettingsRepository: IUserSettingsRepository;
 };
 
 /**
@@ -72,6 +77,9 @@ export type RouteServices = {
     createUserUseCase: CreateUserUseCase;
     updateUserUseCase: UpdateUserUseCase;
     deleteUserUseCase: DeleteUserUseCase;
+    // Settings
+    getUserSettingsUseCase: GetUserSettingsUseCase;
+    upsertUserSettingsUseCase: UpsertUserSettingsUseCase;
     // XDay
     getXDayUseCase: GetXDayUseCase;
     getAnalysisUseCase: GetExpenditureAnalysisUseCase;
@@ -114,6 +122,7 @@ export function createApp(deps: AppDeps) {
     app.route('/api', createUserRoutes(services));
     app.route('/api', createRecoveryRoutes(services));
     app.route('/api', createExportRoutes(services));
+    app.route('/api', createSettingsRoutes(services));
     app.route('/api', createXDayRoutes(services));
 
     app.onError((err, c) => {

--- a/apps/api/src/application/use-cases/settings/GetUserSettingsUseCase.ts
+++ b/apps/api/src/application/use-cases/settings/GetUserSettingsUseCase.ts
@@ -1,0 +1,11 @@
+import type { UserSettings } from '../../../domain/models/UserSettings';
+import type { IUserSettingsRepository } from '../../../domain/repositories/IUserSettingsRepository';
+
+export class GetUserSettingsUseCase {
+    constructor(private readonly userSettingsRepository: IUserSettingsRepository) {}
+
+    /** ユーザー設定を取得する。未設定の場合は null を返す */
+    async execute(userId: string): Promise<UserSettings | null> {
+        return this.userSettingsRepository.findByUserId(userId);
+    }
+}

--- a/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
+++ b/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
@@ -1,0 +1,23 @@
+import type { UserSettings } from '../../../domain/models/UserSettings';
+import type { IUserSettingsRepository } from '../../../domain/repositories/IUserSettingsRepository';
+import { ValidationError } from '../../../shared/errors/DomainException';
+
+export type UpsertUserSettingsInput = {
+    userId: string;
+    totalAssets: number;
+    monthlyIncome: number;
+};
+
+export class UpsertUserSettingsUseCase {
+    constructor(private readonly userSettingsRepository: IUserSettingsRepository) {}
+
+    async execute(input: UpsertUserSettingsInput): Promise<UserSettings> {
+        if (input.totalAssets < 0) {
+            throw new ValidationError('総資産は0以上の値を入力してください');
+        }
+        if (input.monthlyIncome < 0) {
+            throw new ValidationError('月次収入は0以上の値を入力してください');
+        }
+        return this.userSettingsRepository.upsert(input);
+    }
+}

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -14,11 +14,14 @@ import { DeleteUserUseCase } from './application/use-cases/user/DeleteUserUseCas
 import { GetUserByIdUseCase } from './application/use-cases/user/GetUserByIdUseCase';
 import { GetUsersUseCase } from './application/use-cases/user/GetUsersUseCase';
 import { UpdateUserUseCase } from './application/use-cases/user/UpdateUserUseCase';
+import { GetUserSettingsUseCase } from './application/use-cases/settings/GetUserSettingsUseCase';
+import { UpsertUserSettingsUseCase } from './application/use-cases/settings/UpsertUserSettingsUseCase';
 import { GetExpenditureAnalysisUseCase } from './application/use-cases/xday/GetExpenditureAnalysisUseCase';
 import { GetXDayUseCase } from './application/use-cases/xday/GetXDayUseCase';
 import { PrismaBudgetRepository } from './infrastructure/persistence/PrismaBudgetRepository';
 import { PrismaExpenseRepository } from './infrastructure/persistence/PrismaExpenseRepository';
 import { PrismaPasswordResetTokenRepository } from './infrastructure/persistence/PrismaPasswordResetTokenRepository';
+import { PrismaUserSettingsRepository } from './infrastructure/persistence/PrismaUserSettingsRepository';
 import { PrismaRefreshTokenRepository } from './infrastructure/persistence/PrismaRefreshTokenRepository';
 import { PrismaSecurityAnswerRepository } from './infrastructure/persistence/PrismaSecurityAnswerRepository';
 import { PrismaUserRepository } from './infrastructure/persistence/PrismaUserRepository';
@@ -37,6 +40,7 @@ export function buildDeps(): AppDeps {
         refreshTokenRepository: new PrismaRefreshTokenRepository(prisma),
         securityAnswerRepository: new PrismaSecurityAnswerRepository(prisma),
         passwordResetTokenRepository: new PrismaPasswordResetTokenRepository(prisma),
+        userSettingsRepository: new PrismaUserSettingsRepository(prisma),
     };
 }
 
@@ -73,6 +77,9 @@ export function buildServices(deps: AppDeps, tokenService: TokenService): RouteS
         createUserUseCase: new CreateUserUseCase(deps.userRepository, passwordHasher),
         updateUserUseCase: new UpdateUserUseCase(deps.userRepository),
         deleteUserUseCase: new DeleteUserUseCase(deps.userRepository),
+        // Settings
+        getUserSettingsUseCase: new GetUserSettingsUseCase(deps.userSettingsRepository),
+        upsertUserSettingsUseCase: new UpsertUserSettingsUseCase(deps.userSettingsRepository),
         // XDay
         getXDayUseCase: new GetXDayUseCase(deps.expenseRepository),
         getAnalysisUseCase: new GetExpenditureAnalysisUseCase(deps.expenseRepository),

--- a/apps/api/src/domain/models/UserSettings.ts
+++ b/apps/api/src/domain/models/UserSettings.ts
@@ -1,0 +1,9 @@
+/** ユーザー設定ドメインモデル（総資産・月次収入） */
+export type UserSettings = {
+    id: string;
+    userId: string;
+    totalAssets: number;
+    monthlyIncome: number;
+    createdAt: Date;
+    updatedAt: Date;
+};

--- a/apps/api/src/domain/repositories/IUserSettingsRepository.ts
+++ b/apps/api/src/domain/repositories/IUserSettingsRepository.ts
@@ -1,0 +1,8 @@
+import type { UserSettings } from '../models/UserSettings';
+
+export interface IUserSettingsRepository {
+    /** ユーザーIDで設定を取得する（未設定時は null） */
+    findByUserId(userId: string): Promise<UserSettings | null>;
+    /** 設定を保存する（存在すれば更新、なければ作成） */
+    upsert(settings: Omit<UserSettings, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserSettings>;
+}

--- a/apps/api/src/infrastructure/persistence/PrismaUserSettingsRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaUserSettingsRepository.ts
@@ -1,0 +1,45 @@
+import type { PrismaClient } from '@prisma/client';
+import { ulid } from 'ulid';
+import type { UserSettings } from '../../domain/models/UserSettings';
+import type { IUserSettingsRepository } from '../../domain/repositories/IUserSettingsRepository';
+
+export class PrismaUserSettingsRepository implements IUserSettingsRepository {
+    constructor(private readonly prisma: PrismaClient) {}
+
+    async findByUserId(userId: string): Promise<UserSettings | null> {
+        const record = await this.prisma.userSettings.findUnique({ where: { userId } });
+        if (!record) return null;
+        return {
+            id: record.id,
+            userId: record.userId,
+            totalAssets: record.totalAssets,
+            monthlyIncome: record.monthlyIncome,
+            createdAt: record.createdAt,
+            updatedAt: record.updatedAt,
+        };
+    }
+
+    async upsert(settings: Omit<UserSettings, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserSettings> {
+        const record = await this.prisma.userSettings.upsert({
+            where: { userId: settings.userId },
+            create: {
+                id: ulid(),
+                userId: settings.userId,
+                totalAssets: settings.totalAssets,
+                monthlyIncome: settings.monthlyIncome,
+            },
+            update: {
+                totalAssets: settings.totalAssets,
+                monthlyIncome: settings.monthlyIncome,
+            },
+        });
+        return {
+            id: record.id,
+            userId: record.userId,
+            totalAssets: record.totalAssets,
+            monthlyIncome: record.monthlyIncome,
+            createdAt: record.createdAt,
+            updatedAt: record.updatedAt,
+        };
+    }
+}

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -384,3 +384,27 @@ export const ExpenditureAnalysisResponseSchema = z
 export const ExportQuerySchema = z.object({
     format: z.enum(['json', 'csv']).default('json').openapi({ description: 'エクスポート形式', example: 'json' }),
 });
+
+// ─── ユーザー設定 (Settings) ──────────────────────────────────────
+
+export const UserSettingsResponseSchema = z
+    .object({
+        totalAssets: z.number().int().min(0).openapi({ description: '総資産（円）', example: 5000000 }),
+        monthlyIncome: z.number().int().min(0).openapi({ description: '月次固定収入（円）', example: 200000 }),
+    })
+    .openapi('UserSettingsResponse');
+
+export const UpsertUserSettingsBodySchema = z
+    .object({
+        totalAssets: z
+            .number({ invalid_type_error: '総資産は数値で入力してください' })
+            .int()
+            .min(0, '総資産は0以上の値を入力してください')
+            .openapi({ description: '総資産（円）', example: 5000000 }),
+        monthlyIncome: z
+            .number({ invalid_type_error: '月次収入は数値で入力してください' })
+            .int()
+            .min(0, '月次収入は0以上の値を入力してください')
+            .openapi({ description: '月次固定収入（円）', example: 200000 }),
+    })
+    .openapi('UpsertUserSettingsBody');

--- a/apps/api/src/presentation/routes/settings.ts
+++ b/apps/api/src/presentation/routes/settings.ts
@@ -1,0 +1,93 @@
+import { createRoute } from '@hono/zod-openapi';
+import type { RouteServices } from '../../app';
+import { createOpenAPIApp } from '../../lib/openapi-app';
+import { ErrorResponseSchema, UpsertUserSettingsBodySchema, UserSettingsResponseSchema } from '../../openapi/schemas';
+import { createAuthMiddleware } from '../middleware/auth';
+
+// ─── Route 定義 ──────────────────────────────────────────────────
+
+const getUserSettingsRoute = createRoute({
+    method: 'get',
+    path: '/settings',
+    tags: ['Settings'],
+    summary: 'ユーザー設定取得',
+    security: [{ bearerAuth: [] }],
+    responses: {
+        200: {
+            content: { 'application/json': { schema: UserSettingsResponseSchema } },
+            description: 'ユーザー設定（未設定時はデフォルト値を返す）',
+        },
+        401: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: '未認証',
+        },
+    },
+});
+
+const upsertUserSettingsRoute = createRoute({
+    method: 'put',
+    path: '/settings',
+    tags: ['Settings'],
+    summary: 'ユーザー設定保存',
+    security: [{ bearerAuth: [] }],
+    request: {
+        body: {
+            content: { 'application/json': { schema: UpsertUserSettingsBodySchema } },
+            required: true,
+        },
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: UserSettingsResponseSchema } },
+            description: '保存成功',
+        },
+        400: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'バリデーションエラー',
+        },
+        401: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: '未認証',
+        },
+    },
+});
+
+// ─── Handler 実装 ────────────────────────────────────────────────
+
+export function createSettingsRoutes({
+    tokenService,
+    getUserSettingsUseCase,
+    upsertUserSettingsUseCase,
+}: RouteServices) {
+    const auth = createAuthMiddleware(tokenService);
+    const app = createOpenAPIApp();
+
+    app.use('/settings', auth);
+
+    app.openapi(getUserSettingsRoute, async (c) => {
+        const userId = c.get('userId');
+        const settings = await getUserSettingsUseCase.execute(userId);
+        return c.json(
+            {
+                totalAssets: settings?.totalAssets ?? 0,
+                monthlyIncome: settings?.monthlyIncome ?? 0,
+            },
+            200
+        );
+    });
+
+    app.openapi(upsertUserSettingsRoute, async (c) => {
+        const userId = c.get('userId');
+        const { totalAssets, monthlyIncome } = c.req.valid('json');
+        const settings = await upsertUserSettingsUseCase.execute({ userId, totalAssets, monthlyIncome });
+        return c.json(
+            {
+                totalAssets: settings.totalAssets,
+                monthlyIncome: settings.monthlyIncome,
+            },
+            200
+        );
+    });
+
+    return app;
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { getExpenses } from "@/lib/api/expense";
+import { getSettings } from "@/lib/api/settings";
 import { ApiError } from "@/lib/api/client";
 import { AppShell } from "@/components/layout/AppShell";
 import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
@@ -53,14 +54,23 @@ function computeXDayInputs(expenses: { balanceType: number; amount: number; date
 
 async function DashboardContent({ userId }: { userId: string }) {
   let expenses;
+  let settings = { totalAssets: null as number | null, monthlyIncome: 0 };
+
   try {
-    const data = await getExpenses();
-    expenses = data.expense ?? [];
+    const [expenseData, settingsData] = await Promise.all([getExpenses(), getSettings()]);
+    expenses = expenseData.expense ?? [];
+    settings = {
+      totalAssets: settingsData.totalAssets === 0 && settingsData.monthlyIncome === 0
+        ? null  // 未設定扱い（初回セットアップ）
+        : settingsData.totalAssets,
+      monthlyIncome: settingsData.monthlyIncome,
+    };
   } catch (err) {
     if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
       redirect("/login");
     }
-    throw err;
+    // settings の取得に失敗しても expenses は続行できる場合はそのまま
+    if (expenses === undefined) throw err;
   }
 
   const { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays } =
@@ -90,6 +100,8 @@ async function DashboardContent({ userId }: { userId: string }) {
               zeroStreakDays={zeroStreakDays}
               avgDailyExpense={avgDailyExpense}
               recordedDays={recordedDays}
+              initialAssets={settings.totalAssets}
+              initialIncome={settings.monthlyIncome}
             />
           </div>
         </div>

--- a/apps/web/src/components/dashboard/SetupModal.tsx
+++ b/apps/web/src/components/dashboard/SetupModal.tsx
@@ -1,9 +1,15 @@
 "use client";
 
 import { X } from "lucide-react";
+import type { SettingsActionState } from "@/lib/actions/settings";
 
 interface Props {
+    /** 保存完了後にローカル state を更新するコールバック */
     onSave: (totalAssets: number, monthlyIncome: number) => void;
+    /** useActionState から渡す formAction */
+    formAction: (payload: FormData) => void;
+    /** useActionState から渡す state */
+    actionState: SettingsActionState;
     /** 前回保存済みの値（再設定時に初期セット） */
     defaultAssets?: number;
     defaultIncome?: number;
@@ -12,13 +18,23 @@ interface Props {
 }
 
 /** 資産・月次収入を入力するセットアップモーダル */
-export function SetupModal({ onSave, defaultAssets, defaultIncome, onClose }: Props) {
+export function SetupModal({
+    onSave,
+    formAction,
+    actionState,
+    defaultAssets,
+    defaultIncome,
+    onClose,
+}: Props) {
     function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
         const fd = new FormData(e.currentTarget);
         const assets = Number(fd.get("totalAssets"));
         const income = Number(fd.get("monthlyIncome") ?? 0);
         if (assets < 0 || Number.isNaN(assets)) return;
+        // Server Action を呼び出す
+        formAction(fd);
+        // ローカル state をすぐに更新（楽観的 UI）
         onSave(assets, income);
     }
 
@@ -70,6 +86,12 @@ export function SetupModal({ onSave, defaultAssets, defaultIncome, onClose }: Pr
                             あと何年・何ヶ月 自由に暮らせるか
                         </span>
                         がわかります。
+                    </p>
+                )}
+
+                {actionState.error && (
+                    <p className="mb-4 rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
+                        {actionState.error}
                     </p>
                 )}
 

--- a/apps/web/src/components/dashboard/XDayDisplay.tsx
+++ b/apps/web/src/components/dashboard/XDayDisplay.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo, useSyncExternalStore } from "react";
+import { useState, useEffect, useCallback, useMemo, useActionState } from "react";
 import {
     calcRealtimeAssets,
     calcExpenseImpact,
@@ -8,30 +8,8 @@ import {
     DEFAULT_STATS_DAILY_EXPENSE,
 } from "@budget/common";
 import { SetupModal } from "./SetupModal";
-
-const STORAGE_KEY_ASSETS = "hkl_total_assets";
-const STORAGE_KEY_INCOME = "hkl_monthly_income";
-
-/**
- * localStorage を外部ストアとして扱う useSyncExternalStore ヘルパー。
- * - サーバースナップショット = null（SSR 時は常に未設定扱い）
- * - クライアントスナップショット = localStorage の現在値
- * これにより hydration 時はサーバーと一致し、マウント後に localStorage 値へ遷移する。
- */
-function subscribeStorage(callback: () => void): () => void {
-    window.addEventListener("storage", callback);
-    return () => window.removeEventListener("storage", callback);
-}
-function readAssetsSnapshot(): number | null {
-    const v = localStorage.getItem(STORAGE_KEY_ASSETS);
-    return v !== null ? Number(v) : null;
-}
-function readIncomeSnapshot(): number {
-    const v = localStorage.getItem(STORAGE_KEY_INCOME);
-    return v ? Number(v) : 0;
-}
-const SERVER_ASSETS: number | null = null;
-const SERVER_INCOME: number = 0;
+import { upsertSettingsAction } from "@/lib/actions/settings";
+import type { SettingsActionState } from "@/lib/actions/settings";
 
 interface Props {
     /** 本日の支出合計 */
@@ -44,6 +22,10 @@ interface Props {
     avgDailyExpense: number;
     /** 記録済み日数n（Server側で算出） */
     recordedDays: number;
+    /** サーバーから取得した総資産（null = 未設定） */
+    initialAssets: number | null;
+    /** サーバーから取得した月次収入 */
+    initialIncome: number;
 }
 
 /** 残存日数を「◯年◯ヶ月」形式に変換 */
@@ -106,26 +88,32 @@ function TrustBar({ value }: { value: number }) {
     );
 }
 
+const initialState: SettingsActionState = { error: null, success: false };
+
 export function XDayDisplay({
     todayExpense,
     yesterdayExpense,
     zeroStreakDays,
     avgDailyExpense,
     recordedDays,
+    initialAssets,
+    initialIncome,
 }: Props) {
-    const totalAssets = useSyncExternalStore(subscribeStorage, readAssetsSnapshot, () => SERVER_ASSETS);
-    const monthlyIncome = useSyncExternalStore(subscribeStorage, readIncomeSnapshot, () => SERVER_INCOME);
+    // サーバーから取得した初期値を state に持つ（更新後は即時反映）
+    const [totalAssets, setTotalAssets] = useState<number | null>(initialAssets);
+    const [monthlyIncome, setMonthlyIncome] = useState<number>(initialIncome);
 
     const [rtAssets, setRtAssets] = useState<number | null>(null);
     const [rtDays, setRtDays] = useState<number | null>(null);
     const [snapshotAt] = useMemo(() => [new Date()], []);
 
     const [showSetup, setShowSetup] = useState(false);
+    const [state, formAction] = useActionState(upsertSettingsAction, initialState);
 
+    // Server Action 成功時にローカル state を更新してモーダルを閉じる
     const handleSetup = useCallback((assets: number, income: number) => {
-        localStorage.setItem(STORAGE_KEY_ASSETS, String(assets));
-        localStorage.setItem(STORAGE_KEY_INCOME, String(income));
-        window.dispatchEvent(new Event("storage"));
+        setTotalAssets(assets);
+        setMonthlyIncome(income);
         setShowSetup(false);
     }, []);
 
@@ -163,13 +151,21 @@ export function XDayDisplay({
     }, [totalAssets, netDailyExpense, snapshotAt]);
 
     if (totalAssets === null) {
-        return <SetupModal onSave={handleSetup} />;
+        return (
+            <SetupModal
+                onSave={handleSetup}
+                formAction={formAction}
+                actionState={state}
+            />
+        );
     }
 
     if (showSetup) {
         return (
             <SetupModal
                 onSave={handleSetup}
+                formAction={formAction}
+                actionState={state}
                 defaultAssets={totalAssets}
                 defaultIncome={monthlyIncome}
                 onClose={() => setShowSetup(false)}

--- a/apps/web/src/lib/actions/settings.ts
+++ b/apps/web/src/lib/actions/settings.ts
@@ -1,0 +1,31 @@
+"use server";
+
+import { putSettings } from "@/lib/api/settings";
+
+export type SettingsActionState = {
+  error: string | null;
+  success: boolean;
+};
+
+/** 総資産・月次収入をサーバーに保存する Server Action */
+export async function upsertSettingsAction(
+  _prev: SettingsActionState,
+  formData: FormData,
+): Promise<SettingsActionState> {
+  const totalAssets = Number(formData.get("totalAssets") ?? 0);
+  const monthlyIncome = Number(formData.get("monthlyIncome") ?? 0);
+
+  if (Number.isNaN(totalAssets) || totalAssets < 0) {
+    return { error: "総資産は0以上の値を入力してください", success: false };
+  }
+  if (Number.isNaN(monthlyIncome) || monthlyIncome < 0) {
+    return { error: "月次収入は0以上の値を入力してください", success: false };
+  }
+
+  try {
+    await putSettings({ totalAssets, monthlyIncome });
+    return { error: null, success: true };
+  } catch {
+    return { error: "保存に失敗しました。しばらくしてから再度お試しください", success: false };
+  }
+}

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -1,0 +1,17 @@
+import { serverFetch } from "./client";
+
+export type UserSettings = {
+  totalAssets: number;
+  monthlyIncome: number;
+};
+
+export async function getSettings(): Promise<UserSettings> {
+  return serverFetch<UserSettings>("/api/settings");
+}
+
+export async function putSettings(data: UserSettings): Promise<UserSettings> {
+  return serverFetch<UserSettings>("/api/settings", {
+    method: "PUT",
+    body: JSON.stringify(data),
+  });
+}

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -53,6 +53,15 @@ Table user_security_answers {
   question security_question_presets [not null]
 }
 
+Table user_settings {
+  id String [pk]
+  userId String [unique, not null]
+  totalAssets Int [not null, default: 0]
+  monthlyIncome Int [not null, default: 0]
+  createdAt DateTime [default: `now()`, not null]
+  updatedAt DateTime [not null]
+}
+
 Table password_reset_tokens {
   id String [pk]
   tokenHash String [unique, not null]

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -598,6 +598,38 @@ components:
       required:
         - resetToken
         - newPassword
+    UserSettingsResponse:
+      type: object
+      properties:
+        totalAssets:
+          type: integer
+          minimum: 0
+          description: 総資産（円）
+          example: 5000000
+        monthlyIncome:
+          type: integer
+          minimum: 0
+          description: 月次固定収入（円）
+          example: 200000
+      required:
+        - totalAssets
+        - monthlyIncome
+    UpsertUserSettingsBody:
+      type: object
+      properties:
+        totalAssets:
+          type: integer
+          minimum: 0
+          description: 総資産（円）
+          example: 5000000
+        monthlyIncome:
+          type: integer
+          minimum: 0
+          description: 月次固定収入（円）
+          example: 200000
+      required:
+        - totalAssets
+        - monthlyIncome
     XDayResponse:
       type: object
       properties:
@@ -1481,6 +1513,57 @@ paths:
             text/csv:
               schema:
                 nullable: true
+        "401":
+          description: 未認証
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/settings:
+    get:
+      tags:
+        - Settings
+      summary: ユーザー設定取得
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: ユーザー設定（未設定時はデフォルト値を返す）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSettingsResponse"
+        "401":
+          description: 未認証
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+    put:
+      tags:
+        - Settings
+      summary: ユーザー設定保存
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpsertUserSettingsBody"
+      responses:
+        "200":
+          description: 保存成功
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserSettingsResponse"
+        "400":
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: 未認証
           content:


### PR DESCRIPTION
## 概要

設定画面（XDayDisplay / SetupModal）で入力した「総資産」「月次収入」をサーバーサイドに永続化する機能を実装した。
これまで localStorage に保存していた設定データを、API 経由で DB（user_settings テーブル）に保存・取得するように変更した。

## 変更内容

**バックエンド**
- Prisma スキーマに `UserSettings` モデルを追加（`user_settings` テーブル・ULID主キー・upsert対応）
- `IUserSettingsRepository` インターフェースと `PrismaUserSettingsRepository` 実装を追加
- `GetUserSettingsUseCase` / `UpsertUserSettingsUseCase` を追加（負数バリデーション付き）
- `GET /api/settings` / `PUT /api/settings` エンドポイントを追加（Bearer 認証必須）
- openapi.yaml に `UserSettingsResponse` / `UpsertUserSettingsBody` スキーマを追加

**フロントエンド**
- `apps/web/src/lib/api/settings.ts`: サーバーから設定を取得する `getSettings()` / `putSettings()` を追加
- `apps/web/src/lib/actions/settings.ts`: Server Action `upsertSettingsAction` を追加
- `XDayDisplay.tsx`: localStorage 依存を除去し、`initialAssets`/`initialIncome` propsと `useActionState` ベースに変更
- `SetupModal.tsx`: `formAction` / `actionState` props を受け取る形式に変更
- `page.tsx`: サーバーサイドで `getSettings()` を呼び出し、初期値を注入

## 影響範囲

- `app.ts` / `container.ts`: `IUserSettingsRepository` を全依存注入に追加
- 既存の auth・expense 統合テストの `createApp()` 呼び出しに `userSettingsRepository` を追加
- フロント: `XDayDisplay`・`SetupModal` のインターフェース変更（破壊的変更なし・既存の props は維持）

## テスト内容

- ユニットテスト追加（7件）: `GetUserSettingsUseCase`（2件）/ `UpsertUserSettingsUseCase`（5件）
- 統合テスト追加（5件）: `GET /api/settings`（2件）/ `PUT /api/settings`（3件）
- 既存テスト（unit 93件・integration 25件）が引き続き全件パス

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（PrismaUserSettingsRepository で ulid() を使用）
- [x] マジックナンバーを排除し、定数化されているか（デフォルト値は DB スキーマの `@default(0)` で管理）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- SetupModal / XDayDisplay のUI自体は変更なし。動作は localStorage から Server Action に切り替え。マージ前に動作確認を推奨。 -->

Closes #81