### PR TITLE
feat: 設定ページにアカウントセクション（ユーザー名・ログアウト導線）を追加する

### DIFF
--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -6,6 +6,7 @@ import { Gallery } from './pages/Gallery'
 import { BottomNavPrototype } from './pages/BottomNavPrototype'
 import { QuickEntryPrototype } from './pages/QuickEntryPrototype'
 import { NavLayoutPrototype } from './pages/NavLayoutPrototype'
+import { AccountSectionPrototype } from './pages/AccountSectionPrototype'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -15,6 +16,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/bottom-nav" element={<BottomNavPrototype />} />
         <Route path="/quick-entry" element={<QuickEntryPrototype />} />
         <Route path="/nav-layout" element={<NavLayoutPrototype />} />
+        <Route path="/account-section" element={<AccountSectionPrototype />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/apps/sandbox/src/pages/AccountSectionPrototype.tsx
+++ b/apps/sandbox/src/pages/AccountSectionPrototype.tsx
@@ -1,0 +1,42 @@
+import { User, LogOut } from 'lucide-react'
+
+/** #179 設定ページ アカウントセクション プロトタイプ */
+export function AccountSectionPrototype() {
+  return (
+    <div className="min-h-screen p-6" style={{ background: 'var(--color-surface-default)' }}>
+      <h1 className="mb-6 text-xl font-extrabold text-[#1c1410]">
+        設定ページ — アカウントセクション (#179)
+      </h1>
+
+      {/* モバイル幅（375px）でのプレビュー */}
+      <div className="w-full max-w-sm mx-auto space-y-4">
+        {/* アカウントセクション */}
+        <div
+          className="rounded-2xl border-2 border-[#1c1410] bg-white p-6 space-y-4"
+          style={{ boxShadow: 'var(--shadow-pop)' }}
+        >
+          <h2 className="text-base font-extrabold text-[#1c1410]">アカウント</h2>
+          <div className="flex items-center gap-3">
+            <User size={18} className="text-[#1c1410]/40" />
+            <span className="text-sm font-bold text-[#1c1410]">yamamoto</span>
+          </div>
+          <form>
+            <button type="submit" className="btn-ghost flex items-center gap-2">
+              <LogOut size={16} />
+              ログアウト
+            </button>
+          </form>
+        </div>
+
+        {/* データエクスポートセクション（既存・参照用） */}
+        <div
+          className="rounded-2xl border-2 border-[#1c1410] bg-white p-6 space-y-4 opacity-50"
+          style={{ boxShadow: 'var(--shadow-pop)' }}
+        >
+          <h2 className="text-base font-extrabold text-[#1c1410]">全データのバックアップ</h2>
+          <p className="text-sm text-[#1c1410]/60">既存の DataExportSection（変更なし）</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Smartphone, PenLine, ArrowRight, Layout } from 'lucide-react'
+import { Smartphone, PenLine, ArrowRight, Layout, User } from 'lucide-react'
 
 type PrototypeCard = {
   path: string
@@ -33,6 +33,14 @@ const prototypes: PrototypeCard[] = [
     description: 'PC:左サイドバー / モバイル:ボトムナビ。NAV_ITEMSを1箇所で定義。',
     icon: Layout,
     issue: '#141',
+    status: 'ready',
+  },
+  {
+    path: '/account-section',
+    title: 'アカウントセクション（設定ページ）',
+    description: 'モバイル向けユーザー名表示・ログアウト導線の試作。',
+    icon: User,
+    issue: '#179',
     status: 'ready',
   },
 ]

--- a/apps/web/src/__tests__/components/AccountSection.test.tsx
+++ b/apps/web/src/__tests__/components/AccountSection.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AccountSection } from '../../components/settings/AccountSection'
+
+vi.mock('@/lib/actions/auth', () => ({
+    logoutAction: vi.fn(),
+}))
+
+describe('AccountSection', () => {
+    it('ユーザー名が表示されること', () => {
+        render(<AccountSection userName="yamamoto" />)
+
+        expect(screen.getByText('yamamoto')).toBeInTheDocument()
+    })
+
+    it('ゲストユーザー名が渡されたとき、Guest と表示されること', () => {
+        render(<AccountSection userName="Guest" />)
+
+        expect(screen.getByText('Guest')).toBeInTheDocument()
+    })
+
+    it('ログアウトボタンが存在すること', () => {
+        render(<AccountSection userName="yamamoto" />)
+
+        expect(screen.getByRole('button', { name: /ログアウト/ })).toBeInTheDocument()
+    })
+
+    it('アカウントセクションの見出しが表示されること', () => {
+        render(<AccountSection userName="yamamoto" />)
+
+        expect(screen.getByRole('heading', { name: 'アカウント' })).toBeInTheDocument()
+    })
+
+    it('ログアウトボタンが form 内に配置されていること', () => {
+        render(<AccountSection userName="yamamoto" />)
+
+        const button = screen.getByRole('button', { name: /ログアウト/ })
+        expect(button.closest('form')).toBeInTheDocument()
+    })
+})

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { DataExportSection } from "@/components/settings/DataExportSection";
+import { AccountSection } from "@/components/settings/AccountSection";
 import { AppShell } from "@/components/layout/AppShell";
 import { cookies } from "next/headers";
 
@@ -13,7 +14,10 @@ export default async function SettingsPage() {
         <AppShell userName={userId}>
             <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
                 <h1 className="mb-6 text-2xl font-extrabold text-[#1c1410]">設定</h1>
-                <DataExportSection />
+                <div className="space-y-4">
+                    <AccountSection userName={userId} />
+                    <DataExportSection />
+                </div>
             </main>
         </AppShell>
     );

--- a/apps/web/src/components/settings/AccountSection.tsx
+++ b/apps/web/src/components/settings/AccountSection.tsx
@@ -1,0 +1,27 @@
+import { logoutAction } from "@/lib/actions/auth";
+import { User, LogOut } from "lucide-react";
+
+type Props = {
+    userName: string;
+};
+
+export function AccountSection({ userName }: Props) {
+    return (
+        <div
+            className="rounded-2xl border-2 border-[#1c1410] bg-white p-6 space-y-4"
+            style={{ boxShadow: "var(--shadow-pop)" }}
+        >
+            <h2 className="text-base font-extrabold text-[#1c1410]">アカウント</h2>
+            <div className="flex items-center gap-3">
+                <User size={18} className="text-[#1c1410]/40" aria-hidden="true" />
+                <span className="text-sm font-bold text-[#1c1410]">{userName}</span>
+            </div>
+            <form action={logoutAction}>
+                <button type="submit" className="btn-ghost">
+                    <LogOut size={16} aria-hidden="true" />
+                    ログアウト
+                </button>
+            </form>
+        </div>
+    );
+}


### PR DESCRIPTION
## 概要

モバイルではサイドバーが非表示のため、設定ページ（`/settings`）からログアウト・ユーザー名確認ができる手段がなかった。
`AccountSection` コンポーネントを新規作成し、設定ページの最上部に配置することで解決する。

## 変更内容

- `apps/web/src/components/settings/AccountSection.tsx` — 新規作成
  - ログイン中のユーザー名を表示（User アイコン + テキスト）
  - ログアウトボタンを `<form action={logoutAction}>` で実装
  - 既存の `btn-ghost` クラスを使用
- `apps/web/src/app/settings/page.tsx` — `AccountSection` をインポートし、`DataExportSection` より前に配置
- `apps/sandbox/src/pages/AccountSectionPrototype.tsx` — Sandbox プロトタイプを追加
- `apps/sandbox/src/main.tsx` — `/account-section` ルートを追加
- `apps/sandbox/src/pages/Gallery.tsx` — ギャラリーにエントリを追加
- `apps/web/src/__tests__/components/AccountSection.test.tsx` — コンポーネントテスト追加

## 影響範囲

- `/settings` ページの表示が変更される（AccountSection が上部に追加される）
- `DataExportSection` の表示は変更なし
- サイドバー（PC）のログアウト導線は変更なし（重複は許容）

## テスト内容

Vitest + RTL で 5 ケース追加（全件グリーン確認済み）:
- ユーザー名が表示されること
- Guest ユーザー名が渡されたとき、Guest と表示されること
- ログアウトボタンが存在すること
- アカウントセクションの見出しが表示されること
- ログアウトボタンが form 内に配置されていること

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- UI変更を含むため、マージ前にレビュー担当者がローカルで確認の上チェックを入れてください -->

Closes #179
Sprint: 5