### PR TITLE
feat: 前月比・前年同月比レポートを追加する

### DIFF
--- a/apps/web/src/__tests__/components/MonthlyComparisonCard.test.tsx
+++ b/apps/web/src/__tests__/components/MonthlyComparisonCard.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MonthlyComparisonCard } from '../../components/report/MonthlyComparisonCard'
+import type { MonthlyComparisonData } from '@budget/common'
+
+/** テスト用デフォルトデータ */
+const baseData: MonthlyComparisonData = {
+    currentTotal: 60000,
+    prevMonthTotal: 50000,
+    prevYearTotal: null,
+    prevMonthDiff: 10000,
+    prevMonthPct: 20,
+    prevYearDiff: null,
+    prevYearPct: null,
+}
+
+describe('MonthlyComparisonCard', () => {
+    describe('前月比の表示', () => {
+        it('セクションヘッダー「前月比・前年同月比」が表示される', () => {
+            render(<MonthlyComparisonCard data={baseData} />)
+            expect(screen.getByText('前月比・前年同月比')).toBeInTheDocument()
+        })
+
+        it('前月の金額が表示される', () => {
+            render(<MonthlyComparisonCard data={baseData} />)
+            expect(screen.getByText(/前月: ¥50,000/)).toBeInTheDocument()
+        })
+
+        it('前月より増加のとき、増加額と増加率が表示される', () => {
+            render(<MonthlyComparisonCard data={baseData} />)
+            expect(screen.getByText(/\+¥10,000.*\+20%/)).toBeInTheDocument()
+        })
+
+        it('前月より減少のとき、減少額と減少率が表示される', () => {
+            const data: MonthlyComparisonData = {
+                ...baseData,
+                prevMonthTotal: 70000,
+                prevMonthDiff: -10000,
+                prevMonthPct: -14,
+            }
+            render(<MonthlyComparisonCard data={data} />)
+            expect(screen.getByText(/-¥10,000.*-14%/)).toBeInTheDocument()
+        })
+
+        it('前月と同額のとき「増減なし」が表示される', () => {
+            const data: MonthlyComparisonData = {
+                ...baseData,
+                prevMonthTotal: 60000,
+                prevMonthDiff: 0,
+                prevMonthPct: 0,
+            }
+            render(<MonthlyComparisonCard data={data} />)
+            expect(screen.getByText('増減なし')).toBeInTheDocument()
+        })
+    })
+
+    describe('前年同月比の表示', () => {
+        it('prevYearTotal=null のとき「前年同月のデータがありません」が表示される', () => {
+            render(<MonthlyComparisonCard data={baseData} />)
+            expect(screen.getByText('前年同月のデータがありません')).toBeInTheDocument()
+        })
+
+        it('prevYearTotal が設定されているとき前年同月の金額と増減が表示される', () => {
+            const data: MonthlyComparisonData = {
+                ...baseData,
+                prevYearTotal: 55000,
+                prevYearDiff: 5000,
+                prevYearPct: 9,
+            }
+            render(<MonthlyComparisonCard data={data} />)
+            expect(screen.getByText(/前年同月: ¥55,000/)).toBeInTheDocument()
+            expect(screen.getByText(/\+¥5,000.*\+9%/)).toBeInTheDocument()
+        })
+
+        it('前年同月より減少のとき、減少額と減少率が表示される', () => {
+            const data: MonthlyComparisonData = {
+                ...baseData,
+                prevYearTotal: 70000,
+                prevYearDiff: -10000,
+                prevYearPct: -14,
+            }
+            render(<MonthlyComparisonCard data={data} />)
+            expect(screen.getByText(/-¥10,000.*-14%/)).toBeInTheDocument()
+        })
+    })
+})

--- a/apps/web/src/app/report/page.tsx
+++ b/apps/web/src/app/report/page.tsx
@@ -6,7 +6,9 @@ import { getBudgets } from "@/lib/api/budget";
 import { deleteBudgetAction } from "@/lib/actions/budget";
 import { getCategoryById, OUTGO_CATEGORIES } from "@/lib/constants/categories";
 import { PeriodSelector } from "@/components/report/PeriodSelector";
+import { MonthlyComparisonCard } from "@/components/report/MonthlyComparisonCard";
 import { AppShell } from "@/components/layout/AppShell";
+import { calcMonthlyComparison } from "@budget/common";
 import type { BudgetResponse } from "@budget/api-client";
 
 export const metadata: Metadata = {
@@ -76,11 +78,26 @@ async function ReportSection({ period }: { period: Period }) {
   const filter = getDateFilter(period);
   const budgets = allBudgets.filter((b) => filter(b.date));
 
+  // 当月表示のときのみ前月比・前年同月比を計算する
+  const now = new Date();
+  const currentMonthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+  const comparisonData = period === "current-month"
+    ? calcMonthlyComparison(
+        allBudgets.map((b) => ({ date: b.date, amount: b.amount, balanceType: b.balanceType })),
+        currentMonthPrefix,
+      )
+    : null;
+
   if (budgets.length === 0) {
     return (
-      <p className="py-12 text-center text-sm font-medium text-[#1c1410]/40">
-        この期間のデータはありません
-      </p>
+      <div className="flex flex-col gap-6">
+        <p className="py-12 text-center text-sm font-medium text-[#1c1410]/40">
+          この期間のデータはありません
+        </p>
+        {comparisonData !== null && (
+          <MonthlyComparisonCard data={comparisonData} />
+        )}
+      </div>
     );
   }
 
@@ -113,6 +130,11 @@ async function ReportSection({ period }: { period: Period }) {
           </p>
         </div>
       </div>
+
+      {/* 前月比・前年同月比（当月のみ） */}
+      {comparisonData !== null && (
+        <MonthlyComparisonCard data={comparisonData} />
+      )}
 
       {/* カテゴリ別バーチャート（支出） */}
       {categoryBreakdown.length > 0 && (

--- a/apps/web/src/components/report/MonthlyComparisonCard.tsx
+++ b/apps/web/src/components/report/MonthlyComparisonCard.tsx
@@ -1,0 +1,94 @@
+import { TrendingDown, TrendingUp, Minus } from "lucide-react";
+import type { MonthlyComparisonData } from "@budget/common";
+
+interface Props {
+    data: MonthlyComparisonData;
+}
+
+/** 増減の向き・色・アイコンを返す */
+function getDiffProps(diff: number, pct: number | null) {
+    if (diff === 0 || pct === 0) {
+        return {
+            icon: <Minus size={14} />,
+            color: "var(--color-income)",
+            label: "増減なし",
+            sign: "",
+        };
+    }
+    if (diff > 0) {
+        return {
+            icon: <TrendingUp size={14} />,
+            color: "var(--color-expense)",
+            label: `+¥${diff.toLocaleString()}${pct !== null ? ` (+${pct}%)` : ""}`,
+            sign: "+",
+        };
+    }
+    return {
+        icon: <TrendingDown size={14} />,
+        color: "var(--color-income)",
+        label: `-¥${Math.abs(diff).toLocaleString()}${pct !== null ? ` (${pct}%)` : ""}`,
+        sign: "-",
+    };
+}
+
+export function MonthlyComparisonCard({ data }: Props) {
+    const prevMonth = getDiffProps(data.prevMonthDiff, data.prevMonthPct);
+    const prevYear = data.prevYearTotal !== null
+        ? getDiffProps(data.prevYearDiff!, data.prevYearPct)
+        : null;
+
+    return (
+        <section>
+            <h2 className="mb-3 text-sm font-extrabold text-[#1c1410]">
+                前月比・前年同月比
+            </h2>
+            <div
+                className="flex flex-col gap-3 rounded-2xl border border-[#1c1410]/12 bg-white p-4"
+                style={{ boxShadow: "var(--shadow-card)" }}
+            >
+                {/* 前月比 */}
+                <div className="flex items-center justify-between">
+                    <div>
+                        <p className="text-xs font-bold text-[#1c1410]/50">前月比</p>
+                        <p className="mt-0.5 text-xs font-medium text-[#1c1410]/40">
+                            前月: ¥{data.prevMonthTotal.toLocaleString()}
+                        </p>
+                    </div>
+                    <div
+                        className="flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-extrabold"
+                        style={{ color: prevMonth.color, backgroundColor: `color-mix(in srgb, ${prevMonth.color} 10%, transparent)` }}
+                    >
+                        {prevMonth.icon}
+                        <span>{prevMonth.label}</span>
+                    </div>
+                </div>
+
+                {/* 前年同月比（データがある場合のみ） */}
+                {prevYear !== null && (
+                    <div className="flex items-center justify-between border-t border-[#e8c8b0] pt-3">
+                        <div>
+                            <p className="text-xs font-bold text-[#1c1410]/50">前年同月比</p>
+                            <p className="mt-0.5 text-xs font-medium text-[#1c1410]/40">
+                                前年同月: ¥{data.prevYearTotal!.toLocaleString()}
+                            </p>
+                        </div>
+                        <div
+                            className="flex items-center gap-1.5 rounded-xl px-3 py-1.5 text-xs font-extrabold"
+                            style={{ color: prevYear.color, backgroundColor: `color-mix(in srgb, ${prevYear.color} 10%, transparent)` }}
+                        >
+                            {prevYear.icon}
+                            <span>{prevYear.label}</span>
+                        </div>
+                    </div>
+                )}
+
+                {/* 前年データなし */}
+                {prevYear === null && (
+                    <p className="border-t border-[#e8c8b0] pt-3 text-xs font-medium text-[#1c1410]/30">
+                        前年同月のデータがありません
+                    </p>
+                )}
+            </div>
+        </section>
+    );
+}

--- a/packages/common/src/__tests__/utils/comparison.test.ts
+++ b/packages/common/src/__tests__/utils/comparison.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { calcMonthlyComparison } from '../../utils/comparison'
+
+/** テスト用エントリ生成ヘルパー */
+function expense(date: string, amount: number) {
+    return { date, amount, balanceType: 0 }
+}
+function income(date: string, amount: number) {
+    return { date, amount, balanceType: 1 }
+}
+
+describe('calcMonthlyComparison', () => {
+    it('データがない場合、currentTotal=0、prevMonthTotal=0、prevYearTotal=null を返す', () => {
+        const result = calcMonthlyComparison([], '2026-05')
+        expect(result.currentTotal).toBe(0)
+        expect(result.prevMonthTotal).toBe(0)
+        expect(result.prevYearTotal).toBeNull()
+        expect(result.prevMonthDiff).toBe(0)
+        expect(result.prevMonthPct).toBeNull()
+        expect(result.prevYearDiff).toBeNull()
+        expect(result.prevYearPct).toBeNull()
+    })
+
+    it('当月のみデータがある場合、前月比は増加、前年同月比は null を返す', () => {
+        const entries = [expense('2026-05-10', 50000), expense('2026-05-20', 30000)]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.currentTotal).toBe(80000)
+        expect(result.prevMonthTotal).toBe(0)
+        expect(result.prevMonthDiff).toBe(80000)
+        expect(result.prevMonthPct).toBeNull() // 前月が 0 なので null
+        expect(result.prevYearTotal).toBeNull()
+    })
+
+    it('当月・前月のデータがある場合、前月比を正しく計算する', () => {
+        const entries = [
+            expense('2026-05-10', 60000),
+            expense('2026-04-15', 50000),
+        ]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.currentTotal).toBe(60000)
+        expect(result.prevMonthTotal).toBe(50000)
+        expect(result.prevMonthDiff).toBe(10000)
+        expect(result.prevMonthPct).toBe(20) // +20%
+    })
+
+    it('前月より支出が減少した場合、負の増減額・率を返す', () => {
+        const entries = [
+            expense('2026-05-10', 40000),
+            expense('2026-04-15', 50000),
+        ]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.prevMonthDiff).toBe(-10000)
+        expect(result.prevMonthPct).toBe(-20) // -20%
+    })
+
+    it('前年同月のデータがある場合、前年同月比を正しく計算する', () => {
+        const entries = [
+            expense('2026-05-10', 60000),
+            expense('2025-05-15', 50000),
+        ]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.prevYearTotal).toBe(50000)
+        expect(result.prevYearDiff).toBe(10000)
+        expect(result.prevYearPct).toBe(20) // +20%
+    })
+
+    it('収入エントリは集計に含めない', () => {
+        const entries = [
+            expense('2026-05-10', 60000),
+            income('2026-05-10', 200000), // 収入は除外
+            expense('2026-04-15', 50000),
+            income('2026-04-15', 200000), // 収入は除外
+        ]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.currentTotal).toBe(60000)
+        expect(result.prevMonthTotal).toBe(50000)
+    })
+
+    it('1月の場合、前月は前年12月になる', () => {
+        const entries = [
+            expense('2026-01-10', 50000),
+            expense('2025-12-20', 40000),
+        ]
+        const result = calcMonthlyComparison(entries, '2026-01')
+        expect(result.prevMonthTotal).toBe(40000)
+        expect(result.prevMonthDiff).toBe(10000)
+    })
+
+    it('前月・前年同月ともにデータがある場合、両方の比較を返す', () => {
+        const entries = [
+            expense('2026-05-01', 60000),
+            expense('2026-04-01', 50000),
+            expense('2025-05-01', 55000),
+        ]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.currentTotal).toBe(60000)
+        expect(result.prevMonthTotal).toBe(50000)
+        expect(result.prevMonthDiff).toBe(10000)
+        expect(result.prevMonthPct).toBe(20)
+        expect(result.prevYearTotal).toBe(55000)
+        expect(result.prevYearDiff).toBe(5000)
+        expect(result.prevYearPct).toBe(9) // Math.round(5000/55000*100)=9
+    })
+
+    it('当月と前月が同額の場合、増減額=0、増減率=0 を返す', () => {
+        const entries = [
+            expense('2026-05-01', 50000),
+            expense('2026-04-01', 50000),
+        ]
+        const result = calcMonthlyComparison(entries, '2026-05')
+        expect(result.prevMonthDiff).toBe(0)
+        expect(result.prevMonthPct).toBe(0)
+    })
+})

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,6 +1,7 @@
 export * from './utils/xday'
 export * from './utils/statistics'
 export * from './utils/streak'
+export * from './utils/comparison'
 export * from './types/expense'
 export * from './types/user'
 export * from './types/budget'

--- a/packages/common/src/utils/comparison.ts
+++ b/packages/common/src/utils/comparison.ts
@@ -1,0 +1,83 @@
+/** 月次比較の計算結果 */
+export type MonthlyComparisonData = {
+    /** 当月の支出合計 */
+    currentTotal: number;
+    /** 前月の支出合計 */
+    prevMonthTotal: number;
+    /** 前年同月の支出合計（データがなければ null） */
+    prevYearTotal: number | null;
+    /** 前月比増減額（正 = 増加、負 = 減少） */
+    prevMonthDiff: number;
+    /** 前月比増減率（前月が 0 なら null） */
+    prevMonthPct: number | null;
+    /** 前年同月比増減額（データがなければ null） */
+    prevYearDiff: number | null;
+    /** 前年同月比増減率（データがなければ null） */
+    prevYearPct: number | null;
+};
+
+type ExpenseEntry = {
+    /** YYYY-MM-DD 形式の日付 */
+    date: string;
+    /** 金額 */
+    amount: number;
+    /** 0 = 支出、1 = 収入 */
+    balanceType: number;
+};
+
+/**
+ * 月次比較データを計算する。
+ * 支出のみ（balanceType === 0）を集計対象とする。
+ *
+ * @param allEntries - 全期間の支出・収入エントリ
+ * @param currentMonthPrefix - 当月の YYYY-MM プレフィックス（例: "2026-05"）
+ */
+export function calcMonthlyComparison(
+    allEntries: ExpenseEntry[],
+    currentMonthPrefix: string,
+): MonthlyComparisonData {
+    const [yearStr, monthStr] = currentMonthPrefix.split('-');
+    const year = parseInt(yearStr, 10);
+    const month = parseInt(monthStr, 10);
+
+    // 前月（月が 1 の場合は前年の 12 月）
+    const prevMonthDate = new Date(year, month - 2, 1);
+    const prevMonthPrefix = `${prevMonthDate.getFullYear()}-${String(prevMonthDate.getMonth() + 1).padStart(2, '0')}`;
+
+    // 前年同月
+    const prevYearPrefix = `${year - 1}-${monthStr}`;
+
+    const sumExpenses = (prefix: string): number =>
+        allEntries
+            .filter((e) => e.balanceType === 0 && e.date.startsWith(prefix))
+            .reduce((s, e) => s + e.amount, 0);
+
+    const hasPrevYear = allEntries.some(
+        (e) => e.balanceType === 0 && e.date.startsWith(prevYearPrefix),
+    );
+
+    const currentTotal = sumExpenses(currentMonthPrefix);
+    const prevMonthTotal = sumExpenses(prevMonthPrefix);
+    const prevYearTotal = hasPrevYear ? sumExpenses(prevYearPrefix) : null;
+
+    const prevMonthDiff = currentTotal - prevMonthTotal;
+    const prevMonthPct = prevMonthTotal > 0
+        ? Math.round((prevMonthDiff / prevMonthTotal) * 100)
+        : null;
+
+    const prevYearDiff = prevYearTotal !== null ? currentTotal - prevYearTotal : null;
+    const prevYearPct =
+        prevYearTotal !== null && prevYearTotal > 0
+            ? Math.round(((currentTotal - prevYearTotal) / prevYearTotal) * 100)
+            : null;
+
+    return {
+        currentTotal,
+        prevMonthTotal,
+        prevYearTotal,
+        prevMonthDiff,
+        prevMonthPct,
+        prevYearDiff,
+        prevYearPct,
+    };
+}


### PR DESCRIPTION
## 概要

Closes #87

当月レポート（`current-month`）表示時に、前月比と前年同月比の増減額・増減率バッジを表示する。
API 変更なし。既存の `getBudgets()` で取得した全データをクライアント側でフィルタして算出。

## 変更内容

### packages/common
- `src/utils/comparison.ts` を新規作成
  - `calcMonthlyComparison(allEntries, currentMonthPrefix)` ユーティリティを実装
  - 当月・前月・前年同月の支出合計と増減額・増減率を返す
  - 前年データがない場合は `prevYearTotal: null` を返す
- `src/index.ts` に `export * from './utils/comparison'` を追加
- `src/__tests__/utils/comparison.test.ts` を新規作成（9テストケース）

### apps/web
- `src/components/report/MonthlyComparisonCard.tsx` を新規作成
  - 前月比・前年同月比の増減額と率をバッジ表示
  - 増加は expense カラー（赤）・減少は income カラー（緑）で視覚化
  - 前年データなし時は「前年同月のデータがありません」と表示
- `src/app/report/page.tsx` を更新
  - `current-month` 表示時のみ `calcMonthlyComparison` で比較データを計算
  - サマリーカードの直後に `MonthlyComparisonCard` を挿入
- `src/__tests__/components/MonthlyComparisonCard.test.tsx` を新規作成（8テストケース）

## 影響範囲

- `@budget/common` の公開 API に `calcMonthlyComparison`・`MonthlyComparisonData` 型が追加される
- `7days` / `last-month` 表示では比較カードは表示されない（`current-month` のみ）
- 既存のカテゴリ内訳・明細セクションに変更なし

## テスト内容

### unit tests (packages/common - 9件)
- データなし: 全フィールドがゼロ/null
- 当月のみ: prevMonthPct=null（前月が0のため）
- 前月比増加・減少の計算
- 1月→前年12月のクロスイヤー計算
- 前年同月比の増加・減少の計算
- 収入エントリの除外確認
- 増減なし（0%）のケース

### component tests (apps/web - 8件)
- ヘッダーの表示
- 前月金額の表示
- 増加・減少・増減なし バッジの表示
- 前年データなし時のメッセージ
- 前年同月比の増加・減少表示

全テスト通過確認（web: 115件、common: 32件）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- UI変更を含むため、マージ前にレビュー担当者がローカルで確認の上チェックを入れてください -->