### PR TITLE
fix: user_settings マイグレーション追加とスキーマ乖離検知チェックを追加する

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -189,6 +189,32 @@ jobs:
           DATABASE_URL: "mysql://user:pass@localhost:3306/dummy"
         run: pnpm --filter @budget/api exec prisma validate
 
+      - name: Check schema changes have corresponding migration
+        run: |
+          # schema.prisma が変更されているのにマイグレーション SQL が追加されていない場合は失敗
+          git fetch origin "${{ github.base_ref }}" --depth=1
+
+          SCHEMA_CHANGED=$(git diff --name-only \
+            "origin/${{ github.base_ref }}...HEAD" \
+            -- "apps/api/prisma/schema.prisma" | wc -l)
+
+          MIGRATION_ADDED=$(git diff --name-only --diff-filter=A \
+            "origin/${{ github.base_ref }}...HEAD" \
+            -- "apps/api/prisma/migrations" 2>/dev/null | grep "\.sql$" | wc -l)
+
+          if [ "${SCHEMA_CHANGED}" -gt 0 ] && [ "${MIGRATION_ADDED}" -eq 0 ]; then
+            echo "エラー: schema.prisma が変更されていますが、マイグレーションファイルが追加されていません。"
+            echo ""
+            echo "以下を実行してマイグレーションを作成してください:"
+            echo "  cd apps/api && npx prisma migrate dev --name <変更内容の説明>"
+            echo ""
+            echo "注意: prisma db push はテスト用途にのみ使用してください。"
+            echo "      本番 DB には migrate deploy が使われるため、migration.sql が必須です。"
+            exit 1
+          fi
+
+          echo "スキーマとマイグレーションの整合性チェック完了。"
+
       - name: Check for destructive migrations
         run: |
           MIGRATION_DIR="apps/api/prisma/migrations"

--- a/apps/api/prisma/migrations/20260508000000_add_user_settings/migration.sql
+++ b/apps/api/prisma/migrations/20260508000000_add_user_settings/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE `user_settings` (
+    `id` VARCHAR(26) NOT NULL,
+    `user_id` VARCHAR(255) NOT NULL,
+    `total_assets` INTEGER NOT NULL DEFAULT 0,
+    `monthly_income` INTEGER NOT NULL DEFAULT 0,
+    `created_at` DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `updated_at` DATETIME(6) NOT NULL,
+
+    UNIQUE INDEX `user_settings_user_id_key`(`user_id`),
+    INDEX `IDX_user_settings_user_id`(`user_id`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -42,7 +42,26 @@ pre-commit:
         fi
       fail_text: "デザイントークンが最新ではありません。`pnpm run sync:tokens` を実行し、生成結果をステージングしてください。"
 
-    # 6. ユニット・コンポーネントテスト（DB 不要・高速）
+    # 6. Prisma マイグレーション整合性チェック:
+    #    schema.prisma が変更されているのに migration SQL が存在しない場合はコミットをブロックする
+    #    （prisma db push はテスト用途のみ。本番には migrate deploy が必要）
+    migration-sync:
+      run: |
+        SCHEMA_STAGED=$(git diff --cached --name-only -- "apps/api/prisma/schema.prisma" | wc -l)
+        MIGRATION_STAGED=$(git diff --cached --name-only --diff-filter=A -- "apps/api/prisma/migrations" | grep "\.sql$" | wc -l)
+
+        if [ "${SCHEMA_STAGED}" -gt 0 ] && [ "${MIGRATION_STAGED}" -eq 0 ]; then
+          echo "エラー: schema.prisma が変更されていますが、マイグレーションファイルが追加されていません。"
+          echo ""
+          echo "以下を実行してマイグレーションを作成してコミットに含めてください:"
+          echo "  cd apps/api && npx prisma migrate dev --name <変更内容の説明>"
+          echo ""
+          echo "注意: prisma db push はテスト用途のみ。本番 DB は migrate deploy を使用します。"
+          exit 1
+        fi
+      fail_text: "schema.prisma の変更にはマイグレーションファイルが必要です。`cd apps/api && npx prisma migrate dev --name <説明>` を実行してください。"
+
+    # 7. ユニット・コンポーネントテスト（DB 不要・高速）
     #    common / api / web の全ユニットテストを実行する
     #    新規コード追加時は対応するテストが存在しなければコミットをブロックする
     unit-test:


### PR DESCRIPTION
## Summary

- `prisma/migrations/20260508000000_add_user_settings/migration.sql` を追加
  - PR #158 (Issue #81) で `schema.prisma` に `UserSettings` モデルを追加したがマイグレーションが欠落していた
  - `user_settings` テーブルがDB上に存在せず `GET /api/settings` が失敗していた
- `lefthook.yml` に `migration-sync` チェックを追加（pre-commit）
  - `schema.prisma` 変更時に対応するマイグレーション SQL が未追加ならコミットをブロック
- `pr-checks.yml` に同様のチェックを追加（CI）
  - スキーマ変更があるのにマイグレーションがないと CI が失敗する

## 根本原因

`lefthook.yml` の pre-push が `prisma db push` でテスト DB を構築するため、マイグレーションファイルなしでも統合テストはパスする。しかし本番/開発 DB は `prisma migrate deploy` を使うためテーブルが作成されなかった。

## Test plan

- [x] ユニットテスト全件パス
- [x] `migration-sync` hook: `schema.prisma` のみ変更してコミットするとブロックされることを確認
- [x] 上記マイグレーションを手動で `prisma migrate deploy` して `user_settings` テーブルが作成されることを確認（ローカルDBにて）

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)