### PR TITLE
feat: PWA 化してモバイルのホーム画面から起動できるようにする

### DIFF
--- a/apps/web/public/icon.svg
+++ b/apps/web/public/icon.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" fill="none">
+  <rect width="192" height="192" rx="40" fill="#f18840"/>
+  <!-- 家のシルエット -->
+  <path d="M96 40 L152 90 L140 90 L140 152 L52 152 L52 90 L40 90 Z" fill="white" fill-opacity="0.95"/>
+  <!-- 玄関ドア -->
+  <rect x="80" y="114" width="32" height="38" rx="4" fill="#f18840"/>
+  <!-- 窓 -->
+  <rect x="60" y="100" width="22" height="18" rx="3" fill="#f18840"/>
+  <rect x="110" y="100" width="22" height="18" rx="3" fill="#f18840"/>
+  <!-- 円マーク -->
+  <circle cx="96" cy="96" r="14" fill="#f18840"/>
+  <text x="96" y="101" text-anchor="middle" font-size="16" font-weight="bold" fill="white" font-family="sans-serif">¥</text>
+</svg>

--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,81 @@
+const CACHE_NAME = 'kakeibo-v1';
+
+// アプリシェルとして事前キャッシュするリソース
+const PRECACHE_URLS = [
+    '/',
+    '/report',
+];
+
+// インストール: アプリシェルを事前キャッシュ
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)),
+    );
+    // 既存の SW を待たずに即アクティブ化
+    self.skipWaiting();
+});
+
+// アクティベート: 古いキャッシュを削除
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys().then((keys) =>
+            Promise.all(
+                keys
+                    .filter((key) => key !== CACHE_NAME)
+                    .map((key) => caches.delete(key)),
+            ),
+        ),
+    );
+    // 全クライアントの制御を即時引き継ぐ
+    self.clients.claim();
+});
+
+// フェッチ: Network-first（オフライン時はキャッシュにフォールバック）
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+
+    // POST / API リクエストはキャッシュしない
+    if (
+        request.method !== 'GET' ||
+        request.url.includes('/api/') ||
+        request.url.includes('/_next/webpack')
+    ) {
+        return;
+    }
+
+    // ナビゲーション（HTML）: Network-first
+    if (request.mode === 'navigate') {
+        event.respondWith(
+            fetch(request)
+                .then((response) => {
+                    if (response.ok) {
+                        const clone = response.clone();
+                        caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+                    }
+                    return response;
+                })
+                .catch(() => caches.match(request).then((cached) => cached ?? caches.match('/'))),
+        );
+        return;
+    }
+
+    // 静的アセット（JS/CSS/画像）: Cache-first
+    if (
+        request.url.includes('/_next/static') ||
+        request.url.includes('/icon.svg')
+    ) {
+        event.respondWith(
+            caches.match(request).then(
+                (cached) =>
+                    cached ??
+                    fetch(request).then((response) => {
+                        if (response.ok) {
+                            const clone = response.clone();
+                            caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+                        }
+                        return response;
+                    }),
+            ),
+        );
+    }
+});

--- a/apps/web/src/__tests__/components/SwRegister.test.tsx
+++ b/apps/web/src/__tests__/components/SwRegister.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import { SwRegister } from '../../components/SwRegister'
+
+describe('SwRegister', () => {
+    beforeEach(() => {
+        vi.stubGlobal('navigator', {
+            ...navigator,
+            serviceWorker: {
+                register: vi.fn().mockResolvedValue({}),
+            },
+        })
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it('DOM ノードをレンダリングしない（null を返す）', () => {
+        const { container } = render(<SwRegister />)
+        expect(container.firstChild).toBeNull()
+    })
+
+    it('serviceWorker が使えるとき /sw.js を登録する', async () => {
+        render(<SwRegister />)
+        // useEffect は非同期で実行される
+        await vi.waitFor(() => {
+            expect(navigator.serviceWorker.register).toHaveBeenCalledWith('/sw.js')
+        })
+    })
+
+    it('serviceWorker が使えないとき登録を試みない', () => {
+        // serviceWorker プロパティを持たないオブジェクトに差し替える
+        vi.stubGlobal('navigator', {})
+        render(<SwRegister />)
+        // エラーが発生せずレンダリングが完了すればOK
+    })
+})

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Outfit } from "next/font/google";
 import { Geist_Mono } from "next/font/google";
+import { SwRegister } from "@/components/SwRegister";
 import "./globals.css";
 
 const outfit = Outfit({
@@ -20,6 +21,19 @@ export const metadata: Metadata = {
     template: "%s | 家計管理",
   },
   description: "日々の支出・収入を記録・管理する家計管理ツール",
+  manifest: "/manifest.webmanifest",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "default",
+    title: "家計管理",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#f18840",
+  width: "device-width",
+  initialScale: 1,
+  minimumScale: 1,
 };
 
 export default function RootLayout({
@@ -32,7 +46,10 @@ export default function RootLayout({
       lang="ja"
       className={`${outfit.variable} ${geistMono.variable} h-full antialiased`}
     >
-      <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">{children}</body>
+      <body className="min-h-full flex flex-col bg-[var(--background)] text-[var(--foreground)]">
+        {children}
+        <SwRegister />
+      </body>
     </html>
   );
 }

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from 'next';
+
+export default function manifest(): MetadataRoute.Manifest {
+    return {
+        name: '家計管理',
+        short_name: '家計管理',
+        description: '日々の支出・収入を記録し、家計の寿命を把握するツール',
+        start_url: '/',
+        display: 'standalone',
+        orientation: 'portrait',
+        background_color: '#fffdf5',
+        theme_color: '#f18840',
+        icons: [
+            {
+                src: '/icon.svg',
+                sizes: 'any',
+                type: 'image/svg+xml',
+                purpose: 'any',
+            },
+            {
+                src: '/icon.svg',
+                sizes: 'any',
+                type: 'image/svg+xml',
+                purpose: 'maskable',
+            },
+        ],
+        categories: ['finance', 'lifestyle'],
+        lang: 'ja',
+        dir: 'ltr',
+    };
+}

--- a/apps/web/src/components/SwRegister.tsx
+++ b/apps/web/src/components/SwRegister.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Service Worker を登録するクライアントコンポーネント。
+ * ルートレイアウトに配置し、ブラウザがサポートしている場合のみ登録する。
+ */
+export function SwRegister() {
+    useEffect(() => {
+        if ('serviceWorker' in navigator) {
+            navigator.serviceWorker
+                .register('/sw.js')
+                .catch(() => {
+                    // SW 登録失敗はアプリの動作に影響しないため握りつぶす
+                });
+        }
+    }, []);
+
+    return null;
+}


### PR DESCRIPTION
## 概要

Closes #90

Web App Manifest と Service Worker を追加し、スマートフォンのホーム画面へのインストールと
最低限のオフラインキャッシュを実現する。API 変更なし。

## 変更内容

### 新規ファイル
- `public/icon.svg`: ブランドカラー（#f18840）を使ったアプリアイコン
- `public/sw.js`: Network-first（HTML）/ Cache-first（静的アセット）Service Worker
  - インストール時に `/` と `/report` をプリキャッシュ
  - API リクエスト（`/api/`）はキャッシュしない
  - 古いキャッシュはアクティベート時に削除
- `src/app/manifest.ts`: Next.js Metadata API でウェブアプリマニフェストを生成
  - `display: "standalone"` でネイティブアプリ風表示
  - `theme_color: "#f18840"` でブランドカラーを設定
- `src/components/SwRegister.tsx`: SW 登録クライアントコンポーネント
  - ブラウザが `serviceWorker` 非対応でもエラーが発生しない安全な実装

### 修正ファイル
- `src/app/layout.tsx`
  - `Viewport` エクスポートを追加（`themeColor`, `width`, `initialScale`）
  - `appleWebApp` メタを追加（iOS ホーム画面追加サポート）
  - `<SwRegister />` を body 末尾に配置

## 影響範囲

- 既存の機能・レンダリングへの影響なし（`SwRegister` は `null` を返す）
- HTTPS 環境でのみ Service Worker が動作する（ローカル開発は localhost が許可される）
- `output: "standalone"` との互換性あり

## テスト内容

### component tests (apps/web - 3件)
- DOM ノードをレンダリングしない
- serviceWorker が使えるとき /sw.js を登録する
- serviceWorker が使えないとき登録を試みない

全テスト通過確認（web: 118件、common: 32件）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか（キャッシュ名は CACHE_NAME 定数）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（UIへの視覚的変更なし）