### PR TITLE
feat: 支出ゼロ日ストリークのマイルストーンバッジを追加する

### DIFF
--- a/apps/web/src/__tests__/components/XDayDisplay.test.tsx
+++ b/apps/web/src/__tests__/components/XDayDisplay.test.tsx
@@ -52,6 +52,35 @@ describe('XDayDisplay', () => {
         })
     })
 
+    describe('支出ゼロ日マイルストーンバッジ', () => {
+        it('zeroStreakDays=0 のときゼロストリークメッセージを表示しない', () => {
+            render(<XDayDisplay {...defaultProps} zeroStreakDays={0} />)
+            expect(screen.queryByText(/日連続で支出ゼロ/)).not.toBeInTheDocument()
+        })
+
+        it('zeroStreakDays=2 のとき連続ゼロメッセージを表示する', () => {
+            render(<XDayDisplay {...defaultProps} zeroStreakDays={2} />)
+            expect(screen.getByText(/2日連続で支出ゼロ/)).toBeInTheDocument()
+        })
+
+        it('zeroStreakDays=3 のとき「3日達成」バッジを表示する', () => {
+            render(<XDayDisplay {...defaultProps} zeroStreakDays={3} />)
+            expect(screen.getByText('3日達成')).toBeInTheDocument()
+        })
+
+        it('zeroStreakDays=7 のとき「7日達成」バッジと次の目標を表示する', () => {
+            render(<XDayDisplay {...defaultProps} zeroStreakDays={7} />)
+            expect(screen.getByText('7日達成')).toBeInTheDocument()
+            expect(screen.getByText(/次の目標: 30日まであと23日/)).toBeInTheDocument()
+        })
+
+        it('zeroStreakDays=100 のとき「100日達成」バッジを表示し次の目標は表示しない', () => {
+            render(<XDayDisplay {...defaultProps} zeroStreakDays={100} />)
+            expect(screen.getByText('100日達成')).toBeInTheDocument()
+            expect(screen.queryByText(/次の目標/)).not.toBeInTheDocument()
+        })
+    })
+
     describe('家計の寿命カード', () => {
         it('initialAssets が設定済みのとき「家計の寿命」ヘッダーが表示される', () => {
             render(<XDayDisplay {...defaultProps} />)

--- a/apps/web/src/components/dashboard/XDayDisplay.tsx
+++ b/apps/web/src/components/dashboard/XDayDisplay.tsx
@@ -7,6 +7,7 @@ import {
     calcExpenseImpact,
     calculateXDay,
     DEFAULT_STATS_DAILY_EXPENSE,
+    getZeroStreakMilestone,
 } from "@budget/common";
 import { SetupModal } from "./SetupModal";
 import { upsertSettingsAction } from "@/lib/actions/settings";
@@ -273,12 +274,27 @@ export function XDayDisplay({
                 </div>
             )}
 
-            {/* 積み上げメッセージ */}
-            {zeroStreakDays >= 2 && (
-                <p className="mb-3 rounded-xl bg-[#ecfaf8] p-3 text-xs font-bold text-[#35b5a2]">
-                    {zeroStreakDays}日連続で支出ゼロ — 着実に余裕が積み上がっています
-                </p>
-            )}
+            {/* 積み上げメッセージ + マイルストーンバッジ */}
+            {zeroStreakDays >= 2 && (() => {
+                const ms = getZeroStreakMilestone(zeroStreakDays);
+                return (
+                    <div className="mb-3 rounded-xl bg-[#ecfaf8] p-3">
+                        <p className="text-xs font-bold text-[#35b5a2]">
+                            {zeroStreakDays}日連続で支出ゼロ — 着実に余裕が積み上がっています
+                        </p>
+                        {ms.achieved !== null && (
+                            <p className="mt-1 text-xs font-extrabold text-[#35b5a2]">
+                                {ms.achieved}日達成
+                            </p>
+                        )}
+                        {ms.next !== null && ms.daysToNext !== null && (
+                            <p className="mt-0.5 text-xs font-medium text-[#35b5a2]/60">
+                                次の目標: {ms.next}日まであと{ms.daysToNext}日
+                            </p>
+                        )}
+                    </div>
+                );
+            })()}
             {todayExpense === 0 && zeroStreakDays < 2 && (
                 <p className="mb-3 rounded-xl bg-[#ecfaf8] p-3 text-xs font-bold text-[#35b5a2]">
                     今日は支出ゼロ — 余裕が1日分増えました

--- a/packages/common/src/__tests__/utils/streak.test.ts
+++ b/packages/common/src/__tests__/utils/streak.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { getZeroStreakMilestone } from '../../utils/streak'
+
+describe('getZeroStreakMilestone', () => {
+    it('0日のとき achieved=null, next=3, daysToNext=3 を返す', () => {
+        const result = getZeroStreakMilestone(0)
+        expect(result.achieved).toBeNull()
+        expect(result.next).toBe(3)
+        expect(result.daysToNext).toBe(3)
+    })
+
+    it('2日のとき achieved=null, next=3, daysToNext=1 を返す', () => {
+        const result = getZeroStreakMilestone(2)
+        expect(result.achieved).toBeNull()
+        expect(result.next).toBe(3)
+        expect(result.daysToNext).toBe(1)
+    })
+
+    it('3日のとき achieved=3, next=7, daysToNext=4 を返す', () => {
+        const result = getZeroStreakMilestone(3)
+        expect(result.achieved).toBe(3)
+        expect(result.next).toBe(7)
+        expect(result.daysToNext).toBe(4)
+    })
+
+    it('7日のとき achieved=7, next=30, daysToNext=23 を返す', () => {
+        const result = getZeroStreakMilestone(7)
+        expect(result.achieved).toBe(7)
+        expect(result.next).toBe(30)
+        expect(result.daysToNext).toBe(23)
+    })
+
+    it('30日のとき achieved=30, next=100, daysToNext=70 を返す', () => {
+        const result = getZeroStreakMilestone(30)
+        expect(result.achieved).toBe(30)
+        expect(result.next).toBe(100)
+        expect(result.daysToNext).toBe(70)
+    })
+
+    it('100日のとき achieved=100, next=null, daysToNext=null を返す（全マイルストーン達成）', () => {
+        const result = getZeroStreakMilestone(100)
+        expect(result.achieved).toBe(100)
+        expect(result.next).toBeNull()
+        expect(result.daysToNext).toBeNull()
+    })
+
+    it('150日のとき achieved=100, next=null を返す', () => {
+        const result = getZeroStreakMilestone(150)
+        expect(result.achieved).toBe(100)
+        expect(result.next).toBeNull()
+    })
+
+    it('マイルストーン境界値: 6日は achieved=3', () => {
+        const result = getZeroStreakMilestone(6)
+        expect(result.achieved).toBe(3)
+        expect(result.next).toBe(7)
+        expect(result.daysToNext).toBe(1)
+    })
+})

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from './utils/xday'
 export * from './utils/statistics'
+export * from './utils/streak'
 export * from './types/expense'
 export * from './types/user'
 export * from './types/budget'

--- a/packages/common/src/utils/streak.ts
+++ b/packages/common/src/utils/streak.ts
@@ -1,0 +1,39 @@
+/** 支出ゼロ日連続のマイルストーン定義 */
+export const ZERO_STREAK_MILESTONES = [3, 7, 30, 100] as const;
+export type ZeroStreakMilestone = (typeof ZERO_STREAK_MILESTONES)[number];
+
+export type ZeroStreakMilestoneResult = {
+    /** 達成済みの最大マイルストーン（未達成なら null） */
+    achieved: ZeroStreakMilestone | null;
+    /** 次のマイルストーン（すべて達成済みなら null） */
+    next: ZeroStreakMilestone | null;
+    /** 次のマイルストーンまでの残り日数 */
+    daysToNext: number | null;
+};
+
+/**
+ * 支出ゼロ連続日数からマイルストーン情報を算出する。
+ * 達成済みマイルストーンのバッジ表示や次目標の表示に使用する。
+ *
+ * @param zeroStreakDays - 現在の支出ゼロ連続日数
+ */
+export function getZeroStreakMilestone(zeroStreakDays: number): ZeroStreakMilestoneResult {
+    const sorted = [...ZERO_STREAK_MILESTONES].sort((a, b) => a - b);
+
+    let achieved: ZeroStreakMilestone | null = null;
+    let next: ZeroStreakMilestone | null = null;
+
+    for (const milestone of sorted) {
+        if (zeroStreakDays >= milestone) {
+            achieved = milestone;
+        } else if (next === null) {
+            next = milestone;
+        }
+    }
+
+    return {
+        achieved,
+        next,
+        daysToNext: next !== null ? next - zeroStreakDays : null,
+    };
+}


### PR DESCRIPTION
## 概要

Closes #88

支出ゼロ連続日数（zeroStreakDays）に対するマイルストーンバッジと次目標カウントダウンを実装する。
3日・7日・30日・100日の節目でバッジを表示し、達成意欲を促進する。

## 変更内容

### packages/common
- `src/utils/streak.ts` を新規作成
  - `ZERO_STREAK_MILESTONES = [3, 7, 30, 100]` を定数定義
  - `getZeroStreakMilestone(zeroStreakDays)` ユーティリティ関数を実装
  - 達成済み最大マイルストーン（`achieved`）・次マイルストーン（`next`）・残り日数（`daysToNext`）を返す
- `src/index.ts` に `export * from './utils/streak'` を追加
- `src/__tests__/utils/streak.test.ts` を新規作成（8テストケース）

### apps/web
- `XDayDisplay.tsx`: `getZeroStreakMilestone` を使用してマイルストーンバッジと次目標を表示
  - `zeroStreakDays >= 2` のとき「○日連続で支出ゼロ」メッセージを表示
  - 達成マイルストーンがある場合は「○日達成」バッジを表示
  - 次マイルストーンがある場合は「次の目標: ○日まであと○日」を表示
- `XDayDisplay.test.tsx` に `describe('支出ゼロ日マイルストーンバッジ')` ブロックを追加（5テストケース）

## 影響範囲

- `@budget/common` の公開 API に `getZeroStreakMilestone`・関連型が追加される
- `XDayDisplay` の表示ロジックのみ変更。他コンポーネントへの影響なし
- 既存の連続記録バッジ（recordingStreak）とは独立した別セクションとして追加

## テスト内容

### unit tests (packages/common)
- 0日: achieved=null, next=3, daysToNext=3
- 2日: achieved=null, next=3, daysToNext=1
- 3日: achieved=3, next=7, daysToNext=4
- 7日: achieved=7, next=30, daysToNext=23
- 30日: achieved=30, next=100, daysToNext=70
- 100日: achieved=100, next=null, daysToNext=null（全達成）
- 150日: achieved=100, next=null（全達成後）
- 境界値6日: achieved=3, next=7, daysToNext=1

### component tests (apps/web)
- zeroStreakDays=0: ゼロストリークメッセージを表示しない
- zeroStreakDays=2: 連続ゼロメッセージを表示する
- zeroStreakDays=3: 「3日達成」バッジを表示する
- zeroStreakDays=7: 「7日達成」バッジと「次の目標: 30日まであと23日」を表示する
- zeroStreakDays=100: 「100日達成」バッジを表示し次の目標は表示しない

全テスト通過確認（web: 107件、common: 23件）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか（ZERO_STREAK_MILESTONES 定数で管理）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- UI変更を含むため、マージ前にレビュー担当者がローカルで確認の上チェックを入れてください -->