### PR TITLE
refactor: ユースケースのエラーハンドリングを Result 型に移行する

### DIFF
--- a/apps/api/src/__tests__/unit/controllers/ExpenseController.test.ts
+++ b/apps/api/src/__tests__/unit/controllers/ExpenseController.test.ts
@@ -81,19 +81,29 @@ describe('CreateExpenseUseCase', () => {
     describe('execute()', () => {
         it('正常系: 有効なデータで支出を作成する', async () => {
             const result = await useCase.execute(validInput);
-            expect(result).toEqual(mockExpense);
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.value).toEqual(mockExpense);
+            }
             expect(mockUserRepository.findById).toHaveBeenCalledWith('user-1');
             expect(mockExpenseRepository.save).toHaveBeenCalledTimes(1);
         });
 
         it('正常系: content が null でも保存できる', async () => {
             const result = await useCase.execute({ ...validInput, content: null });
-            expect(result).toEqual(mockExpense);
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.value).toEqual(mockExpense);
+            }
         });
 
-        it('異常系: 存在しないユーザーIDは Error をthrow', async () => {
+        it('異常系: 存在しないユーザーIDのとき ok=false で NotFoundError を返す', async () => {
             vi.mocked(mockUserRepository.findById).mockResolvedValue(null);
-            await expect(useCase.execute(validInput)).rejects.toThrow('ユーザーが見つかりません');
+            const result = await useCase.execute(validInput);
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error.message).toContain('ユーザーが見つかりません');
+            }
         });
 
         it('異常系: リポジトリが例外をthrowした場合は伝播する', async () => {

--- a/apps/api/src/__tests__/unit/controllers/UpdateExpenseUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/controllers/UpdateExpenseUseCase.test.ts
@@ -55,14 +55,20 @@ describe('UpdateExpenseUseCase', () => {
         it('正常系: 有効なデータで支出を更新する', async () => {
             const result = await useCase.execute('expense-01', validInput);
 
-            expect(result).toEqual(updatedExpense);
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.value).toEqual(updatedExpense);
+            }
             expect(mockExpenseRepository.findById).toHaveBeenCalledWith('expense-01');
             expect(mockExpenseRepository.save).toHaveBeenCalledTimes(1);
         });
 
         it('正常系: content が null でも更新できる', async () => {
             const result = await useCase.execute('expense-01', { ...validInput, content: null });
-            expect(result).toEqual(updatedExpense);
+            expect(result.ok).toBe(true);
+            if (result.ok) {
+                expect(result.value).toEqual(updatedExpense);
+            }
         });
 
         it('正常系: userId は既存エンティティから引き継がれる', async () => {
@@ -79,10 +85,14 @@ describe('UpdateExpenseUseCase', () => {
             expect(savedArg.createdDate).toEqual(mockExpense.createdDate);
         });
 
-        it('異常系: 存在しない ID を指定すると NotFoundError をthrow', async () => {
+        it('異常系: 存在しない ID を指定すると ok=false で NotFoundError を返す', async () => {
             vi.mocked(mockExpenseRepository.findById).mockResolvedValue(null);
 
-            await expect(useCase.execute('not-exist', validInput)).rejects.toBeInstanceOf(NotFoundError);
+            const result = await useCase.execute('not-exist', validInput);
+            expect(result.ok).toBe(false);
+            if (!result.ok) {
+                expect(result.error).toBeInstanceOf(NotFoundError);
+            }
         });
 
         it('異常系: リポジトリが例外をthrowした場合は伝播する', async () => {

--- a/apps/api/src/__tests__/unit/use-cases/CreateExpenseUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/CreateExpenseUseCase.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CreateExpenseUseCase } from '../../../application/use-cases/CreateExpenseUseCase';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import type { IUserRepository } from '../../../domain/repositories/IUserRepository';
+import { User } from '../../../domain/models/User';
+import { Expense } from '../../../domain/models/Expense';
+import { NotFoundError } from '../../../shared/errors/DomainException';
+
+const mockUser = User.reconstruct({
+    userId: 'user-001',
+    userName: 'テストユーザー',
+    password: 'hashed',
+    email: null,
+    role: 'USER',
+    status: 'ACTIVE',
+    createdAt: new Date('2026-05-08T00:00:00.000Z'),
+    updatedAt: new Date('2026-05-08T00:00:00.000Z'),
+});
+
+const mockExpense = Expense.reconstruct({
+    id: 'ulid-001',
+    userId: 'user-001',
+    amount: 1000,
+    balanceType: 0,
+    categoryId: 1,
+    content: 'テスト支出',
+    date: '2026-05-08',
+    createdDate: new Date('2026-05-08T00:00:00.000Z'),
+    updatedDate: new Date('2026-05-08T00:00:00.000Z'),
+    deletedDate: null,
+});
+
+const mockExpenseRepo: IExpenseRepository = {
+    findAll: vi.fn(),
+    findByUserId: vi.fn(),
+    findById: vi.fn(),
+    save: vi.fn(),
+    remove: vi.fn(),
+};
+
+const mockUserRepo: IUserRepository = {
+    findAll: vi.fn(),
+    findById: vi.fn(),
+    findByEmail: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(),
+    verifyPassword: vi.fn(),
+};
+
+describe('CreateExpenseUseCase', () => {
+    let useCase: CreateExpenseUseCase;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useCase = new CreateExpenseUseCase(mockExpenseRepo, mockUserRepo);
+    });
+
+    it('正常系: ユーザーが存在するとき ok=true で Expense を返す', async () => {
+        vi.mocked(mockUserRepo.findById).mockResolvedValue(mockUser);
+        vi.mocked(mockExpenseRepo.save).mockResolvedValue(mockExpense);
+
+        const result = await useCase.execute({
+            userId: 'user-001',
+            amount: 1000,
+            balanceType: 0,
+            categoryId: 1,
+            content: 'テスト支出',
+            date: '2026-05-08',
+        });
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value).toBeInstanceOf(Expense);
+        }
+        expect(mockExpenseRepo.save).toHaveBeenCalledOnce();
+    });
+
+    it('異常系: ユーザーが存在しないとき ok=false で NotFoundError を返す', async () => {
+        vi.mocked(mockUserRepo.findById).mockResolvedValue(null);
+
+        const result = await useCase.execute({
+            userId: 'unknown-user',
+            amount: 1000,
+            balanceType: 0,
+            categoryId: 1,
+            content: 'テスト支出',
+            date: '2026-05-08',
+        });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(NotFoundError);
+        }
+        expect(mockExpenseRepo.save).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/__tests__/unit/use-cases/UpdateExpenseUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/UpdateExpenseUseCase.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { UpdateExpenseUseCase } from '../../../application/use-cases/UpdateExpenseUseCase';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import { Expense } from '../../../domain/models/Expense';
+import { NotFoundError } from '../../../shared/errors/DomainException';
+
+const existingExpense = Expense.reconstruct({
+    id: 'ulid-001',
+    userId: 'user-001',
+    amount: 1000,
+    balanceType: 0,
+    categoryId: 1,
+    content: 'テスト支出',
+    date: '2026-05-08',
+    createdDate: new Date('2026-05-08T00:00:00.000Z'),
+    updatedDate: new Date('2026-05-08T00:00:00.000Z'),
+    deletedDate: null,
+});
+
+const mockExpenseRepo: IExpenseRepository = {
+    findAll: vi.fn(),
+    findByUserId: vi.fn(),
+    findById: vi.fn(),
+    save: vi.fn(),
+    remove: vi.fn(),
+};
+
+describe('UpdateExpenseUseCase', () => {
+    let useCase: UpdateExpenseUseCase;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useCase = new UpdateExpenseUseCase(mockExpenseRepo);
+    });
+
+    it('正常系: 支出が存在するとき ok=true で更新済み Expense を返す', async () => {
+        const updated = Expense.reconstruct({
+            id: 'ulid-001',
+            userId: 'user-001',
+            amount: 2000,
+            balanceType: 0,
+            categoryId: 1,
+            content: '更新後',
+            date: '2026-05-08',
+            createdDate: new Date('2026-05-08T00:00:00.000Z'),
+            updatedDate: new Date(),
+            deletedDate: null,
+        });
+        vi.mocked(mockExpenseRepo.findById).mockResolvedValue(existingExpense);
+        vi.mocked(mockExpenseRepo.save).mockResolvedValue(updated);
+
+        const result = await useCase.execute('ulid-001', {
+            amount: 2000,
+            balanceType: 0,
+            categoryId: 1,
+            content: '更新後',
+            date: '2026-05-08',
+        });
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value).toBeInstanceOf(Expense);
+        }
+        expect(mockExpenseRepo.save).toHaveBeenCalledOnce();
+    });
+
+    it('異常系: 支出が存在しないとき ok=false で NotFoundError を返す', async () => {
+        vi.mocked(mockExpenseRepo.findById).mockResolvedValue(null);
+
+        const result = await useCase.execute('unknown-id', {
+            amount: 2000,
+            balanceType: 0,
+            categoryId: 1,
+            content: '更新後',
+            date: '2026-05-08',
+        });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(NotFoundError);
+        }
+        expect(mockExpenseRepo.save).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/__tests__/unit/use-cases/UpsertUserSettingsUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/UpsertUserSettingsUseCase.test.ts
@@ -41,7 +41,10 @@ describe('UpsertUserSettingsUseCase', () => {
 
         const result = await useCase.execute(validInput);
 
-        expect(result).toEqual(mockSettings);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value).toEqual(mockSettings);
+        }
         expect(mockRepo.upsert).toHaveBeenCalledWith(validInput);
     });
 
@@ -50,7 +53,10 @@ describe('UpsertUserSettingsUseCase', () => {
 
         const result = await useCase.execute({ ...validInput, monthlyIncome: 0 });
 
-        expect(result.monthlyIncome).toBe(0);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.monthlyIncome).toBe(0);
+        }
     });
 
     it('正常系: 総資産 0 で保存できる', async () => {
@@ -58,7 +64,10 @@ describe('UpsertUserSettingsUseCase', () => {
 
         const result = await useCase.execute({ ...validInput, totalAssets: 0 });
 
-        expect(result.totalAssets).toBe(0);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.totalAssets).toBe(0);
+        }
     });
 
     it('正常系: 給料日 1 で保存できる（最小値）', async () => {
@@ -66,7 +75,10 @@ describe('UpsertUserSettingsUseCase', () => {
 
         const result = await useCase.execute({ ...validInput, paydayDay: 1 });
 
-        expect(result.paydayDay).toBe(1);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.paydayDay).toBe(1);
+        }
     });
 
     it('正常系: 給料日 31 で保存できる（最大値）', async () => {
@@ -74,26 +86,54 @@ describe('UpsertUserSettingsUseCase', () => {
 
         const result = await useCase.execute({ ...validInput, paydayDay: 31 });
 
-        expect(result.paydayDay).toBe(31);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.paydayDay).toBe(31);
+        }
     });
 
-    it('異常系: 総資産が負数のとき ValidationError をスローする', async () => {
-        await expect(useCase.execute({ ...validInput, totalAssets: -1 })).rejects.toThrow(ValidationError);
+    it('異常系: 総資産が負数のとき ok=false で ValidationError を返す', async () => {
+        const result = await useCase.execute({ ...validInput, totalAssets: -1 });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(ValidationError);
+        }
     });
 
-    it('異常系: 月次収入が負数のとき ValidationError をスローする', async () => {
-        await expect(useCase.execute({ ...validInput, monthlyIncome: -1 })).rejects.toThrow(ValidationError);
+    it('異常系: 月次収入が負数のとき ok=false で ValidationError を返す', async () => {
+        const result = await useCase.execute({ ...validInput, monthlyIncome: -1 });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(ValidationError);
+        }
     });
 
-    it('異常系: 給料日が 0 のとき ValidationError をスローする', async () => {
-        await expect(useCase.execute({ ...validInput, paydayDay: 0 })).rejects.toThrow(ValidationError);
+    it('異常系: 給料日が 0 のとき ok=false で ValidationError を返す', async () => {
+        const result = await useCase.execute({ ...validInput, paydayDay: 0 });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(ValidationError);
+        }
     });
 
-    it('異常系: 給料日が 32 のとき ValidationError をスローする', async () => {
-        await expect(useCase.execute({ ...validInput, paydayDay: 32 })).rejects.toThrow(ValidationError);
+    it('異常系: 給料日が 32 のとき ok=false で ValidationError を返す', async () => {
+        const result = await useCase.execute({ ...validInput, paydayDay: 32 });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(ValidationError);
+        }
     });
 
-    it('異常系: 固定費が負数のとき ValidationError をスローする', async () => {
-        await expect(useCase.execute({ ...validInput, fixedExpenses: -1 })).rejects.toThrow(ValidationError);
+    it('異常系: 固定費が負数のとき ok=false で ValidationError を返す', async () => {
+        const result = await useCase.execute({ ...validInput, fixedExpenses: -1 });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.error).toBeInstanceOf(ValidationError);
+        }
     });
 });

--- a/apps/api/src/application/use-cases/CreateExpenseUseCase.ts
+++ b/apps/api/src/application/use-cases/CreateExpenseUseCase.ts
@@ -2,6 +2,8 @@ import type { CreateExpenseInput } from '@budget/common';
 import { Expense } from '../../domain/models/Expense';
 import type { IExpenseRepository } from '../../domain/repositories/IExpenseRepository';
 import type { IUserRepository } from '../../domain/repositories/IUserRepository';
+import { NotFoundError } from '../../shared/errors/DomainException';
+import { type Result, ok, err } from '../../shared/types/result';
 
 export type { CreateExpenseInput };
 
@@ -11,11 +13,11 @@ export class CreateExpenseUseCase {
         private readonly userRepository: IUserRepository
     ) {}
 
-    async execute(input: CreateExpenseInput): Promise<Expense> {
+    async execute(input: CreateExpenseInput): Promise<Result<Expense, NotFoundError>> {
         // ユーザー存在確認
         const user = await this.userRepository.findById(input.userId);
         if (!user) {
-            throw new Error(`ユーザーが見つかりません: ${input.userId}`);
+            return err(new NotFoundError(`ユーザーが見つかりません: ${input.userId}`));
         }
 
         const expense = Expense.create({
@@ -27,6 +29,7 @@ export class CreateExpenseUseCase {
             date: input.date,
         });
 
-        return this.expenseRepository.save(expense);
+        const saved = await this.expenseRepository.save(expense);
+        return ok(saved);
     }
 }

--- a/apps/api/src/application/use-cases/UpdateExpenseUseCase.ts
+++ b/apps/api/src/application/use-cases/UpdateExpenseUseCase.ts
@@ -2,16 +2,17 @@ import type { UpdateExpenseInput } from '@budget/common';
 import { Expense } from '../../domain/models/Expense';
 import type { IExpenseRepository } from '../../domain/repositories/IExpenseRepository';
 import { NotFoundError } from '../../shared/errors/DomainException';
+import { type Result, ok, err } from '../../shared/types/result';
 
 export type { UpdateExpenseInput };
 
 export class UpdateExpenseUseCase {
     constructor(private readonly expenseRepository: IExpenseRepository) {}
 
-    async execute(id: string, input: UpdateExpenseInput): Promise<Expense> {
+    async execute(id: string, input: UpdateExpenseInput): Promise<Result<Expense, NotFoundError>> {
         const existing = await this.expenseRepository.findById(id);
         if (!existing) {
-            throw new NotFoundError(`支出が見つかりません: ${id}`);
+            return err(new NotFoundError(`支出が見つかりません: ${id}`));
         }
 
         // 既存エンティティの不変フィールドを保持しつつ更新フィールドを上書き
@@ -28,6 +29,7 @@ export class UpdateExpenseUseCase {
             updatedDate: new Date(),
         });
 
-        return this.expenseRepository.save(updated);
+        const saved = await this.expenseRepository.save(updated);
+        return ok(saved);
     }
 }

--- a/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
+++ b/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
@@ -1,6 +1,7 @@
 import type { UserSettings } from '../../../domain/models/UserSettings';
 import type { IUserSettingsRepository } from '../../../domain/repositories/IUserSettingsRepository';
 import { ValidationError } from '../../../shared/errors/DomainException';
+import { type Result, ok, err } from '../../../shared/types/result';
 
 export type UpsertUserSettingsInput = {
     userId: string;
@@ -19,19 +20,20 @@ const PAYDAY_MAX = 31;
 export class UpsertUserSettingsUseCase {
     constructor(private readonly userSettingsRepository: IUserSettingsRepository) {}
 
-    async execute(input: UpsertUserSettingsInput): Promise<UserSettings> {
+    async execute(input: UpsertUserSettingsInput): Promise<Result<UserSettings, ValidationError>> {
         if (input.totalAssets < 0) {
-            throw new ValidationError('総資産は0以上の値を入力してください');
+            return err(new ValidationError('総資産は0以上の値を入力してください'));
         }
         if (input.monthlyIncome < 0) {
-            throw new ValidationError('月次収入は0以上の値を入力してください');
+            return err(new ValidationError('月次収入は0以上の値を入力してください'));
         }
         if (input.paydayDay < PAYDAY_MIN || input.paydayDay > PAYDAY_MAX) {
-            throw new ValidationError(`給料日は${PAYDAY_MIN}〜${PAYDAY_MAX}の範囲で入力してください`);
+            return err(new ValidationError(`給料日は${PAYDAY_MIN}〜${PAYDAY_MAX}の範囲で入力してください`));
         }
         if (input.fixedExpenses < 0) {
-            throw new ValidationError('固定費は0以上の値を入力してください');
+            return err(new ValidationError('固定費は0以上の値を入力してください'));
         }
-        return this.userSettingsRepository.upsert(input);
+        const settings = await this.userSettingsRepository.upsert(input);
+        return ok(settings);
     }
 }

--- a/apps/api/src/presentation/routes/expense.ts
+++ b/apps/api/src/presentation/routes/expense.ts
@@ -83,6 +83,10 @@ const createExpenseRoute = createRoute({
             content: { 'application/json': { schema: ErrorResponseSchema } },
             description: '未認証',
         },
+        404: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'リソースが見つからない',
+        },
     },
 });
 
@@ -108,6 +112,10 @@ const updateExpenseRoute = createRoute({
         401: {
             content: { 'application/json': { schema: ErrorResponseSchema } },
             description: '未認証',
+        },
+        404: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'リソースが見つからない',
         },
     },
 });
@@ -162,15 +170,27 @@ export function createExpenseRoutes({
 
     app.openapi(createExpenseRoute, async (c) => {
         const { newData } = c.req.valid('json');
-        const expense = await createExpenseUseCase.execute(newData as CreateExpenseInput);
-        return c.json({ expense: toExpenseDto(expense) }, 200);
+        const result = await createExpenseUseCase.execute(newData as CreateExpenseInput);
+        if (!result.ok) {
+            return c.json(
+                { result: 'error' as const, message: result.error.message },
+                result.error.statusCode as 400 | 404
+            );
+        }
+        return c.json({ expense: toExpenseDto(result.value) }, 200);
     });
 
     app.openapi(updateExpenseRoute, async (c) => {
         const { id } = c.req.valid('param');
         const { updateData } = c.req.valid('json');
-        const expense = await updateExpenseUseCase.execute(id, updateData as UpdateExpenseInput);
-        return c.json({ expense: toExpenseDto(expense) }, 200);
+        const result = await updateExpenseUseCase.execute(id, updateData as UpdateExpenseInput);
+        if (!result.ok) {
+            return c.json(
+                { result: 'error' as const, message: result.error.message },
+                result.error.statusCode as 400 | 404
+            );
+        }
+        return c.json({ expense: toExpenseDto(result.value) }, 200);
     });
 
     app.openapi(deleteExpenseRoute, async (c) => {

--- a/apps/api/src/presentation/routes/settings.ts
+++ b/apps/api/src/presentation/routes/settings.ts
@@ -81,19 +81,22 @@ export function createSettingsRoutes({
     app.openapi(upsertUserSettingsRoute, async (c) => {
         const userId = c.get('userId');
         const { totalAssets, monthlyIncome, paydayDay, fixedExpenses } = c.req.valid('json');
-        const settings = await upsertUserSettingsUseCase.execute({
+        const result = await upsertUserSettingsUseCase.execute({
             userId,
             totalAssets,
             monthlyIncome,
             paydayDay,
             fixedExpenses,
         });
+        if (!result.ok) {
+            return c.json({ result: 'error' as const, message: result.error.message }, result.error.statusCode as 400);
+        }
         return c.json(
             {
-                totalAssets: settings.totalAssets,
-                monthlyIncome: settings.monthlyIncome,
-                paydayDay: settings.paydayDay,
-                fixedExpenses: settings.fixedExpenses,
+                totalAssets: result.value.totalAssets,
+                monthlyIncome: result.value.monthlyIncome,
+                paydayDay: result.value.paydayDay,
+                fixedExpenses: result.value.fixedExpenses,
             },
             200
         );

--- a/apps/api/src/shared/types/result.ts
+++ b/apps/api/src/shared/types/result.ts
@@ -1,0 +1,17 @@
+import type { DomainException } from '../errors/DomainException';
+
+/**
+ * 成功・失敗を型で表現する Result 型。
+ * ユースケースが例外を throw せずに呼び出し側へエラーを伝える際に使用する。
+ */
+export type Result<T, E extends DomainException = DomainException> = { ok: true; value: T } | { ok: false; error: E };
+
+/** 成功値をラップして Result を返すヘルパー */
+export function ok<T>(value: T): Result<T, never> {
+    return { ok: true, value };
+}
+
+/** エラーをラップして Result を返すヘルパー */
+export function err<E extends DomainException>(error: E): Result<never, E> {
+    return { ok: false, error };
+}

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -332,6 +332,15 @@ export interface paths {
                         "application/json": components["schemas"]["ErrorResponse"];
                     };
                 };
+                /** @description リソースが見つからない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
             };
         };
         delete?: never;
@@ -424,6 +433,15 @@ export interface paths {
                 };
                 /** @description 未認証 */
                 401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description リソースが見つからない */
+                404: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -939,6 +939,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: リソースが見つからない
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
   /api/expense/{id}:
     get:
       tags:
@@ -1008,6 +1014,12 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: 未認証
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: リソースが見つからない
           content:
             application/json:
               schema:


### PR DESCRIPTION
## 概要

Issue #99 対応。ユースケースが例外（`throw`）ベースでエラーを返す設計を、型安全な `Result<T, E>` 型に移行した。

## 変更内容

### 新規: `shared/types/result.ts`
```typescript
export type Result<T, E extends DomainException = DomainException> =
    | { ok: true; value: T }
    | { ok: false; error: E }
```
- `ok<T>(value)` / `err<E>(error)` ヘルパーを提供

### ユースケース移行
| UseCase | 変更前 | 変更後 |
|---|---|---|
| `CreateExpenseUseCase` | `throw new Error()` | `Result<Expense, NotFoundError>` |
| `UpdateExpenseUseCase` | `throw new NotFoundError()` | `Result<Expense, NotFoundError>` |
| `UpsertUserSettingsUseCase` | `throw new ValidationError()` | `Result<UserSettings, ValidationError>` |

### ルートハンドラ
- `expense.ts`: `createExpenseRoute`・`updateExpenseRoute` で Result を unwrap し、`!result.ok` 時に `result.error.statusCode` でレスポンス
- `settings.ts`: `upsertUserSettingsRoute` で同様の unwrap パターンに統一
- OpenAPI ルート定義に `404` レスポンスを追加（POST /expense・PUT /expense/{id}）

### OpenAPI / api-client
- `openapi.yaml`・`schema.d.ts` を再生成（404 レスポンス追加反映）

## 影響範囲

- ルートハンドラの `app.onError` は予期しない例外（DB エラー等）のフォールバックとして引き続き機能
- 外部 API 契約（レスポンス形式・ステータスコード）に変更なし（404 追加のみ）

## テスト内容

- `unit/controllers/ExpenseController.test.ts`: Result 型 API に合わせてアサーション更新
- `unit/controllers/UpdateExpenseUseCase.test.ts`: 同上
- `unit/use-cases/CreateExpenseUseCase.test.ts`: 新規追加（2 ケース）
- `unit/use-cases/UpdateExpenseUseCase.test.ts`: 新規追加（2 ケース）
- `unit/use-cases/UpsertUserSettingsUseCase.test.ts`: Result 型 API に合わせてアサーション更新（10 ケース）
- 全ユニットテスト（30 件）・統合テスト（34 件）パス

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（Result 型は shared/types に配置）
- [x] ID（ulid）の生成・利用箇所は適切か（ID 操作なし）
- [x] マジックナンバーを排除し、定数化されているか（新規マジックナンバーなし）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（BE のみの変更のため該当なし）

Closes #99