### PR TITLE
refactor: フロントエンドで自動生成 API クライアント型を一貫して使用する

### DIFF
--- a/apps/web/src/app/report/page.tsx
+++ b/apps/web/src/app/report/page.tsx
@@ -7,7 +7,7 @@ import { deleteBudgetAction } from "@/lib/actions/budget";
 import { getCategoryById, OUTGO_CATEGORIES } from "@/lib/constants/categories";
 import { PeriodSelector } from "@/components/report/PeriodSelector";
 import { AppShell } from "@/components/layout/AppShell";
-import type { BudgetResponse } from "@/lib/api/budget";
+import type { BudgetResponse } from "@budget/api-client";
 
 export const metadata: Metadata = {
   title: "レポート | 家計管理",

--- a/apps/web/src/lib/actions/budget.ts
+++ b/apps/web/src/lib/actions/budget.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { serverFetch, ApiError } from "../api/client";
-import type { GetBudgetResponse } from "../api/budget";
+import type { BudgetDetailResponse } from "@budget/api-client";
 import type { BalanceType } from "@budget/common";
 
 export type BudgetActionState = {
@@ -41,7 +41,7 @@ export async function createBudgetAction(
   const input: CreateBudgetInput = { amount, balanceType, userId, categoryId, date, content };
 
   try {
-    await serverFetch<GetBudgetResponse>("/api/budget", {
+    await serverFetch<BudgetDetailResponse>("/api/budget", {
       method: "POST",
       body: JSON.stringify({ newData: input }),
     });

--- a/apps/web/src/lib/api/budget.ts
+++ b/apps/web/src/lib/api/budget.ts
@@ -1,28 +1,7 @@
 import { serverFetch } from "./client";
-import type { BudgetProps } from "@budget/common";
-
-/**
- * JSON シリアライズ後の Budget レスポンス型。
- * Date フィールドは JSON 転送時に string になる。
- */
-export type BudgetResponse = Omit<
-  BudgetProps,
-  "createdDate" | "updatedDate" | "deletedDate"
-> & {
-  createdDate: string;
-  updatedDate: string;
-  deletedDate: string | null;
-};
-
-export type GetBudgetsResponse = {
-  budget: BudgetResponse[];
-};
-
-export type GetBudgetResponse = {
-  budget: BudgetResponse;
-};
+import type { BudgetListResponse } from "@budget/api-client";
 
 /** 全 Budget を取得する（Server Component 用） */
-export async function getBudgets(): Promise<GetBudgetsResponse> {
-  return serverFetch<GetBudgetsResponse>("/api/budget");
+export async function getBudgets(): Promise<BudgetListResponse> {
+  return serverFetch<BudgetListResponse>("/api/budget");
 }

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -1,16 +1,15 @@
 import { serverFetch } from "./client";
+import type { UserSettingsResponse } from "@budget/api-client";
 
-export type UserSettings = {
-  totalAssets: number;
-  monthlyIncome: number;
-};
+// 後方互換エイリアス（既存コードが参照中）
+export type UserSettings = UserSettingsResponse;
 
-export async function getSettings(): Promise<UserSettings> {
-  return serverFetch<UserSettings>("/api/settings");
+export async function getSettings(): Promise<UserSettingsResponse> {
+  return serverFetch<UserSettingsResponse>("/api/settings");
 }
 
-export async function putSettings(data: UserSettings): Promise<UserSettings> {
-  return serverFetch<UserSettings>("/api/settings", {
+export async function putSettings(data: UserSettingsResponse): Promise<UserSettingsResponse> {
+  return serverFetch<UserSettingsResponse>("/api/settings", {
     method: "PUT",
     body: JSON.stringify(data),
   });

--- a/apps/web/src/lib/api/types.ts
+++ b/apps/web/src/lib/api/types.ts
@@ -11,6 +11,16 @@ export type {
     GetExpenseResponse,
     LoginResponse,
     LogoutResponse,
+    BudgetResponse,
+    BudgetListResponse,
+    BudgetDetailResponse,
+    GetBudgetsResponse,
+    GetBudgetResponse,
+    XDayResponse,
+    ExpenditureAnalysisResponse,
+    CategoryAnalysis,
+    UserSettingsResponse,
+    UpsertUserSettingsBody,
 } from "@budget/api-client";
 
 /** 収支区分: 0=支出, 1=収入 */

--- a/apps/web/src/lib/api/xday.ts
+++ b/apps/web/src/lib/api/xday.ts
@@ -1,18 +1,18 @@
 import { serverFetch } from './client';
-import type { GetXDayOutput } from '../../../../api/src/application/use-cases/xday/GetXDayUseCase';
-import type { GetExpenditureAnalysisOutput } from '../../../../api/src/application/use-cases/xday/GetExpenditureAnalysisUseCase';
+import type { XDayResponse, ExpenditureAnalysisResponse } from '@budget/api-client';
 
-export type XDayData = GetXDayOutput & { snapshotAt: string };
-export type AnalysisData = GetExpenditureAnalysisOutput;
+// 後方互換エイリアス（既存コンポーネントが参照中）
+export type XDayData = XDayResponse;
+export type AnalysisData = ExpenditureAnalysisResponse;
 
-export async function getXDay(totalAssets: number, monthlyIncome: number): Promise<XDayData> {
-    return serverFetch<XDayData>(
+export async function getXDay(totalAssets: number, monthlyIncome: number): Promise<XDayResponse> {
+    return serverFetch<XDayResponse>(
         `/api/xday?totalAssets=${totalAssets}&monthlyIncome=${monthlyIncome}`
     );
 }
 
-export async function getExpenditureAnalysis(netDailyExpense: number): Promise<AnalysisData> {
-    return serverFetch<AnalysisData>(
+export async function getExpenditureAnalysis(netDailyExpense: number): Promise<ExpenditureAnalysisResponse> {
+    return serverFetch<ExpenditureAnalysisResponse>(
         `/api/xday/analysis?netDailyExpense=${netDailyExpense}`
     );
 }

--- a/packages/api-client/src/index.ts
+++ b/packages/api-client/src/index.ts
@@ -50,3 +50,22 @@ export type CreateExpenseRequest = CreateExpenseBody;
 export type LoginResponse = TokenPairResponse;
 export type GetExpensesResponse = ExpenseListResponse;
 export type GetExpenseResponse = ExpenseDetailResponse;
+
+// Budget 型
+export type BudgetResponse = components['schemas']['BudgetResponse'];
+export type BudgetListResponse = components['schemas']['BudgetListResponse'];
+export type BudgetDetailResponse = components['schemas']['BudgetDetailResponse'];
+export type CreateBudgetBody = components['schemas']['CreateBudgetBody'];
+
+// 旧スキーマ名の後方互換エイリアス
+export type GetBudgetsResponse = BudgetListResponse;
+export type GetBudgetResponse = BudgetDetailResponse;
+
+// XDay 型
+export type XDayResponse = components['schemas']['XDayResponse'];
+export type ExpenditureAnalysisResponse = components['schemas']['ExpenditureAnalysisResponse'];
+export type CategoryAnalysis = components['schemas']['CategoryAnalysis'];
+
+// UserSettings 型
+export type UserSettingsResponse = components['schemas']['UserSettingsResponse'];
+export type UpsertUserSettingsBody = components['schemas']['UpsertUserSettingsBody'];

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -400,7 +400,7 @@ export interface paths {
             };
             requestBody: {
                 content: {
-                    "application/json": components["schemas"]["CreateExpenseBody"];
+                    "application/json": components["schemas"]["UpdateExpenseBody"];
                 };
             };
             responses: {
@@ -1264,6 +1264,93 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/settings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** ユーザー設定取得 */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description ユーザー設定（未設定時はデフォルト値を返す） */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserSettingsResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        /** ユーザー設定保存 */
+        put: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpsertUserSettingsBody"];
+                };
+            };
+            responses: {
+                /** @description 保存成功 */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["UserSettingsResponse"];
+                    };
+                };
+                /** @description バリデーションエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/xday": {
         parameters: {
             query?: never;
@@ -1487,6 +1574,31 @@ export interface components {
                  * @example user01
                  */
                 userId: string;
+                /**
+                 * @description 日付 (YYYY-MM-DD)
+                 * @example 2024-03-15
+                 */
+                date: string;
+                /**
+                 * @description 備考
+                 * @example 昼食代
+                 */
+                content?: string | null;
+            };
+        };
+        UpdateExpenseBody: {
+            /** @description 更新データ */
+            updateData: {
+                /**
+                 * @description 金額（円）
+                 * @example 1500
+                 */
+                amount: number;
+                /**
+                 * @description 収支区分: 0=支出, 1=収入
+                 * @example 0
+                 */
+                balanceType: 0 | 1;
                 /**
                  * @description 日付 (YYYY-MM-DD)
                  * @example 2024-03-15
@@ -1737,6 +1849,30 @@ export interface components {
             resetToken: string;
             /** @description 新しいパスワード（平文） */
             newPassword: string;
+        };
+        UserSettingsResponse: {
+            /**
+             * @description 総資産（円）
+             * @example 5000000
+             */
+            totalAssets: number;
+            /**
+             * @description 月次固定収入（円）
+             * @example 200000
+             */
+            monthlyIncome: number;
+        };
+        UpsertUserSettingsBody: {
+            /**
+             * @description 総資産（円）
+             * @example 5000000
+             */
+            totalAssets: number;
+            /**
+             * @description 月次固定収入（円）
+             * @example 200000
+             */
+            monthlyIncome: number;
         };
         XDayResponse: {
             /** @example 2031-09-14T00:00:00.000Z */


### PR DESCRIPTION
## Summary

- `pnpm codegen` を実行し `schema.d.ts` を再生成（settings エンドポイントが反映されていなかった）
- `packages/api-client/src/index.ts` に Budget・XDay・UserSettings 型エイリアスを追加
- `apps/web` の手書き型を `@budget/api-client` の自動生成型に置き換え

| ファイル | 変更内容 |
|---------|---------|
| `lib/api/budget.ts` | 手書き BudgetResponse → BudgetListResponse |
| `lib/api/xday.ts` | バックエンド UseCase 型の直接参照 → XDayResponse/ExpenditureAnalysisResponse |
| `lib/api/settings.ts` | 手書き UserSettings → UserSettingsResponse |
| `lib/api/types.ts` | 新規型エイリアスを追加 |
| `lib/actions/budget.ts` | GetBudgetResponse → BudgetDetailResponse |
| `app/report/page.tsx` | BudgetResponse を @budget/api-client から import |

## Test plan

- [x] type-check: 全パッケージエラーなし
- [x] unit-test: 102件全パス
- [x] 後方互換エイリアス（XDayData, AnalysisData, UserSettings）を維持し既存コンポーネントへの影響なし

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)