### PR TITLE
feat: 連続記録日数（記録ストリーク）バッジをダッシュボードに表示する

### DIFF
--- a/apps/web/src/__tests__/components/XDayDisplay.test.tsx
+++ b/apps/web/src/__tests__/components/XDayDisplay.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { XDayDisplay } from '../../components/dashboard/XDayDisplay'
+
+// upsertSettingsAction をモック（useActionState 内で使用）
+vi.mock('../../lib/actions/settings', () => ({
+    upsertSettingsAction: vi.fn(),
+}))
+
+/** XDayDisplay のデフォルト props（SetupModal が表示されない最低限の値） */
+const defaultProps = {
+    todayExpense: 0,
+    yesterdayExpense: 0,
+    zeroStreakDays: 0,
+    avgDailyExpense: 1000,
+    recordedDays: 10,
+    recordingStreak: 0,
+    initialAssets: 1000000,
+    initialIncome: 200000,
+}
+
+describe('XDayDisplay', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+        vi.setSystemTime(new Date('2024-03-15T12:00:00Z'))
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    describe('連続記録バッジ', () => {
+        it('recordingStreak=0 のとき連続記録バッジを表示しない', () => {
+            render(<XDayDisplay {...defaultProps} recordingStreak={0} />)
+            expect(screen.queryByText(/日連続記録中/)).not.toBeInTheDocument()
+        })
+
+        it('recordingStreak=1 のとき「1日連続記録中」バッジを表示する', () => {
+            render(<XDayDisplay {...defaultProps} recordingStreak={1} />)
+            expect(screen.getByText('1日連続記録中')).toBeInTheDocument()
+        })
+
+        it('recordingStreak=30 のとき「30日連続記録中」バッジを表示する', () => {
+            render(<XDayDisplay {...defaultProps} recordingStreak={30} />)
+            expect(screen.getByText('30日連続記録中')).toBeInTheDocument()
+        })
+
+        it('initialAssets=null（未設定）のとき SetupModal が表示されバッジは表示されない', () => {
+            render(<XDayDisplay {...defaultProps} initialAssets={null} recordingStreak={5} />)
+            // SetupModal が表示されているので連続記録バッジは表示されない
+            expect(screen.queryByText('5日連続記録中')).not.toBeInTheDocument()
+        })
+    })
+
+    describe('家計の寿命カード', () => {
+        it('initialAssets が設定済みのとき「家計の寿命」ヘッダーが表示される', () => {
+            render(<XDayDisplay {...defaultProps} />)
+            expect(screen.getByText('家計の寿命')).toBeInTheDocument()
+        })
+
+        it('initialAssets=null のとき SetupModal が表示される', () => {
+            render(<XDayDisplay {...defaultProps} initialAssets={null} />)
+            // SetupModal に含まれるテキストが表示される
+            expect(screen.getByText(/総資産|月次収入|設定/)).toBeInTheDocument()
+        })
+    })
+})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -39,6 +39,15 @@ function computeXDayInputs(expenses: { balanceType: number; amount: number; date
     zeroStreakDays++;
   }
 
+  // 連続記録日数: 今日から遡って何らかの記録がある日が続く日数
+  const allRecordDates = new Set(expenses.map((e) => e.date));
+  let recordingStreak = 0;
+  for (let i = 0; i < 365; i++) {
+    const d = new Date(Date.now() - i * 86400_000).toISOString().slice(0, 10);
+    if (!allRecordDates.has(d)) break;
+    recordingStreak++;
+  }
+
   // 直近30日の日次平均支出B（実績ベース）
   const cutoff = new Date(Date.now() - 30 * 86400_000).toISOString().slice(0, 10);
   const recent30 = expenses.filter((e) => e.balanceType === 0 && e.date >= cutoff);
@@ -49,7 +58,7 @@ function computeXDayInputs(expenses: { balanceType: number; amount: number; date
       ? recent30.reduce((s, e) => s + e.amount, 0) / recordedDays
       : 0;
 
-  return { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays };
+  return { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays, recordingStreak };
 }
 
 async function DashboardContent({ userId }: { userId: string }) {
@@ -73,7 +82,7 @@ async function DashboardContent({ userId }: { userId: string }) {
     if (expenses === undefined) throw err;
   }
 
-  const { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays } =
+  const { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays, recordingStreak } =
     computeXDayInputs(expenses);
 
   return (
@@ -100,6 +109,7 @@ async function DashboardContent({ userId }: { userId: string }) {
               zeroStreakDays={zeroStreakDays}
               avgDailyExpense={avgDailyExpense}
               recordedDays={recordedDays}
+              recordingStreak={recordingStreak}
               initialAssets={settings.totalAssets}
               initialIncome={settings.monthlyIncome}
             />

--- a/apps/web/src/components/dashboard/XDayDisplay.tsx
+++ b/apps/web/src/components/dashboard/XDayDisplay.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useMemo, useActionState } from "react";
+import { Flame } from "lucide-react";
 import {
     calcRealtimeAssets,
     calcExpenseImpact,
@@ -22,6 +23,8 @@ interface Props {
     avgDailyExpense: number;
     /** 記録済み日数n（Server側で算出） */
     recordedDays: number;
+    /** 連続記録日数（今日から遡り記録がある日が続く日数） */
+    recordingStreak: number;
     /** サーバーから取得した総資産（null = 未設定） */
     initialAssets: number | null;
     /** サーバーから取得した月次収入 */
@@ -96,6 +99,7 @@ export function XDayDisplay({
     zeroStreakDays,
     avgDailyExpense,
     recordedDays,
+    recordingStreak,
     initialAssets,
     initialIncome,
 }: Props) {
@@ -258,6 +262,16 @@ export function XDayDisplay({
                 </div>
                 <TrustBar value={trustWeight} />
             </div>
+
+            {/* 連続記録バッジ */}
+            {recordingStreak >= 1 && (
+                <div className="mb-3 flex items-center gap-2 rounded-xl bg-[#fff6ee] px-3 py-2">
+                    <Flame size={16} className="text-[#f18840]" />
+                    <span className="text-xs font-bold text-[#f18840]">
+                        {recordingStreak}日連続記録中
+                    </span>
+                </div>
+            )}
 
             {/* 積み上げメッセージ */}
             {zeroStreakDays >= 2 && (


### PR DESCRIPTION
## 概要

ダッシュボードに「N日連続記録中」バッジを追加した。
今日から遡って何らかの家計記録がある日が連続する日数を算出し、継続記録の動機付けに活用する。

## 変更内容

- `page.tsx`: `computeXDayInputs` に `recordingStreak` の計算を追加
  - 今日から遡り、expense/income を問わず記録のある日が途切れずに続く日数をカウント
  - 計算した値を `XDayDisplay` に渡す
- `XDayDisplay.tsx`:
  - `recordingStreak: number` prop を追加
  - `recordingStreak >= 1` のとき `Flame` アイコン（lucide-react）付きバッジを表示
  - `initialAssets=null`（未設定）の場合は SetupModal が表示されるためバッジは非表示

## 影響範囲

- `XDayDisplay` の Props 型が変更（`recordingStreak` が追加）
- `page.tsx` の `computeXDayInputs` の返り値に `recordingStreak` が追加
- 既存 UI の変更なし（バッジの追加のみ）

## テスト内容

- `XDayDisplay.test.tsx` を新規追加（6件）
  - `recordingStreak=0` でバッジ非表示
  - `recordingStreak=1`・`30` でバッジ表示
  - `initialAssets=null` のとき SetupModal が表示されバッジは非表示
  - 家計の寿命ヘッダー表示・SetupModal 表示の確認

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（FE のみの変更）
- [x] ID（ulid）の生成・利用箇所は適切か（ID 操作なし）
- [x] マジックナンバーを排除し、定数化されているか（閾値は `>= 1` のみ）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- XDayDisplay にバッジを追加。マージ前にローカルで動作確認を推奨。 -->

Closes #89