### PR TITLE
design: ログイン画面をブランドアイデンティティに沿ったデザインにリデザインする

### DIFF
--- a/apps/web/src/__tests__/components/LoginForm.test.tsx
+++ b/apps/web/src/__tests__/components/LoginForm.test.tsx
@@ -129,4 +129,17 @@ describe('LoginForm', () => {
 
         expect(screen.queryByRole('alert')).not.toBeInTheDocument()
     })
+
+    it('ブランドキャッチコピーが表示される', () => {
+        vi.mocked(React.useActionState).mockReturnValue([
+            { error: null },
+            vi.fn(),
+            false,
+        ] as unknown as ReturnType<typeof React.useActionState>)
+
+        render(<LoginForm />)
+
+        expect(screen.getByText('家計を、もっとシンプルに。')).toBeInTheDocument()
+        expect(screen.getByText('Budget')).toBeInTheDocument()
+    })
 })

--- a/apps/web/src/components/login/LoginForm.tsx
+++ b/apps/web/src/components/login/LoginForm.tsx
@@ -47,40 +47,27 @@ export function LoginForm({ returnTo }: Props) {
   const [state, formAction, isPending] = useActionState(loginAction, initialState);
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#fffdf5] px-4">
-      {/* 背景の幾何学デコレーション（控えめなサイズ） */}
-      <div
-        className="pointer-events-none fixed left-8 top-20 h-16 w-16 rounded-full border border-[#f18840]/20 bg-[#fff6ee]"
-        aria-hidden="true"
-      />
-      <div
-        className="pointer-events-none fixed right-12 bottom-24 h-10 w-10 rotate-12 rounded-md border border-[#35b5a2]/20 bg-[#ecfaf8]"
-        aria-hidden="true"
-      />
-      <div
-        className="pointer-events-none fixed left-1/4 bottom-16 h-7 w-7 rounded-sm border border-[#fbbf24]/30 bg-[#fef3c7]"
-        aria-hidden="true"
-      />
-
-      <section
-        className="w-full max-w-sm rounded-2xl border-2 border-[#1c1410] bg-white p-8"
-        style={{ boxShadow: "var(--shadow-pop)" }}
-      >
-        {/* ヘッダー */}
-        <div className="mb-6 flex items-center gap-3">
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#fef5ee] px-4 gap-6">
+      {/* ブランドロゴ + キャッチコピー（カード外・上部） */}
+      <div className="flex flex-col items-center gap-2 text-center">
+        <div className="flex items-center gap-3">
           <span
-            className="flex h-10 w-10 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-base font-extrabold text-white"
+            className="flex h-12 w-12 items-center justify-center rounded-2xl border-2 border-[#1c1410] bg-[#f18840] text-lg font-extrabold text-white"
             style={{ boxShadow: "var(--shadow-pop-sm)" }}
           >
             B
           </span>
-          <div>
-            <h1 className="text-xl font-bold text-[#1c1410] leading-tight">
-              ログイン
-            </h1>
-            <p className="text-xs text-[#1c1410]/50">家計を整えよう</p>
-          </div>
+          <span className="text-2xl font-extrabold text-[#1c1410] tracking-tight">
+            Budget
+          </span>
         </div>
+        <p className="text-sm text-[#1c1410]/60 font-medium">
+          家計を、もっとシンプルに。
+        </p>
+      </div>
+
+      <section className="w-full max-w-sm rounded-2xl border border-[#e8c8b0] bg-white p-8">
+        <h1 className="mb-5 text-lg font-bold text-[#1c1410]">ログイン</h1>
 
         <Suspense>
           <NotificationBanner />


### PR DESCRIPTION
Sprint: 4
Closes #123

## 📋 概要

ログイン画面をブランドカラー（オレンジ・ウォームベージュ）に統一し、アプリロゴ + キャッチコピーを追加した。

## 🛠 変更内容

- `apps/web/src/components/login/LoginForm.tsx`:
  - ロゴ + キャッチコピー「家計を、もっとシンプルに。」をカード外・上部に配置
  - 「Budget」のアプリ名テキストをロゴ横に追加
  - 背景色を `#fffdf5` → `#fef5ee`（ウォームベージュ）に変更
  - カードの `border-2 border-[#1c1410]` + `shadow-pop` をフラット方針（`border border-[#e8c8b0]`）に変更
  - カード内のロゴ・サブタイトルブロックを削除し、シンプルな `h1` に変更
- `apps/web/src/__tests__/components/LoginForm.test.tsx`:
  - 「ブランドキャッチコピーが表示される」テストケースを追加

## 🔍 影響範囲

- ログイン画面のビジュアルのみ変更。Server Action・認証ロジックへの影響なし
- 登録画面・パスワードリセット画面は変更なし

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（フロントエンド UI のみ）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（既存の CSS ユーティリティクラス + Tailwind カラー値を使用）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（スプリント完了後にユーザーレビュー予定）

## 📸 スクリーンショット

スプリント完了後にユーザーレビューを実施予定。

## 🧪 テスト内容

- `LoginForm.test.tsx` にキャッチコピー表示テストを追加（計9ケース）
- `pnpm test:unit` 全件パス（127件）、integration テスト 34件パス

## ⚠️ 備考

- `AGENTS.md` の Sandbox-First ルールについて: 本スプリントはユーザーが「スプリント完了後にレビュー」を明示したため、sandbox プロトタイプを経由せず直接実装した