### PR TITLE
feat: POST /api/expense/parse エンドポイント雛形を追加（ルールベースパース）

### DIFF
--- a/apps/api/src/__tests__/unit/use-cases/ParseExpenseUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/ParseExpenseUseCase.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { ParseExpenseUseCase, RuleBasedExpenseParser } from '../../../application/use-cases/parse/ParseExpenseUseCase';
+
+describe('RuleBasedExpenseParser', () => {
+    const parser = new RuleBasedExpenseParser();
+
+    it('正常系: 「ランチ代¥900」から amount=900, categoryId=1（食費）を抽出できる', () => {
+        const result = parser.parse('ランチ代¥900');
+        expect(result.amount).toBe(900);
+        expect(result.categoryId).toBe(1);
+        expect(result.content).toBe('ランチ代¥900');
+        expect(result.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    });
+
+    it('正常系: 「スーパーで1,200円」から amount=1200, categoryId=1（食費）を抽出できる', () => {
+        const result = parser.parse('スーパーで1,200円');
+        expect(result.amount).toBe(1200);
+        expect(result.categoryId).toBe(1);
+    });
+
+    it('正常系: 「電車代500円」から categoryId=2（交通費）を抽出できる', () => {
+        const result = parser.parse('電車代500円');
+        expect(result.amount).toBe(500);
+        expect(result.categoryId).toBe(2);
+    });
+
+    it('正常系: 金額のないテキストのとき amount=null を返す', () => {
+        const result = parser.parse('ランチを食べた');
+        expect(result.amount).toBeNull();
+        expect(result.categoryId).toBe(1);
+    });
+
+    it('境界値: 空文字のとき amount=null, categoryId=0（未分類）を返す', () => {
+        const result = parser.parse('謎の支出');
+        expect(result.amount).toBeNull();
+        expect(result.categoryId).toBe(0);
+    });
+});
+
+describe('ParseExpenseUseCase', () => {
+    const useCase = new ParseExpenseUseCase(new RuleBasedExpenseParser());
+
+    it('正常系: テキストをパースして ParsedExpense を返す', () => {
+        const result = useCase.execute({ text: 'ランチ代¥900' });
+        expect(result.amount).toBe(900);
+        expect(result.categoryId).toBe(1);
+        expect(result.content).toBe('ランチ代¥900');
+    });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -8,6 +8,7 @@ import type { RegisterUserUseCase } from './application/use-cases/auth/RegisterU
 import type { ResetPasswordUseCase } from './application/use-cases/auth/ResetPasswordUseCase';
 import type { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
 import type { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
+import type { ParseExpenseUseCase } from './application/use-cases/parse/ParseExpenseUseCase';
 import type { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
 import type { UpdateExpenseUseCase } from './application/use-cases/UpdateExpenseUseCase';
 import type { CheckUserNameUseCase } from './application/use-cases/user/CheckUserNameUseCase';
@@ -59,6 +60,7 @@ export type RouteServices = {
     // Expense
     createExpenseUseCase: CreateExpenseUseCase;
     updateExpenseUseCase: UpdateExpenseUseCase;
+    parseExpenseUseCase: ParseExpenseUseCase;
     // Export
     exportUseCase: ExportUserDataUseCase;
     // Recovery / Registration

--- a/apps/api/src/application/use-cases/parse/ParseExpenseUseCase.ts
+++ b/apps/api/src/application/use-cases/parse/ParseExpenseUseCase.ts
@@ -1,0 +1,34 @@
+import { extractAmount, extractCategoryId } from '@budget/common';
+import type { IExpenseParser, ParsedExpense } from '../../../domain/services/IExpenseParser';
+
+export type ParseExpenseInput = {
+    /** パース対象テキスト */
+    text: string;
+};
+
+export class ParseExpenseUseCase {
+    constructor(private readonly parser: IExpenseParser) {}
+
+    execute(input: ParseExpenseInput): ParsedExpense {
+        return this.parser.parse(input.text);
+    }
+}
+
+/**
+ * ルールベースの簡易パース実装。
+ * 将来的に AI モデル（Claude API 等）に差し替えられる設計。
+ */
+export class RuleBasedExpenseParser implements IExpenseParser {
+    parse(text: string): ParsedExpense {
+        const amount = extractAmount(text);
+        const categoryId = extractCategoryId(text);
+        const date = new Date().toISOString().slice(0, 10);
+
+        return {
+            amount,
+            categoryId,
+            content: text,
+            date,
+        };
+    }
+}

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -7,6 +7,7 @@ import { ResetPasswordUseCase } from './application/use-cases/auth/ResetPassword
 import { VerifyRecoveryAnswerUseCase } from './application/use-cases/auth/VerifyRecoveryAnswerUseCase';
 import { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
 import { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
+import { ParseExpenseUseCase, RuleBasedExpenseParser } from './application/use-cases/parse/ParseExpenseUseCase';
 import { UpdateExpenseUseCase } from './application/use-cases/UpdateExpenseUseCase';
 import { CheckUserNameUseCase } from './application/use-cases/user/CheckUserNameUseCase';
 import { CreateUserUseCase } from './application/use-cases/user/CreateUserUseCase';
@@ -56,6 +57,7 @@ export function buildServices(deps: AppDeps, tokenService: TokenService): RouteS
         // Expense
         createExpenseUseCase: new CreateExpenseUseCase(deps.expenseRepository, deps.userRepository),
         updateExpenseUseCase: new UpdateExpenseUseCase(deps.expenseRepository),
+        parseExpenseUseCase: new ParseExpenseUseCase(new RuleBasedExpenseParser()),
         // Export
         exportUseCase: new ExportUserDataUseCase(deps.expenseRepository),
         // Recovery / Registration

--- a/apps/api/src/domain/services/IExpenseParser.ts
+++ b/apps/api/src/domain/services/IExpenseParser.ts
@@ -1,0 +1,19 @@
+/** パース結果の候補 */
+export type ParsedExpense = {
+    /** 抽出された金額（円）。見つからない場合は null */
+    amount: number | null;
+    /** 推定カテゴリ ID（0: 未分類） */
+    categoryId: number;
+    /** パース対象テキストをそのまま content として使用 */
+    content: string;
+    /** パース実行日（YYYY-MM-DD 形式） */
+    date: string;
+};
+
+/**
+ * テキスト/画像から支出情報を抽出するインターフェース。
+ * ルールベース実装と AI モデル実装を差し替え可能にするための抽象。
+ */
+export interface IExpenseParser {
+    parse(text: string): ParsedExpense;
+}

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -141,6 +141,39 @@ export const IdParamSchema = z.object({
     id: z.string().openapi({ description: 'リソース ID (ULID)', example: '01ARZ3NDEKTSV4RRFFQ69G5FAV' }),
 });
 
+export const ExpenseParseRequestSchema = z
+    .object({
+        text: z.string().min(1, 'テキストを入力してください').openapi({
+            description: 'パース対象テキスト（例: 「ランチ代¥900」「スーパーで1200円」）',
+            example: 'ランチ代¥900',
+        }),
+        imageBase64: z.string().optional().openapi({
+            description: 'レシート画像（Base64）。現時点では未対応（将来的に AI モデルで処理）',
+        }),
+    })
+    .openapi('ExpenseParseRequest');
+
+export const ExpenseParseResponseSchema = z
+    .object({
+        amount: z.number().int().nullable().openapi({
+            description: '抽出された金額（円）。見つからない場合は null',
+            example: 900,
+        }),
+        categoryId: z.number().int().openapi({
+            description: '推定カテゴリ ID（0: 未分類）',
+            example: 1,
+        }),
+        content: z.string().openapi({
+            description: '入力テキスト（備考欄の初期値として利用）',
+            example: 'ランチ代¥900',
+        }),
+        date: z.string().openapi({
+            description: 'パース実行日（YYYY-MM-DD）',
+            example: '2026-05-09',
+        }),
+    })
+    .openapi('ExpenseParseResponse');
+
 // ─── 予算 (Budget) ───────────────────────────────────────────────
 
 export const BudgetResponseSchema = z

--- a/apps/api/src/presentation/routes/expense.ts
+++ b/apps/api/src/presentation/routes/expense.ts
@@ -5,6 +5,8 @@ import { createOpenAPIApp } from '../../lib/openapi-app';
 import {
     CreateExpenseBodySchema,
     ErrorResponseSchema,
+    ExpenseParseRequestSchema,
+    ExpenseParseResponseSchema,
     ExpenseResponseSchema,
     IdParamSchema,
     UpdateExpenseBodySchema,
@@ -120,6 +122,27 @@ const updateExpenseRoute = createRoute({
     },
 });
 
+const parseExpenseRoute = createRoute({
+    method: 'post',
+    path: '/expense/parse',
+    tags: ['Expense'],
+    summary: 'テキストから支出情報をパース',
+    security: [{ bearerAuth: [] }],
+    request: {
+        body: { content: { 'application/json': { schema: ExpenseParseRequestSchema } }, required: true },
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: ExpenseParseResponseSchema } },
+            description: 'パース結果',
+        },
+        401: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: '未認証',
+        },
+    },
+});
+
 const deleteExpenseRoute = createRoute({
     method: 'delete',
     path: '/expense/{id}',
@@ -146,6 +169,7 @@ export function createExpenseRoutes({
     expenseRepository,
     createExpenseUseCase,
     updateExpenseUseCase,
+    parseExpenseUseCase,
 }: RouteServices) {
     const auth = createAuthMiddleware(tokenService);
     const app = createOpenAPIApp();
@@ -191,6 +215,12 @@ export function createExpenseRoutes({
             );
         }
         return c.json({ expense: toExpenseDto(result.value) }, 200);
+    });
+
+    app.openapi(parseExpenseRoute, (c) => {
+        const { text } = c.req.valid('json');
+        const result = parseExpenseUseCase.execute({ text });
+        return c.json(result, 200);
     });
 
     app.openapi(deleteExpenseRoute, async (c) => {

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -252,6 +252,44 @@ components:
           description: 更新データ
       required:
         - updateData
+    ExpenseParseResponse:
+      type: object
+      properties:
+        amount:
+          type: integer
+          nullable: true
+          description: 抽出された金額（円）。見つからない場合は null
+          example: 900
+        categoryId:
+          type: integer
+          description: "推定カテゴリ ID（0: 未分類）"
+          example: 1
+        content:
+          type: string
+          description: 入力テキスト（備考欄の初期値として利用）
+          example: ランチ代¥900
+        date:
+          type: string
+          description: パース実行日（YYYY-MM-DD）
+          example: 2026-05-09
+      required:
+        - amount
+        - categoryId
+        - content
+        - date
+    ExpenseParseRequest:
+      type: object
+      properties:
+        text:
+          type: string
+          minLength: 1
+          description: "パース対象テキスト（例: 「ランチ代¥900」「スーパーで1200円」）"
+          example: ランチ代¥900
+        imageBase64:
+          type: string
+          description: レシート画像（Base64）。現時点では未対応（将来的に AI モデルで処理）
+      required:
+        - text
     BudgetResponse:
       type: object
       properties:
@@ -1052,6 +1090,32 @@ paths:
                       - success
                 required:
                   - result
+        "401":
+          description: 未認証
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/expense/parse:
+    post:
+      tags:
+        - Expense
+      summary: テキストから支出情報をパース
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExpenseParseRequest"
+      responses:
+        "200":
+          description: パース結果
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExpenseParseResponse"
         "401":
           description: 未認証
           content:

--- a/packages/common/src/__tests__/utils/parse.test.ts
+++ b/packages/common/src/__tests__/utils/parse.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { extractAmount, extractCategoryId } from '../../utils/parse';
+
+describe('extractAmount', () => {
+    it('正常系: ¥1500 から 1500 を抽出できる', () => {
+        expect(extractAmount('¥1500')).toBe(1500);
+    });
+
+    it('正常系: ¥1,500 から 1500 を抽出できる', () => {
+        expect(extractAmount('¥1,500')).toBe(1500);
+    });
+
+    it('正常系: ￥1500 から 1500 を抽出できる（全角円マーク）', () => {
+        expect(extractAmount('￥1500')).toBe(1500);
+    });
+
+    it('正常系: 1500円 から 1500 を抽出できる', () => {
+        expect(extractAmount('1500円')).toBe(1500);
+    });
+
+    it('正常系: 1,500円 から 1500 を抽出できる', () => {
+        expect(extractAmount('1,500円')).toBe(1500);
+    });
+
+    it('正常系: 文中に埋め込まれた「スーパーで1200円」から 1200 を抽出できる', () => {
+        expect(extractAmount('スーパーで1200円')).toBe(1200);
+    });
+
+    it('正常系: 文中に埋め込まれた「ランチ代¥900」から 900 を抽出できる', () => {
+        expect(extractAmount('ランチ代¥900')).toBe(900);
+    });
+
+    it('境界値: 金額が1のとき、1 を返す', () => {
+        expect(extractAmount('1円')).toBe(1);
+    });
+
+    it('境界値: 金額情報がないとき、null を返す', () => {
+        expect(extractAmount('ランチ食べた')).toBeNull();
+    });
+
+    it('境界値: 空文字のとき、null を返す', () => {
+        expect(extractAmount('')).toBeNull();
+    });
+});
+
+describe('extractCategoryId', () => {
+    it('正常系: 「ランチ」→ 食費（1）', () => {
+        expect(extractCategoryId('ランチ代')).toBe(1);
+    });
+
+    it('正常系: 「スーパー」→ 食費（1）', () => {
+        expect(extractCategoryId('スーパーで買い物')).toBe(1);
+    });
+
+    it('正常系: 「電車」→ 交通費（2）', () => {
+        expect(extractCategoryId('電車代')).toBe(2);
+    });
+
+    it('正常系: 「ガス」→ 光熱費（3）', () => {
+        expect(extractCategoryId('ガス代')).toBe(3);
+    });
+
+    it('正常系: 「スマホ」→ 通信費（4）', () => {
+        expect(extractCategoryId('スマホ代')).toBe(4);
+    });
+
+    it('正常系: 「家賃」→ 住宅費（5）', () => {
+        expect(extractCategoryId('家賃')).toBe(5);
+    });
+
+    it('正常系: 「病院」→ 医療費（6）', () => {
+        expect(extractCategoryId('病院代')).toBe(6);
+    });
+
+    it('正常系: 「保険」→ 保険（7）', () => {
+        expect(extractCategoryId('保険料')).toBe(7);
+    });
+
+    it('正常系: 「日用品」→ 日用品（8）', () => {
+        expect(extractCategoryId('日用品')).toBe(8);
+    });
+
+    it('正常系: 「服」→ 衣類（9）', () => {
+        expect(extractCategoryId('服を買った')).toBe(9);
+    });
+
+    it('正常系: 「映画」→ 趣味（10）', () => {
+        expect(extractCategoryId('映画代')).toBe(10);
+    });
+
+    it('境界値: マッチするキーワードがないとき、0（未分類）を返す', () => {
+        expect(extractCategoryId('謎の支出')).toBe(0);
+    });
+
+    it('境界値: 空文字のとき、0（未分類）を返す', () => {
+        expect(extractCategoryId('')).toBe(0);
+    });
+});

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,4 +1,5 @@
 export * from './utils/xday'
+export * from './utils/parse'
 export * from './utils/statistics'
 export * from './utils/streak'
 export * from './utils/comparison'

--- a/packages/common/src/utils/parse.ts
+++ b/packages/common/src/utils/parse.ts
@@ -1,0 +1,62 @@
+/**
+ * テキストから支出情報を抽出するユーティリティ。
+ * ルールベースの簡易パース（将来的に AI モデルへ差し替え可能）。
+ */
+
+/**
+ * テキストから金額（円）を抽出する。
+ *
+ * 対応フォーマット:
+ *   ¥1500 / ¥1,500 / 1500円 / 1,500円
+ *
+ * @param text - パース対象テキスト
+ * @returns 抽出された金額（正の整数）。見つからない場合は null
+ */
+export function extractAmount(text: string): number | null {
+    const patterns = [
+        /[¥￥]([0-9]{1,3}(?:,[0-9]{3})+|[0-9]+)/,
+        /([0-9]{1,3}(?:,[0-9]{3})+|[0-9]+)円/,
+    ];
+
+    for (const pattern of patterns) {
+        const m = text.match(pattern);
+        if (m) {
+            const n = Number(m[1].replace(/,/g, ''));
+            if (!Number.isNaN(n) && n > 0) return n;
+        }
+    }
+
+    return null;
+}
+
+/** カテゴリキーワードマッピング。順序は優先度を表す（先に一致したものを採用）。 */
+const CATEGORY_KEYWORDS: ReadonlyArray<{ readonly keywords: readonly string[]; readonly categoryId: number }> = [
+    { keywords: ['ランチ', '昼食', '夕食', '朝食', '食事', 'スーパー', 'コンビニ', '外食', 'カフェ', '食費', 'レストラン', '弁当'], categoryId: 1 },
+    { keywords: ['電車', 'バス', 'タクシー', '地下鉄', '新幹線', '交通', '運賃'], categoryId: 2 },
+    { keywords: ['ガス', '電気', '水道', '光熱'], categoryId: 3 },
+    { keywords: ['スマホ', '携帯', 'WiFi', 'Wi-Fi', 'インターネット', '通信'], categoryId: 4 },
+    { keywords: ['家賃', '住宅', '家代'], categoryId: 5 },
+    { keywords: ['薬', '病院', '医療', 'クリニック', '歯医者'], categoryId: 6 },
+    { keywords: ['保険'], categoryId: 7 },
+    { keywords: ['洗剤', 'シャンプー', '日用品', '消耗品', 'ティッシュ'], categoryId: 8 },
+    { keywords: ['服', '洋服', '衣類', 'ファッション'], categoryId: 9 },
+    { keywords: ['ゲーム', '映画', '趣味', 'エンタメ', '娯楽'], categoryId: 10 },
+];
+
+/** 未分類カテゴリ ID */
+const CATEGORY_ID_UNCATEGORIZED = 0;
+
+/**
+ * テキストからカテゴリ ID を推定する。
+ *
+ * @param text - パース対象テキスト
+ * @returns 推定されたカテゴリ ID。一致するキーワードがない場合は 0（未分類）
+ */
+export function extractCategoryId(text: string): number {
+    for (const { keywords, categoryId } of CATEGORY_KEYWORDS) {
+        if (keywords.some((k) => text.includes(k))) {
+            return categoryId;
+        }
+    }
+    return CATEGORY_ID_UNCATEGORIZED;
+}


### PR DESCRIPTION
Closes #134

## 📋 概要

テキストから支出情報（金額・カテゴリ・日付）をルールベースで抽出する `POST /api/expense/parse` エンドポイントを実装した。将来的に AI モデルへ差し替え可能なインターフェース設計とし、`@hono/zod-openapi` による型安全なルート定義で OpenAPI スペックと同期している。

## 🛠 変更内容

- `packages/common/src/utils/parse.ts`（新規）: `extractAmount`・`extractCategoryId` ユーティリティ関数を追加
  - `extractAmount`: ¥1500 / ¥1,500 / 1500円 / 1,500円 形式に対応
  - `extractCategoryId`: 10カテゴリのキーワードマッピングで categoryId を推定（不一致は 0=未分類）
- `packages/common/src/__tests__/utils/parse.test.ts`（新規）: 正常系・異常系・境界値計23ケース
- `packages/common/src/index.ts`: `parse.ts` を再エクスポート
- `apps/api/src/domain/services/IExpenseParser.ts`（新規）: `ParsedExpense` 型と `IExpenseParser` インターフェース定義
- `apps/api/src/application/use-cases/parse/ParseExpenseUseCase.ts`（新規）: `ParseExpenseUseCase` と `RuleBasedExpenseParser` を実装
- `apps/api/src/__tests__/unit/use-cases/ParseExpenseUseCase.test.ts`（新規）: 正常系・境界値6ケース
- `apps/api/src/openapi/schemas.ts`: `ExpenseParseRequestSchema`・`ExpenseParseResponseSchema` を追加
- `apps/api/src/presentation/routes/expense.ts`: `POST /expense/parse` ルートとハンドラを追加（Bearer 認証必須）
- `apps/api/src/app.ts`: `RouteServices` に `parseExpenseUseCase` を追加
- `apps/api/src/container.ts`: `buildServices` で `ParseExpenseUseCase` をインスタンス化
- `packages/api-spec/openapi.yaml`: `generate:openapi` で再生成

## 🔍 影響範囲

- 既存エンドポイントへの影響なし（新規エンドポイント追加のみ）
- `packages/common` に追加した `parse.ts` は FE からも参照可能だが、今回は BE のみで使用
- フロントエンド UI は別 PBI に分離（今回はバックエンドのみ）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（ID 生成なし）
- [x] マジックナンバーを排除し、定数化されているか（`CATEGORY_KEYWORDS` 配列・`CATEGORY_ID_UNCATEGORIZED` 定数で管理）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし: BE のみ）

## 📸 スクリーンショット

該当なし（バックエンドのみの変更）

## 🧪 テスト内容

- `packages/common/src/__tests__/utils/parse.test.ts`: `extractAmount`・`extractCategoryId` の単体テスト（23ケース）
- `apps/api/src/__tests__/unit/use-cases/ParseExpenseUseCase.test.ts`: `RuleBasedExpenseParser`・`ParseExpenseUseCase` の単体テスト（6ケース）
- `pnpm test:unit` 全件パス確認済み

## ⚠️ 備考

- `IExpenseParser` インターフェース経由で実装を差し替え可能な設計のため、将来的に AI モデル（OpenAI 等）へ移行する際もコアロジックの変更は不要