### PR TITLE
chore: スプリント番号によるベロシティ記録の設計改善（日付キー → sprint_number キー）

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -95,6 +95,7 @@
 1. **リファインメント**: `スプリントリファインメントをして` のロジックで `backlog` を整査する
    - `size` / `priority` / 完了条件の欠落がある Issue は自動でラベルを補完・コメントで通知する
 2. **プランニング**: `スプリントプランニングをして` のロジックでスコープを確定する
+   - `meta.next_sprint_number` をインクリメントして現スプリント番号を確定し main にコミットする
    - ベロシティから今日のキャパシティを計算し、収まる PBI を自動選定する
    - 選定した PBI に `sprint-backlog` + `in-progress` ラベルを付与する
 3. **実装ループ**: `スプリントを進めて` のメインループを実行する（全 PBI 完了まで繰り返す）
@@ -162,19 +163,31 @@
 
 #### `スプリントプランニングをして`
 
-1. `.github/velocity-log.json` を読み込み、直近3スプリントの平均ベロシティを計算する
+1. **スプリント番号を採番する**（最初に必ず実行）:
+   - `.github/velocity-log.json` を読み込み、`meta.next_sprint_number` を取得する
+   - 現在のスプリント番号 = `next_sprint_number` の現在値
+   - `meta.next_sprint_number` を +1 してファイルに書き戻す（スプリント開始宣言）
+   - 変更をコミット・プッシュして main に反映する:
+     ```bash
+     git add .github/velocity-log.json
+     git commit -m "chore(sprint): スプリント #N を開始する"
+     git push origin main
+     ```
+   - 以降このスプリントで作成する **すべての PR 本文に `Sprint: N`** を含める
+2. `.github/velocity-log.json` から直近3スプリントの平均ベロシティを計算する
    - 実績がない場合は初期値 6pt を使用する
-2. 全オープン Issue を取得して候補を選定する（ラベルの有無は問わない）
+3. 全オープン Issue を取得して候補を選定する（ラベルの有無は問わない）
    ```
    gh issue list --state open --json number,title,body,labels,assignees --limit 50
    ```
-3. 以下の基準で PBI を選定し、合計ポイントが平均ベロシティ以内に収まる組み合わせを提案する：
+4. 以下の基準で PBI を選定し、合計ポイントが平均ベロシティ以内に収まる組み合わせを提案する：
    - `priority: P0/P1` を最優先
    - `size: XS/S/M` を優先（1日で完了しやすい）
    - 依存関係（ブロッカー）を確認
    - 完了不可と判断した PBI は分割案を提示する
-4. 以下の形式でユーザーに提示する：
+5. 以下の形式でユーザーに提示する：
    ```
+   スプリント #N（next_sprint_number から採番）
    今日のキャパシティ: Xpt（直近3スプリント平均 or 初期値）
    前回との比較: +X / -X pt（実績がある場合）
 
@@ -182,7 +195,7 @@
    - #番号 タイトル（size: M / 3pt）
    - #番号 タイトル（size: S / 2pt）
    ```
-5. 承認後、対象 PBI に `sprint-backlog` ラベルを付与し、続けて実装する場合は `in-progress` も付与する
+6. 承認後、対象 PBI に `sprint-backlog` ラベルを付与し、続けて実装する場合は `in-progress` も付与する
 
 #### `スプリントを進めて`（メインループ）
 
@@ -218,6 +231,7 @@
 9. **PR 作成 & ラベル更新**: `gh pr create` で PR を作成する。以下を必ず守ること：
    - `.github/pull-request-instructions.md` の生成ルールに従う（チェックリスト評価・記入必須）
    - 本文に `Closes #Issue番号` を含める（サイクルタイム・ベロシティの自動計測に必要）
+   - 本文に `Sprint: N`（プランニング時に採番したスプリント番号）を含める（ベロシティログのグルーピングキー）
    - PR 作成後、`in-progress` を外して `in-review` を付与する：
      ```bash
      gh issue edit {Issue番号} --remove-label "in-progress" --add-label "in-review"

--- a/.github/velocity-log.json
+++ b/.github/velocity-log.json
@@ -9,10 +9,12 @@
       "XL": 8
     },
     "initial_velocity_estimate": 6,
-    "note": "initial_velocity_estimate は仮設定値（1作業日 ≈ 6pt）。実績を蓄積しながら調整する。"
+    "note": "initial_velocity_estimate は仮設定値（1作業日 ≈ 6pt）。実績を蓄積しながら調整する。",
+    "next_sprint_number": 5
   },
   "sprints": [
     {
+      "sprint_number": 1,
       "date": "2026-05-06",
       "total_points": 9,
       "pbis": [
@@ -51,6 +53,7 @@
       ]
     },
     {
+      "sprint_number": 2,
       "date": "2026-05-08",
       "total_points": 45,
       "pbis": [
@@ -185,6 +188,7 @@
       ]
     },
     {
+      "sprint_number": 3,
       "date": "2026-05-09",
       "total_points": 8,
       "pbis": [
@@ -213,6 +217,12 @@
           "pr": 174
         }
       ]
+    },
+    {
+      "sprint_number": 4,
+      "date": "2026-05-09",
+      "total_points": 0,
+      "pbis": []
     }
   ]
 }

--- a/.github/workflows/update-velocity.yml
+++ b/.github/workflows/update-velocity.yml
@@ -87,24 +87,49 @@ jobs:
               }
             }
 
-            // マージ日を JST で取得（スプリント日付として使用）
+            // マージ日を JST で取得（スプリントエントリの date フィールドに使用）
             const mergedAt = new Date(pr.merged_at);
             const mergedDateJst = new Date(mergedAt.getTime() + 9 * 60 * 60 * 1000)
               .toISOString().slice(0, 10);
+
+            // PR 本文から Sprint: N を抽出してスプリント番号を取得
+            const sprintMatch = prBody.match(/Sprint:\s*(\d+)/i);
+            const sprintNumber = sprintMatch ? parseInt(sprintMatch[1], 10) : null;
+
+            if (sprintNumber === null) {
+              console.log('Sprint: N が PR 本文に見つかりませんでした。日付でフォールバックします。');
+            }
 
             // velocity-log.json を読み込んで更新
             const logPath = '.github/velocity-log.json';
             const log = JSON.parse(fs.readFileSync(logPath, 'utf8'));
 
-            // 同じ日付のスプリントエントリを探す（なければ新規作成）
-            let sprint = log.sprints.find(s => s.date === mergedDateJst);
-            if (!sprint) {
-              sprint = {
-                date: mergedDateJst,
-                total_points: 0,
-                pbis: [],
-              };
-              log.sprints.push(sprint);
+            // sprint_number でスプリントエントリを探す（なければ新規作成）
+            let sprint;
+            if (sprintNumber !== null) {
+              sprint = log.sprints.find(s => s.sprint_number === sprintNumber);
+              if (!sprint) {
+                sprint = {
+                  sprint_number: sprintNumber,
+                  date: mergedDateJst,
+                  total_points: 0,
+                  pbis: [],
+                };
+                log.sprints.push(sprint);
+                // sprint_number 昇順に並べ替え
+                log.sprints.sort((a, b) => (a.sprint_number ?? 0) - (b.sprint_number ?? 0));
+              }
+            } else {
+              // フォールバック: 日付で探す（Sprint: N なし PR 用）
+              sprint = log.sprints.find(s => s.date === mergedDateJst && s.sprint_number == null);
+              if (!sprint) {
+                sprint = {
+                  date: mergedDateJst,
+                  total_points: 0,
+                  pbis: [],
+                };
+                log.sprints.push(sprint);
+              }
             }
 
             // PBI を追記（重複チェック）
@@ -124,8 +149,10 @@ jobs:
             // ファイルに書き戻し
             fs.writeFileSync(logPath, JSON.stringify(log, null, 2) + '\n');
 
-            console.log(`Issue #${issueNumber}: ${points}pt を ${mergedDateJst} のスプリントに記録しました`);
+            const sprintLabel = sprintNumber !== null ? `スプリント #${sprintNumber}` : mergedDateJst;
+            console.log(`Issue #${issueNumber}: ${points}pt を ${sprintLabel} に記録しました`);
             core.setOutput('updated', 'true');
+            core.setOutput('sprint_number', String(sprintNumber ?? ''));
             core.setOutput('sprint_date', mergedDateJst);
             core.setOutput('issue_number', String(issueNumber));
             core.setOutput('points', String(points));
@@ -136,5 +163,11 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/velocity-log.json
-          git diff --cached --quiet || git commit -m "chore(velocity): Issue #${{ steps.update.outputs.issue_number }} の完了を記録する（${{ steps.update.outputs.points }}pt / ${{ steps.update.outputs.sprint_date }}）"
+          SPRINT_LABEL="${{ steps.update.outputs.sprint_number }}"
+          if [ -n "${SPRINT_LABEL}" ]; then
+            SPRINT_LABEL="Sprint #${SPRINT_LABEL}"
+          else
+            SPRINT_LABEL="${{ steps.update.outputs.sprint_date }}"
+          fi
+          git diff --cached --quiet || git commit -m "chore(velocity): Issue #${{ steps.update.outputs.issue_number }} の完了を記録する（${{ steps.update.outputs.points }}pt / ${SPRINT_LABEL}）"
           git push


### PR DESCRIPTION
Sprint: 4
Closes #175

## 📋 概要

`velocity-log.json` のスプリント識別子を `date`（日付）から `sprint_number`（連番）に変更した。
同日複数スプリントを実施しても PBI が混在しない設計とし、スプリント単位での評価・振り返りを可能にした。

## 🛠 変更内容

- `.github/velocity-log.json`:
  - `meta.next_sprint_number: 5` を追加（現スプリントは Sprint #4）
  - 既存3スプリントに `sprint_number: 1〜3` を遡及付与
  - Sprint #4 の空エントリを追加（現スプリント用）
- `.github/workflows/update-velocity.yml`:
  - PR 本文の `Sprint: N` からスプリント番号を取得してグルーピングキーに使用
  - `Sprint: N` がない PR は日付フォールバックで後方互換性を維持
  - コミットメッセージを `Sprint #N` 表記に更新
- `.claude/CLAUDE.md`:
  - `スプリントプランニングをして` の冒頭に `next_sprint_number` インクリメント手順を追記
  - `スプリントを進めて` の PR 作成ステップに `Sprint: N` 埋め込みルールを追記
  - `フルスプリントを回して` のプランニングステップにも同内容を追記

## 🔍 影響範囲

- `Sprint: N` なしの既存 PR は日付フォールバックで引き続き記録される（後方互換）
- 今後のスプリントはすべて `sprint_number` で識別されるため、同日複数スプリントが正確に区別される

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（該当なし: 設定ファイルのみ）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（`POINT_SCALE` は既存の定数を継続使用）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし）

## 📸 スクリーンショット

該当なし（設定ファイル・ワークフロー・プロトコル文書のみの変更）

## 🧪 テスト内容

- 既存全テストパス（unit 192件・integration 34件）
- ワークフローは GH Actions で次スプリント以降の PR マージ時に動作確認予定

## ⚠️ 備考

- このPRのマージ後、次スプリントのプランニング時から `next_sprint_number` インクリメント手順が有効になる