### PR TITLE
fix: ExpenseEditModal にカテゴリ選択フィールドを追加

### DIFF
--- a/apps/web/src/__tests__/components/ExpenseEditModal.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseEditModal.test.tsx
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import * as React from 'react'
+import { ExpenseEditModal } from '../../components/expense/ExpenseEditModal'
+import type { ExpenseResponse } from '@/lib/api/types'
+
+// Server Action をモック
+vi.mock('@/lib/actions/expense', () => ({
+    updateExpenseAction: vi.fn(),
+}))
+
+// useActionState をモック
+vi.mock('react', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('react')>()
+    return {
+        ...actual,
+        useActionState: vi.fn(),
+    }
+})
+
+const mockExpense: ExpenseResponse = {
+    id: 'expense-001',
+    amount: 1500,
+    balanceType: 0,
+    userId: 'user-001',
+    categoryId: 1,
+    content: '昼食代',
+    date: '2026-05-01',
+    createdDate: '2026-05-01T12:00:00.000Z',
+    updatedDate: '2026-05-01T12:00:00.000Z',
+    deletedDate: null,
+}
+
+describe('ExpenseEditModal', () => {
+    const defaultProps = {
+        expense: mockExpense,
+        onClose: vi.fn(),
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('初期表示: 既存の balanceType が選択されている', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        // balanceType select は最初の combobox
+        const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
+        expect(selects[0].value).toBe('0')
+    })
+
+    it('初期表示: 既存の categoryId が選択されている', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        // categoryId select は2番目の combobox
+        const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
+        expect(selects[1].value).toBe('1')
+    })
+
+    it('初期表示: 収入データを開いたとき、収入のカテゴリ一覧が表示される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} expense={{ ...mockExpense, balanceType: 1, categoryId: 1 }} />)
+
+        // 収入カテゴリ「給料」が表示される
+        expect(screen.getByText('給料')).toBeInTheDocument()
+        // 支出専用カテゴリ「食費」は表示されない
+        expect(screen.queryByText('食費')).not.toBeInTheDocument()
+    })
+
+    it('balanceType を切り替えたとき: カテゴリが「未分類」（id=0）にリセットされる', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        const selects = screen.getAllByRole('combobox') as HTMLSelectElement[]
+        const balanceTypeSelect = selects[0]
+        const categorySelect = selects[1]
+
+        // 初期は categoryId=1（食費）
+        expect(categorySelect.value).toBe('1')
+
+        // balanceType を 収入（1）に切り替え
+        fireEvent.change(balanceTypeSelect, { target: { value: '1' } })
+
+        // カテゴリが id=0（未分類）にリセットされる
+        expect(categorySelect.value).toBe('0')
+    })
+
+    it('balanceType を切り替えたとき: 収入カテゴリ一覧に切り替わる', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        // 支出カテゴリ「食費」が表示されている
+        expect(screen.getByText('食費')).toBeInTheDocument()
+
+        // balanceType を 収入に切り替え
+        const selects = screen.getAllByRole('combobox')
+        fireEvent.change(selects[0], { target: { value: '1' } })
+
+        // 支出カテゴリ「食費」は消え、収入カテゴリ「給料」が表示される
+        expect(screen.queryByText('食費')).not.toBeInTheDocument()
+        expect(screen.getByText('給料')).toBeInTheDocument()
+    })
+
+    it('state.error があるとき、エラーメッセージを表示する', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: '支出の更新に失敗しました', success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        expect(screen.getByText('支出の更新に失敗しました')).toBeInTheDocument()
+    })
+
+    it('isPending=true のとき、ボタンが disabled になる', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            true,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        expect(screen.getByRole('button', { name: '更新中...' })).toBeDisabled()
+    })
+
+    it('閉じるボタン押下: onClose が呼ばれる', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null, success: false },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<ExpenseEditModal {...defaultProps} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
+
+        expect(defaultProps.onClose).toHaveBeenCalledOnce()
+    })
+})

--- a/apps/web/src/components/expense/ExpenseEditModal.tsx
+++ b/apps/web/src/components/expense/ExpenseEditModal.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useActionState, useEffect } from "react";
+import { useActionState, useEffect, useState } from "react";
 import { X } from "lucide-react";
 import { updateExpenseAction } from "@/lib/actions/expense";
 import type { UpdateExpenseActionState } from "@/lib/actions/expense";
 import type { ExpenseResponse } from "@/lib/api/types";
+import { getCategoriesByType } from "@/lib/constants/categories";
 
 type Props = {
   expense: ExpenseResponse;
@@ -16,6 +17,9 @@ const initialState: UpdateExpenseActionState = { error: null, success: false };
 export function ExpenseEditModal({ expense, onClose }: Props) {
   const boundAction = updateExpenseAction.bind(null, expense.id);
   const [state, formAction, isPending] = useActionState(boundAction, initialState);
+  const [balanceType, setBalanceType] = useState<0 | 1>(expense.balanceType);
+  const [categoryId, setCategoryId] = useState<number>(expense.categoryId);
+  const categories = getCategoriesByType(balanceType);
 
   // 更新成功時にモーダルを閉じる
   useEffect(() => {
@@ -50,7 +54,13 @@ export function ExpenseEditModal({ expense, onClose }: Props) {
             <label className="text-xs font-bold text-[#1c1410]/60">種別</label>
             <select
               name="balanceType"
-              defaultValue={String(expense.balanceType)}
+              value={balanceType}
+              onChange={(e) => {
+                const next = Number(e.target.value) as 0 | 1;
+                setBalanceType(next);
+                // 種別変更時はカテゴリを「未分類」にリセット
+                setCategoryId(0);
+              }}
               className="rounded-xl border border-[#e8c8b0] bg-[#fdf8f5] px-3 py-2 text-sm text-[#1c1410] focus:outline-none focus:ring-2 focus:ring-[#c8956c]"
             >
               <option value="0">支出</option>
@@ -59,6 +69,21 @@ export function ExpenseEditModal({ expense, onClose }: Props) {
             {state.fieldErrors?.balanceType && (
               <p className="text-xs text-red-500">{state.fieldErrors.balanceType[0]}</p>
             )}
+          </div>
+
+          {/* カテゴリ */}
+          <div className="flex flex-col gap-1">
+            <label className="text-xs font-bold text-[#1c1410]/60">カテゴリ</label>
+            <select
+              name="categoryId"
+              value={categoryId}
+              onChange={(e) => setCategoryId(Number(e.target.value))}
+              className="rounded-xl border border-[#e8c8b0] bg-[#fdf8f5] px-3 py-2 text-sm text-[#1c1410] focus:outline-none focus:ring-2 focus:ring-[#c8956c]"
+            >
+              {categories.map((cat) => (
+                <option key={cat.id} value={cat.id}>{cat.name}</option>
+              ))}
+            </select>
           </div>
 
           {/* 金額 */}

--- a/apps/web/src/lib/actions/expense.ts
+++ b/apps/web/src/lib/actions/expense.ts
@@ -62,6 +62,7 @@ export async function createExpenseAction(
 export type UpdateExpenseFieldErrors = {
   amount?: string[];
   balanceType?: string[];
+  categoryId?: string[];
   date?: string[];
 };
 


### PR DESCRIPTION
Closes #153

## 📋 概要

支出編集モーダルに categoryId フィールドが存在しなかったため、編集保存時にカテゴリが常に「未分類（id=0）」に上書きされていた問題を修正する。

## 🛠 変更内容

- `apps/web/src/components/expense/ExpenseEditModal.tsx`
  - `useState` と `getCategoriesByType` をインポート追加
  - `balanceType` / `categoryId` の制御ステートを追加（既存データを初期値）
  - `balanceType` セレクトを uncontrolled から controlled に変更
  - `categoryId` セレクトを新規追加（balanceType に連動するカテゴリ一覧を表示）
  - `balanceType` 切り替え時に `categoryId` を 0（未分類）にリセット
- `apps/web/src/lib/actions/expense.ts`
  - `UpdateExpenseFieldErrors` 型に `categoryId?: string[]` を追加
- `apps/web/src/__tests__/components/ExpenseEditModal.test.tsx`（新規）
  - 既存データの初期選択確認
  - 収入データを開いたとき収入カテゴリが表示されること
  - balanceType 切り替え時のカテゴリリセット
  - balanceType 切り替え時のカテゴリ一覧切り替え
  - エラー状態表示
  - isPending 時の disabled
  - 閉じるボタンの onClose 呼び出し（計8ケース）

## 🔍 影響範囲

- 支出編集モーダルの保存動作: categoryId が正しく送信されるようになる
- 新規作成フォーム（`ExpenseCreateForm`）・削除フローには影響なし

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（ID操作なし）
- [x] マジックナンバーを排除し、定数化されているか（getCategoriesByType を利用、マジックナンバーなし）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（UI変更あり・スクリーンショット未添付）

## 📸 スクリーンショット

UI 変更あり（カテゴリセレクトの追加）。スクリーンショットは手動で添付予定。

## 🧪 テスト内容

- `pnpm --filter web test:unit`: 126件全パス
- `pnpm test:integration`: 34件全パス
- `pnpm --filter web build`: エラーなし
- `tsc --noEmit`: 型エラーなし

## ⚠️ 備考

PR #154 はサーバーアクションとスキーマのみ修正し、モーダルコンポーネント自体への修正が抜けていた。
本 PR でフロントエンドの根本原因を修正し、コンポーネントテストを追加することで再発防止する。