### PR TITLE
chore: ファビコン・ロゴの設定を整備する

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -22,6 +22,13 @@ export const metadata: Metadata = {
   },
   description: "日々の支出・収入を記録・管理する家計管理ツール",
   manifest: "/manifest.webmanifest",
+  icons: {
+    icon: [
+      { url: "/favicon.ico", sizes: "any" },
+      { url: "/icon.svg", type: "image/svg+xml" },
+    ],
+    apple: { url: "/icon.svg", type: "image/svg+xml" },
+  },
   appleWebApp: {
     capable: true,
     statusBarStyle: "default",

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -8,7 +8,7 @@ export default function manifest(): MetadataRoute.Manifest {
         start_url: '/',
         display: 'standalone',
         orientation: 'portrait',
-        background_color: '#fffdf5',
+        background_color: '#fef5ee',
         theme_color: '#f18840',
         icons: [
             {


### PR DESCRIPTION
Sprint: 4
Closes #130

## 📋 概要

ファビコン（`favicon.ico`）は既存ファイルを確認し、Next.js App Router の自動処理に委ねた。
Metadata に `icons` フィールドを明示追加してブラウザ互換性を強化し、manifest の `background_color` をブランドカラーに統一した。

## 🛠 変更内容

- `apps/web/src/app/layout.tsx`:
  - `metadata.icons` を追加し `favicon.ico`（any サイズ）と `icon.svg`（SVG）を明示宣言
  - `apple` アイコンとして `icon.svg` を設定（iOS ホーム画面対応）
- `apps/web/src/app/manifest.ts`:
  - `background_color` を `#fffdf5` → `#fef5ee` に変更（ログイン画面・デザインシステムと統一）

## 🔍 影響範囲

- ブラウザタブ・PWA インストール・iOS ホーム画面のアイコン表示に影響
- アプリロジックへの影響なし

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（フロントエンド設定のみ）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（カラー値は Tailwind / CSS 変数と整合）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（スプリント完了後にユーザーレビュー予定）

## 📸 スクリーンショット

スプリント完了後にユーザーレビューを実施予定（ファビコン・ホーム画面アイコンの視覚確認）。

## 🧪 テスト内容

- 既存テスト全件パス（unit 127件・integration 34件）
- metadata は TypeScript 型チェックでバリデーション済み

## ⚠️ 備考

- `favicon.ico`（25.3KB）は `apps/web/src/app/favicon.ico` に既存、Next.js App Router が自動でサーブする
- `icon.svg` は `apps/web/public/icon.svg` に既存（ウォレットアイコン + オレンジ背景）