### PR TITLE
fix: db-migrate 新イメージ実行 + page.tsx getSettings 失敗時のレジリエンス向上

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,11 +132,51 @@ jobs:
             .
           echo "built=true" >> "$GITHUB_OUTPUT"
 
+  # ─── API タスク定義を新イメージで先行登録 ─────────────────────────────────────
+  # db-migrate より先に新イメージのタスク定義を登録する。
+  # これにより db-migrate が新イメージ（新マイグレーションファイル収録済み）で実行される。
+  register-api-task-def:
+    name: Register API Task Definition
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: needs.build-and-push.outputs.api-built == 'true'
+    steps:
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Register new api task definition
+        env:
+          TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_API }}
+          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          NEW_IMAGE="${ECR_REGISTRY}/budget-dev-api:${IMAGE_TAG}"
+
+          TASK_DEF=$(aws ecs describe-task-definition \
+            --task-definition "${TASK_FAMILY}" \
+            --query 'taskDefinition' \
+            --output json)
+
+          NEW_TASK_DEF=$(echo "${TASK_DEF}" | \
+            jq --arg IMAGE "${NEW_IMAGE}" \
+            '.containerDefinitions[0].image = $IMAGE |
+             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .placementConstraints, .compatibilities, .registeredAt, .registeredBy)')
+
+          aws ecs register-task-definition \
+            --cli-input-json "${NEW_TASK_DEF}" \
+            --query 'taskDefinition.taskDefinitionArn' \
+            --output text
+
+          echo "New task definition registered with image: ${NEW_IMAGE}"
+
   # ─── DB マイグレーション ─────────────────────────────────────────────────────
   db-migrate:
     name: DB Migration
     runs-on: ubuntu-latest
-    needs: build-and-push
+    needs: [build-and-push, register-api-task-def]
     if: needs.build-and-push.outputs.api-built == 'true'
     steps:
       - name: Configure AWS credentials (OIDC)
@@ -224,7 +264,7 @@ jobs:
   db-seed:
     name: DB Seed
     runs-on: ubuntu-latest
-    needs: [build-and-push, db-migrate]
+    needs: [build-and-push, register-api-task-def, db-migrate]
     # 冪等なため毎デプロイ実行する（build-and-push が成功し、migrate が成功 or スキップなら実行）
     if: |
       always() &&
@@ -302,11 +342,12 @@ jobs:
   deploy-ecs:
     name: Deploy ECS
     runs-on: ubuntu-latest
-    needs: [build-and-push, db-migrate, db-seed]
-    # db-migrate / db-seed がスキップの場合も実行する
+    needs: [build-and-push, register-api-task-def, db-migrate, db-seed]
+    # register-api-task-def / db-migrate / db-seed がスキップの場合も実行する
     if: |
       always() &&
       needs.build-and-push.result == 'success' &&
+      (needs.register-api-task-def.result == 'success' || needs.register-api-task-def.result == 'skipped') &&
       (needs.db-migrate.result == 'success' || needs.db-migrate.result == 'skipped') &&
       (needs.db-seed.result == 'success' || needs.db-seed.result == 'skipped')
     steps:
@@ -364,31 +405,6 @@ jobs:
             --task-definition "${NEW_TASK_DEF_ARN}" \
             --desired-count 1 \
             --force-new-deployment
-
-      - name: Update api task definition for DB migration
-        # api タスク定義を最新イメージで更新（migrate コマンド実行のベースとして使用）
-        if: needs.build-and-push.outputs.api-built == 'true'
-        env:
-          TASK_FAMILY: ${{ secrets.ECS_TASK_FAMILY_API }}
-          ECR_REGISTRY: ${{ secrets.ECR_REGISTRY }}
-          IMAGE_TAG: ${{ github.sha }}
-        run: |
-          NEW_IMAGE="${ECR_REGISTRY}/budget-dev-api:${IMAGE_TAG}"
-
-          TASK_DEF=$(aws ecs describe-task-definition \
-            --task-definition "${TASK_FAMILY}" \
-            --query 'taskDefinition' \
-            --output json)
-
-          NEW_TASK_DEF=$(echo "${TASK_DEF}" | \
-            jq --arg IMAGE "${NEW_IMAGE}" \
-            '.containerDefinitions[0].image = $IMAGE |
-             del(.taskDefinitionArn, .revision, .status, .requiresAttributes, .placementConstraints, .compatibilities, .registeredAt, .registeredBy)')
-
-          aws ecs register-task-definition \
-            --cli-input-json "${NEW_TASK_DEF}" \
-            --query 'taskDefinition.taskDefinitionArn' \
-            --output text
 
       - name: Wait for web service stability
         # タイムアウトしても後続の CloudFront 更新は実行する（continue-on-error）

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -62,25 +62,33 @@ function computeXDayInputs(expenses: { balanceType: number; amount: number; date
 }
 
 async function DashboardContent({ userId }: { userId: string }) {
-  let expenses;
-  let settings = { totalAssets: null as number | null, monthlyIncome: 0 };
+  const [expensesResult, settingsResult] = await Promise.allSettled([
+    getExpenses(),
+    getSettings(),
+  ]);
 
-  try {
-    const [expenseData, settingsData] = await Promise.all([getExpenses(), getSettings()]);
-    expenses = expenseData.expense ?? [];
-    settings = {
-      totalAssets: settingsData.totalAssets === 0 && settingsData.monthlyIncome === 0
-        ? null  // 未設定扱い（初回セットアップ）
-        : settingsData.totalAssets,
-      monthlyIncome: settingsData.monthlyIncome,
-    };
-  } catch (err) {
-    if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
-      redirect("/login");
+  // 認証エラーはログインページにリダイレクト
+  for (const result of [expensesResult, settingsResult]) {
+    if (result.status === "rejected" && result.reason instanceof ApiError) {
+      if (result.reason.status === 401 || result.reason.status === 403) {
+        redirect("/login");
+      }
     }
-    // settings の取得に失敗しても expenses は続行できる場合はそのまま
-    if (expenses === undefined) throw err;
   }
+
+  // 支出取得失敗はクラッシュ（認証エラー以外）
+  if (expensesResult.status === "rejected") throw expensesResult.reason;
+
+  const expenses = expensesResult.value.expense ?? [];
+
+  // 設定取得失敗はデフォルト値で続行（マイグレーション未適用等でもホーム画面を表示する）
+  const settingsData = settingsResult.status === "fulfilled" ? settingsResult.value : null;
+  const settings = {
+    totalAssets: settingsData && !(settingsData.totalAssets === 0 && settingsData.monthlyIncome === 0)
+      ? settingsData.totalAssets
+      : null,
+    monthlyIncome: settingsData?.monthlyIncome ?? 0,
+  };
 
   const { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays, recordingStreak } =
     computeXDayInputs(expenses);


### PR DESCRIPTION
Closes #171

## 📋 概要

ログイン後ホーム画面がクラッシュする問題を2つの観点から恒久対策する。

1. **deploy.yml**: `db-migrate` が古いイメージで実行される問題を修正 — 新イメージのタスク定義を先行登録するジョブを追加
2. **page.tsx**: `getSettings()` の失敗でホーム画面全体がクラッシュしないようにレジリエンスを向上

## 🛠 変更内容

### deploy.yml
- `register-api-task-def` ジョブを新設し、`build-and-push` の直後・`db-migrate` の前に実行する
- 新ジョブが新イメージ（新マイグレーションファイル収録済み）でタスク定義を登録する
- `db-migrate` の `needs` を `[build-and-push, register-api-task-def]` に変更
- `db-seed` / `deploy-ecs` の `needs` と `if` 条件も `register-api-task-def` を含めるよう更新
- `deploy-ecs` 内の冗長な「Update api task definition for DB migration」ステップを削除

**修正後フロー:**
```
build-and-push
  → register-api-task-def（新イメージで API タスク定義を先行登録）
  → db-migrate（新タスク定義 → 新マイグレーション実行）
  → db-seed
  → deploy-ecs
```

### page.tsx
- `Promise.all` を `Promise.allSettled` に変更
- `getSettings()` が失敗（500等）してもデフォルト値（totalAssets=null, monthlyIncome=0）でホーム画面を描画継続
- 認証エラー（401/403）は両 API いずれかが返した時点でリダイレクト
- `getExpenses()` の失敗は引き続きクラッシュ（認証エラー以外）

## 🔍 影響範囲

- `deploy.yml` のジョブ順序変更: スキップ条件も含め `register-api-task-def` の結果を反映
- ホーム画面: `getSettings()` 失敗時はデフォルト値でXデー表示（initialAssets=null）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（ID操作なし）
- [x] マジックナンバーを排除し、定数化されているか（新規リテラルなし）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし：BE/CI変更のみ）

## 📸 スクリーンショット

該当なし（CI ワークフロー・サーバーコンポーネントのエラーハンドリング変更のみ）

## 🧪 テスト内容

- `pnpm --filter web test:unit`: 126件全パス
- `pnpm test:integration`: 34件全パス
- `pnpm --filter web build`: エラーなし
- `tsc --noEmit`: 型エラーなし

## ⚠️ 備考

deploy.yml の変更は実際の AWS 環境でのみ検証可能。
ローカルでは `register-api-task-def` → `db-migrate` の順序が正しいことを YAMLの構造で確認。