### PR TITLE
fix: AppShell の flex-col を復元しモバイルレイアウト崩れを修正する

### DIFF
--- a/apps/web/src/__tests__/components/AppShell.test.tsx
+++ b/apps/web/src/__tests__/components/AppShell.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * AppShell レイアウト構造テスト
+ *
+ * 【目的】
+ * - モバイルでコンテンツが正しく縦積みになることを保証する
+ * - flex-col（モバイル縦積み）が欠落するリグレッションを防ぐ
+ *
+ * 【背景】
+ * PR #157（Issue #141）で AppShell の外側ラッパーから flex-col が削除され、
+ * モバイルビューでヘッダーとコンテンツが横並びになる不具合が発生した。
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { AppShell } from '../../components/layout/AppShell'
+
+vi.mock('../../components/layout/Header', () => ({
+    Header: () => <div data-testid="mock-header" />,
+}))
+
+vi.mock('../../components/layout/BottomNav', () => ({
+    BottomNav: () => <div data-testid="mock-bottom-nav" />,
+}))
+
+describe('AppShell', () => {
+    it('外側ラッパーに flex-col クラスが含まれる（モバイル縦積みのリグレッション防止）', () => {
+        const { container } = render(
+            <AppShell>
+                <div data-testid="content">コンテンツ</div>
+            </AppShell>
+        )
+
+        // 最外側の div が flex-col を持つことを確認する
+        // これが欠落するとモバイルでヘッダーとコンテンツが横並びになる
+        const outerDiv = container.firstChild as HTMLElement
+        expect(outerDiv.className).toContain('flex-col')
+    })
+
+    it('children が描画される', () => {
+        const { getByTestId } = render(
+            <AppShell>
+                <div data-testid="content">コンテンツ</div>
+            </AppShell>
+        )
+
+        expect(getByTestId('content')).toBeInTheDocument()
+    })
+
+    it('PC 向けに md:flex-row クラスが含まれる', () => {
+        const { container } = render(
+            <AppShell>
+                <div>コンテンツ</div>
+            </AppShell>
+        )
+
+        const outerDiv = container.firstChild as HTMLElement
+        expect(outerDiv.className).toContain('md:flex-row')
+    })
+})

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -13,7 +13,7 @@ type Props = {
  */
 export function AppShell({ userName, children }: Props) {
   return (
-    <div className="flex min-h-screen bg-[#fffdf5]">
+    <div className="flex flex-col min-h-screen md:flex-row bg-[#fffdf5]">
       {/* PC: サイドバー / モバイル: ミニヘッダー */}
       <Header userName={userName} />
 


### PR DESCRIPTION
## 概要

PR #157（Issue #141）でサイドバーを導入した際、`AppShell.tsx` の外側ラッパーから `flex-col` が削除された。
`flex` のデフォルトは `flex-row` のため、モバイルでもヘッダーとコンテンツが横並びになり、すべてのページでレイアウトが崩れていた。

## 変更内容

**`AppShell.tsx`**
```
// Before（不具合）
<div className="flex min-h-screen bg-[#fffdf5]">

// After（修正済み）
<div className="flex flex-col min-h-screen md:flex-row bg-[#fffdf5]">
```
モバイル（< md）: `flex-col`で縦積み  
PC（≥ md）: `md:flex-row` でサイドバー横並び

**`AppShell.test.tsx`（新規）**
- `flex-col` が存在することを検証するリグレッション防止テストを追加

## 影響範囲

AppShell を使う全認証済みページのモバイルレイアウトが正常化される

## テスト内容

- `AppShell.test.tsx` 3 件追加（flex-col 存在確認・children 描画・md:flex-row 存在確認）
- 既存 unit テスト 102 件全パス

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（FE のみ）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（該当なし）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（レイアウト修正のみ・ユーザー報告スクリーンショット参照）

Closes #161