### PR TITLE
feat: フリップ形式オンボーディング画面を実装する

### DIFF
--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -7,6 +7,7 @@ import { BottomNavPrototype } from './pages/BottomNavPrototype'
 import { QuickEntryPrototype } from './pages/QuickEntryPrototype'
 import { NavLayoutPrototype } from './pages/NavLayoutPrototype'
 import { AccountSectionPrototype } from './pages/AccountSectionPrototype'
+import { OnboardingPrototype } from './pages/OnboardingPrototype'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -17,6 +18,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/quick-entry" element={<QuickEntryPrototype />} />
         <Route path="/nav-layout" element={<NavLayoutPrototype />} />
         <Route path="/account-section" element={<AccountSectionPrototype />} />
+        <Route path="/onboarding" element={<OnboardingPrototype />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Smartphone, PenLine, ArrowRight, Layout, User } from 'lucide-react'
+import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle } from 'lucide-react'
 
 type PrototypeCard = {
   path: string
@@ -41,6 +41,14 @@ const prototypes: PrototypeCard[] = [
     description: 'モバイル向けユーザー名表示・ログアウト導線の試作。',
     icon: User,
     issue: '#179',
+    status: 'ready',
+  },
+  {
+    path: '/onboarding',
+    title: 'オンボーディングウィザード',
+    description: '3ステップで給料日・固定費・残高を入力し1日予算を即時提示するフリップUI。',
+    icon: PlayCircle,
+    issue: '#132',
     status: 'ready',
   },
 ]

--- a/apps/sandbox/src/pages/OnboardingPrototype.tsx
+++ b/apps/sandbox/src/pages/OnboardingPrototype.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react'
+import { ChevronRight, ChevronLeft, Check, Calendar, Receipt, Wallet, Banknote } from 'lucide-react'
+
+type FormData = {
+  paydayDay: number
+  monthlyIncome: number
+  fixedExpenses: number
+  totalAssets: number
+}
+
+const INITIAL: FormData = { paydayDay: 25, monthlyIncome: 250000, fixedExpenses: 80000, totalAssets: 150000 }
+
+function formatAmount(v: number) {
+  return `¥${v.toLocaleString('ja-JP')}`
+}
+
+function calcDailyBudget(data: FormData): { dailyBudget: number; daysUntilPayday: number } {
+  const today = new Date()
+  const todayDate = today.getDate()
+  const currentMonth = today.getMonth()
+  const currentYear = today.getFullYear()
+  let payday = new Date(currentYear, currentMonth, data.paydayDay)
+  if (todayDate >= data.paydayDay) {
+    payday = new Date(currentYear, currentMonth + 1, data.paydayDay)
+  }
+  const msPerDay = 24 * 60 * 60 * 1000
+  const daysUntilPayday = Math.max(1, Math.ceil((payday.getTime() - today.getTime()) / msPerDay))
+  const available = data.totalAssets - data.fixedExpenses
+  return {
+    dailyBudget: available > 0 ? Math.floor(available / daysUntilPayday) : 0,
+    daysUntilPayday,
+  }
+}
+
+/** #132 フリップ形式オンボーディング プロトタイプ */
+export function OnboardingPrototype() {
+  const [step, setStep] = useState(0)
+  const [data, setData] = useState<FormData>(INITIAL)
+
+  const { dailyBudget, daysUntilPayday } = calcDailyBudget(data)
+
+  const STEPS = [
+    { label: '給料日', icon: Calendar },
+    { label: '固定費', icon: Receipt },
+    { label: '残高', icon: Wallet },
+  ]
+
+  return (
+    <div className="min-h-screen p-6 flex items-center justify-center" style={{ background: 'var(--color-surface-default)' }}>
+      <style>{`@keyframes slideIn { from { opacity: 0; transform: translateX(12px); } to { opacity: 1; transform: translateX(0); } }`}</style>
+      <div className="w-full max-w-sm">
+        {/* ヘッダー */}
+        <div className="mb-8 text-center">
+          <div
+            className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border-2 border-[#1c1410] text-white text-lg font-extrabold mb-4"
+            style={{ background: 'var(--color-brand-primary)', boxShadow: 'var(--shadow-pop-sm)' }}
+          >
+            家
+          </div>
+          <h1 className="text-xl font-extrabold text-[#1c1410]">はじめましょう</h1>
+          <p className="mt-1 text-sm text-[#1c1410]/50">3つの数字で、あなたの1日予算がわかります</p>
+        </div>
+
+        {/* ステップインジケーター */}
+        <div className="mb-6 flex gap-1.5 justify-center">
+          {STEPS.map((_, i) => (
+            <div
+              key={i}
+              className="h-1.5 w-8 rounded-full transition-colors duration-300"
+              style={{ background: i <= step && step < 3 ? 'var(--color-brand-primary)' : '#e5e7eb' }}
+            />
+          ))}
+        </div>
+
+        {/* ステップコンテンツ */}
+        <div key={step} style={{ animation: 'slideIn 0.25s ease' }} className="rounded-2xl border-2 border-[#1c1410] bg-white p-6 space-y-5">
+          {step === 0 && (
+            <>
+              <div className="flex items-center gap-2">
+                <Calendar size={20} style={{ color: 'var(--color-brand-primary)' }} />
+                <h2 className="font-extrabold text-[#1c1410]">給料日と月収を教えてください</h2>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <label className="text-xs font-bold text-[#1c1410]/60 block mb-1">給料日</label>
+                  <div className="flex items-center gap-2">
+                    <input type="number" min={1} max={31} value={data.paydayDay}
+                      onChange={(e) => setData(d => ({ ...d, paydayDay: Number(e.target.value) }))}
+                      className="input-field w-24 text-center font-bold text-lg" />
+                    <span className="text-sm font-bold text-[#1c1410]/60">日</span>
+                  </div>
+                </div>
+                <div>
+                  <label className="text-xs font-bold text-[#1c1410]/60 block mb-1">月収（手取り）</label>
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-[#1c1410]/60">¥</span>
+                    <input type="number" min={0} step={1000} value={data.monthlyIncome}
+                      onChange={(e) => setData(d => ({ ...d, monthlyIncome: Number(e.target.value) }))}
+                      className="input-field flex-1 font-bold" />
+                  </div>
+                </div>
+              </div>
+              <button type="button" onClick={() => setStep(1)} className="btn-candy w-full">
+                <span>次へ</span><ChevronRight size={18} />
+              </button>
+            </>
+          )}
+
+          {step === 1 && (
+            <>
+              <div className="flex items-center gap-2">
+                <Receipt size={20} style={{ color: 'var(--color-brand-primary)' }} />
+                <h2 className="font-extrabold text-[#1c1410]">月の固定費を教えてください</h2>
+              </div>
+              <p className="text-xs text-[#1c1410]/50">家賃・光熱費・サブスクなど毎月出ていく金額の合計</p>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-bold text-[#1c1410]/60">¥</span>
+                <input type="number" min={0} step={1000} value={data.fixedExpenses}
+                  onChange={(e) => setData(d => ({ ...d, fixedExpenses: Number(e.target.value) }))}
+                  className="input-field flex-1 font-bold" />
+              </div>
+              <div className="flex gap-3">
+                <button type="button" onClick={() => setStep(0)} className="btn-ghost"><ChevronLeft size={18} /></button>
+                <button type="button" onClick={() => setStep(2)} className="btn-candy flex-1">
+                  <span>次へ</span><ChevronRight size={18} />
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 2 && (
+            <>
+              <div className="flex items-center gap-2">
+                <Wallet size={20} style={{ color: 'var(--color-brand-primary)' }} />
+                <h2 className="font-extrabold text-[#1c1410]">今の残高を教えてください</h2>
+              </div>
+              <p className="text-xs text-[#1c1410]/50">銀行口座・財布の合計でだいたいの金額で大丈夫です</p>
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-bold text-[#1c1410]/60">¥</span>
+                <input type="number" min={0} step={1000} value={data.totalAssets}
+                  onChange={(e) => setData(d => ({ ...d, totalAssets: Number(e.target.value) }))}
+                  className="input-field flex-1 font-bold" />
+              </div>
+              <div className="flex gap-3">
+                <button type="button" onClick={() => setStep(1)} className="btn-ghost"><ChevronLeft size={18} /></button>
+                <button type="button" onClick={() => setStep(3)} className="btn-candy flex-1">
+                  <span>計算する</span><ChevronRight size={18} />
+                </button>
+              </div>
+            </>
+          )}
+
+          {step === 3 && (
+            <>
+              <div className="flex items-center gap-2">
+                <Banknote size={20} style={{ color: 'var(--color-brand-primary)' }} />
+                <h2 className="font-extrabold text-[#1c1410]">あなたの1日予算</h2>
+              </div>
+              <div
+                className="rounded-xl border-2 border-[#1c1410] py-5 text-center"
+                style={{ background: 'var(--color-surface-subtle)', boxShadow: 'var(--shadow-pop-sm)' }}
+              >
+                <p className="text-xs font-bold text-[#1c1410]/50 mb-1">今日から給料日まで、1日に使えるお金</p>
+                <p className="text-3xl font-extrabold text-[#1c1410]">{formatAmount(dailyBudget)}</p>
+                <p className="text-xs text-[#1c1410]/40 mt-1">給料日まで あと {daysUntilPayday} 日</p>
+              </div>
+              <ul className="space-y-2 text-sm">
+                <li className="flex justify-between">
+                  <span className="text-[#1c1410]/60">給料日</span>
+                  <span className="font-bold text-[#1c1410]">毎月 {data.paydayDay} 日</span>
+                </li>
+                <li className="flex justify-between">
+                  <span className="text-[#1c1410]/60">月収</span>
+                  <span className="font-bold text-[#1c1410]">{formatAmount(data.monthlyIncome)}</span>
+                </li>
+                <li className="flex justify-between">
+                  <span className="text-[#1c1410]/60">固定費</span>
+                  <span className="font-bold text-[#1c1410]">{formatAmount(data.fixedExpenses)}</span>
+                </li>
+                <li className="flex justify-between">
+                  <span className="text-[#1c1410]/60">現在の残高</span>
+                  <span className="font-bold text-[#1c1410]">{formatAmount(data.totalAssets)}</span>
+                </li>
+              </ul>
+              <div className="flex gap-3">
+                <button type="button" onClick={() => setStep(2)} className="btn-ghost"><ChevronLeft size={18} /></button>
+                <button type="button" onClick={() => alert('保存されました！')} className="btn-candy flex-1">
+                  <Check size={18} /><span>はじめる</span>
+                </button>
+              </div>
+            </>
+          )}
+        </div>
+
+        {step < 3 && (
+          <button type="button" onClick={() => setStep(3)} className="mt-4 w-full text-center text-xs text-[#1c1410]/40 underline underline-offset-2">
+            あとで設定する
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/__tests__/components/OnboardingWizard.test.tsx
+++ b/apps/web/src/__tests__/components/OnboardingWizard.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { OnboardingWizard } from '../../components/onboarding/OnboardingWizard'
+
+vi.mock('@/lib/actions/settings', () => ({
+    saveUserSettingsAction: vi.fn().mockResolvedValue(null),
+}))
+
+vi.mock('@budget/common', () => ({
+    calcDailyBudget: vi.fn().mockReturnValue({
+        dailyBudget: 3000,
+        daysUntilPayday: 10,
+        availableBalance: 30000,
+    }),
+}))
+
+import { saveUserSettingsAction } from '../../lib/actions/settings'
+
+describe('OnboardingWizard', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.mocked(saveUserSettingsAction).mockResolvedValue(null)
+    })
+
+    it('初期表示: ステップ1（給料日・月収）が表示されること', () => {
+        render(<OnboardingWizard />)
+
+        expect(screen.getByText('給料日と月収を教えてください')).toBeInTheDocument()
+        expect(screen.getByRole('spinbutton', { name: '給料日' })).toBeInTheDocument()
+        expect(screen.getByRole('spinbutton', { name: '月収' })).toBeInTheDocument()
+    })
+
+    it('「次へ」ボタンを押すとステップ2（固定費）に進むこと', () => {
+        render(<OnboardingWizard />)
+
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+
+        expect(screen.getByText('月の固定費を教えてください')).toBeInTheDocument()
+        expect(screen.getByRole('spinbutton', { name: '固定費' })).toBeInTheDocument()
+    })
+
+    it('ステップ2 → ステップ3（現在残高）に進めること', () => {
+        render(<OnboardingWizard />)
+
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+
+        expect(screen.getByText('今の残高を教えてください')).toBeInTheDocument()
+        expect(screen.getByRole('spinbutton', { name: '現在の残高' })).toBeInTheDocument()
+    })
+
+    it('ステップ3 → 完了サマリーに進めること', () => {
+        render(<OnboardingWizard />)
+
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /計算する/ }))
+
+        expect(screen.getByText('あなたの1日予算')).toBeInTheDocument()
+        expect(screen.getByLabelText('1日予算')).toBeInTheDocument()
+    })
+
+    it('戻るボタンで前のステップに戻れること', () => {
+        render(<OnboardingWizard />)
+
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        expect(screen.getByText('月の固定費を教えてください')).toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('button', { name: '' })) // ChevronLeft のみのボタン
+        expect(screen.getByText('給料日と月収を教えてください')).toBeInTheDocument()
+    })
+
+    it('「はじめる」を押すと saveUserSettingsAction が呼ばれること', async () => {
+        render(<OnboardingWizard />)
+
+        // 3ステップ進んでサマリーへ
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /計算する/ }))
+
+        fireEvent.click(screen.getByRole('button', { name: /はじめる/ }))
+
+        await waitFor(() => {
+            expect(saveUserSettingsAction).toHaveBeenCalledOnce()
+        })
+    })
+
+    it('saveUserSettingsAction がエラーを返したとき、エラーメッセージを表示すること', async () => {
+        vi.mocked(saveUserSettingsAction).mockResolvedValue({ error: '保存に失敗しました' })
+
+        render(<OnboardingWizard />)
+
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /計算する/ }))
+
+        fireEvent.click(screen.getByRole('button', { name: /はじめる/ }))
+
+        await waitFor(() => {
+            expect(screen.getByText('保存に失敗しました')).toBeInTheDocument()
+        })
+    })
+
+    it('「あとで設定する」ボタンを押すと saveUserSettingsAction が呼ばれること', async () => {
+        render(<OnboardingWizard />)
+
+        fireEvent.click(screen.getByRole('button', { name: 'あとで設定する' }))
+
+        await waitFor(() => {
+            expect(saveUserSettingsAction).toHaveBeenCalledOnce()
+        })
+    })
+
+    it('完了サマリーに入力値が表示されること', () => {
+        render(<OnboardingWizard />)
+
+        // デフォルト値で進む
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /次へ/ }))
+        fireEvent.click(screen.getByRole('button', { name: /計算する/ }))
+
+        // 給料日（デフォルト25日）が表示されること
+        expect(screen.getByText('毎月 25 日')).toBeInTheDocument()
+    })
+})

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { OnboardingWizard } from "@/components/onboarding/OnboardingWizard";
+
+export const metadata: Metadata = { title: "はじめる | 家計管理" };
+
+export default async function OnboardingPage() {
+    const cookieStore = await cookies();
+    // すでにオンボーディング済みのユーザーはホームへ
+    if (cookieStore.get("onboarding_completed")) {
+        redirect("/");
+    }
+
+    return (
+        <div
+            className="min-h-screen flex items-center justify-center p-4"
+            style={{ background: "var(--color-surface-default)" }}
+        >
+            {/* CSS アニメーション定義（keyframes はグローバルスコープに汚染しないようインライン定義） */}
+            <style>{`
+                @keyframes slideIn {
+                    from { opacity: 0; transform: translateX(12px); }
+                    to   { opacity: 1; transform: translateX(0); }
+                }
+            `}</style>
+            <OnboardingWizard />
+        </div>
+    );
+}

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -1,0 +1,355 @@
+"use client";
+
+import { useState } from "react";
+import { ChevronRight, ChevronLeft, Check, Calendar, Banknote, Receipt, Wallet } from "lucide-react";
+import { calcDailyBudget } from "@budget/common";
+import { saveUserSettingsAction } from "@/lib/actions/settings";
+
+type FormData = {
+    paydayDay: number;
+    monthlyIncome: number;
+    fixedExpenses: number;
+    totalAssets: number;
+};
+
+const INITIAL_DATA: FormData = {
+    paydayDay: 25,
+    monthlyIncome: 0,
+    fixedExpenses: 0,
+    totalAssets: 0,
+};
+
+const STEP_COUNT = 4; // 給料日/月収, 固定費, 現在残高, 完了サマリー
+
+/** 金額を「¥XXX,XXX」形式にフォーマット */
+function formatAmount(amount: number): string {
+    return `¥${amount.toLocaleString("ja-JP")}`;
+}
+
+export function OnboardingWizard() {
+    const [step, setStep] = useState(0);
+    const [data, setData] = useState<FormData>(INITIAL_DATA);
+    const [isPending, setIsPending] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    const budget = calcDailyBudget({
+        totalAssets: data.totalAssets,
+        fixedExpenses: data.fixedExpenses,
+        paydayDay: data.paydayDay,
+        today: new Date(),
+    });
+
+    function goNext() {
+        setStep((s) => s + 1);
+    }
+
+    function goBack() {
+        setStep((s) => s - 1);
+    }
+
+    async function handleSubmit() {
+        setIsPending(true);
+        setError(null);
+        const result = await saveUserSettingsAction(data);
+        if (result?.error) {
+            setError(result.error);
+            setIsPending(false);
+        }
+        // 成功時は redirect() により画面が切り替わる
+    }
+
+    return (
+        <div className="w-full max-w-sm">
+            {/* ロゴ・ヘッダー */}
+            <div className="mb-8 text-center">
+                <div
+                    className="inline-flex h-12 w-12 items-center justify-center rounded-2xl border-2 border-[#1c1410] text-white text-lg font-extrabold mb-4"
+                    style={{ background: "var(--color-brand-primary)", boxShadow: "var(--shadow-pop-sm)" }}
+                >
+                    家
+                </div>
+                <h1 className="text-xl font-extrabold text-[#1c1410]">はじめましょう</h1>
+                <p className="mt-1 text-sm text-[#1c1410]/50">3つの数字で、あなたの1日予算がわかります</p>
+            </div>
+
+            {/* ステップインジケーター */}
+            <div className="mb-6 flex gap-1.5 justify-center">
+                {Array.from({ length: STEP_COUNT - 1 }).map((_, i) => (
+                    <div
+                        key={i}
+                        className="h-1.5 w-8 rounded-full transition-colors duration-300"
+                        style={{ background: i < step ? "var(--color-brand-primary)" : i === step ? "var(--color-brand-primary)" : "#e5e7eb" }}
+                    />
+                ))}
+            </div>
+
+            {/* ステップコンテンツ */}
+            <div
+                key={step}
+                style={{ animation: "slideIn 0.25s ease" }}
+                className="rounded-2xl border-2 border-[#1c1410] bg-white p-6"
+                data-testid="step-container"
+            >
+                {step === 0 && (
+                    <PaydayStep
+                        paydayDay={data.paydayDay}
+                        monthlyIncome={data.monthlyIncome}
+                        onChange={(partial) => setData((d) => ({ ...d, ...partial }))}
+                        onNext={goNext}
+                    />
+                )}
+                {step === 1 && (
+                    <FixedExpensesStep
+                        fixedExpenses={data.fixedExpenses}
+                        onChange={(v) => setData((d) => ({ ...d, fixedExpenses: v }))}
+                        onNext={goNext}
+                        onBack={goBack}
+                    />
+                )}
+                {step === 2 && (
+                    <TotalAssetsStep
+                        totalAssets={data.totalAssets}
+                        onChange={(v) => setData((d) => ({ ...d, totalAssets: v }))}
+                        onNext={goNext}
+                        onBack={goBack}
+                    />
+                )}
+                {step === 3 && (
+                    <SummaryStep
+                        data={data}
+                        dailyBudget={budget.dailyBudget}
+                        daysUntilPayday={budget.daysUntilPayday}
+                        onBack={goBack}
+                        onSubmit={handleSubmit}
+                        isPending={isPending}
+                        error={error}
+                    />
+                )}
+            </div>
+
+            {/* スキップ導線 */}
+            {step < 3 && (
+                <button
+                    type="button"
+                    onClick={handleSubmit}
+                    className="mt-4 w-full text-center text-xs text-[#1c1410]/40 underline underline-offset-2"
+                    disabled={isPending}
+                >
+                    あとで設定する
+                </button>
+            )}
+        </div>
+    );
+}
+
+// --- 各ステップコンポーネント ---
+
+type PaydayStepProps = {
+    paydayDay: number;
+    monthlyIncome: number;
+    onChange: (partial: Partial<Pick<FormData, "paydayDay" | "monthlyIncome">>) => void;
+    onNext: () => void;
+};
+
+function PaydayStep({ paydayDay, monthlyIncome, onChange, onNext }: PaydayStepProps) {
+    const isValid = paydayDay >= 1 && paydayDay <= 31 && monthlyIncome >= 0;
+    return (
+        <div className="space-y-5">
+            <div className="flex items-center gap-2">
+                <Calendar size={20} style={{ color: "var(--color-brand-primary)" }} />
+                <h2 className="font-extrabold text-[#1c1410]">給料日と月収を教えてください</h2>
+            </div>
+            <div className="space-y-4">
+                <div>
+                    <label className="text-xs font-bold text-[#1c1410]/60 block mb-1">給料日（毎月何日？）</label>
+                    <div className="flex items-center gap-2">
+                        <input
+                            type="number"
+                            min={1}
+                            max={31}
+                            value={paydayDay}
+                            onChange={(e) => onChange({ paydayDay: Number(e.target.value) })}
+                            className="input-field w-24 text-center font-bold text-lg"
+                            aria-label="給料日"
+                        />
+                        <span className="text-sm font-bold text-[#1c1410]/60">日</span>
+                    </div>
+                </div>
+                <div>
+                    <label className="text-xs font-bold text-[#1c1410]/60 block mb-1">月収（手取り）</label>
+                    <div className="flex items-center gap-2">
+                        <span className="text-sm font-bold text-[#1c1410]/60">¥</span>
+                        <input
+                            type="number"
+                            min={0}
+                            step={1000}
+                            value={monthlyIncome}
+                            onChange={(e) => onChange({ monthlyIncome: Number(e.target.value) })}
+                            className="input-field flex-1 font-bold"
+                            aria-label="月収"
+                        />
+                    </div>
+                </div>
+            </div>
+            <button type="button" onClick={onNext} disabled={!isValid} className="btn-candy w-full">
+                <span>次へ</span>
+                <ChevronRight size={18} />
+            </button>
+        </div>
+    );
+}
+
+type FixedExpensesStepProps = {
+    fixedExpenses: number;
+    onChange: (v: number) => void;
+    onNext: () => void;
+    onBack: () => void;
+};
+
+function FixedExpensesStep({ fixedExpenses, onChange, onNext, onBack }: FixedExpensesStepProps) {
+    return (
+        <div className="space-y-5">
+            <div className="flex items-center gap-2">
+                <Receipt size={20} style={{ color: "var(--color-brand-primary)" }} />
+                <h2 className="font-extrabold text-[#1c1410]">月の固定費を教えてください</h2>
+            </div>
+            <p className="text-xs text-[#1c1410]/50">家賃・光熱費・サブスクなど、毎月必ず出ていく金額の合計です。</p>
+            <div>
+                <label className="text-xs font-bold text-[#1c1410]/60 block mb-1">固定費（月額合計）</label>
+                <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-[#1c1410]/60">¥</span>
+                    <input
+                        type="number"
+                        min={0}
+                        step={1000}
+                        value={fixedExpenses}
+                        onChange={(e) => onChange(Number(e.target.value))}
+                        className="input-field flex-1 font-bold"
+                        aria-label="固定費"
+                    />
+                </div>
+            </div>
+            <div className="flex gap-3">
+                <button type="button" onClick={onBack} className="btn-ghost">
+                    <ChevronLeft size={18} />
+                </button>
+                <button type="button" onClick={onNext} className="btn-candy flex-1">
+                    <span>次へ</span>
+                    <ChevronRight size={18} />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+type TotalAssetsStepProps = {
+    totalAssets: number;
+    onChange: (v: number) => void;
+    onNext: () => void;
+    onBack: () => void;
+};
+
+function TotalAssetsStep({ totalAssets, onChange, onNext, onBack }: TotalAssetsStepProps) {
+    return (
+        <div className="space-y-5">
+            <div className="flex items-center gap-2">
+                <Wallet size={20} style={{ color: "var(--color-brand-primary)" }} />
+                <h2 className="font-extrabold text-[#1c1410]">今の残高を教えてください</h2>
+            </div>
+            <p className="text-xs text-[#1c1410]/50">銀行口座・財布の合計で大丈夫です。だいたいの金額で問題ありません。</p>
+            <div>
+                <label className="text-xs font-bold text-[#1c1410]/60 block mb-1">現在の残高</label>
+                <div className="flex items-center gap-2">
+                    <span className="text-sm font-bold text-[#1c1410]/60">¥</span>
+                    <input
+                        type="number"
+                        min={0}
+                        step={1000}
+                        value={totalAssets}
+                        onChange={(e) => onChange(Number(e.target.value))}
+                        className="input-field flex-1 font-bold"
+                        aria-label="現在の残高"
+                    />
+                </div>
+            </div>
+            <div className="flex gap-3">
+                <button type="button" onClick={onBack} className="btn-ghost">
+                    <ChevronLeft size={18} />
+                </button>
+                <button type="button" onClick={onNext} className="btn-candy flex-1">
+                    <span>計算する</span>
+                    <ChevronRight size={18} />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+type SummaryStepProps = {
+    data: FormData;
+    dailyBudget: number;
+    daysUntilPayday: number;
+    onBack: () => void;
+    onSubmit: () => void;
+    isPending: boolean;
+    error: string | null;
+};
+
+function SummaryStep({ data, dailyBudget, daysUntilPayday, onBack, onSubmit, isPending, error }: SummaryStepProps) {
+    return (
+        <div className="space-y-5">
+            <div className="flex items-center gap-2">
+                <Banknote size={20} style={{ color: "var(--color-brand-primary)" }} />
+                <h2 className="font-extrabold text-[#1c1410]">あなたの1日予算</h2>
+            </div>
+
+            {/* 1日予算ハイライト */}
+            <div
+                className="rounded-xl border-2 border-[#1c1410] py-5 text-center"
+                style={{ background: "var(--color-surface-subtle)", boxShadow: "var(--shadow-pop-sm)" }}
+            >
+                <p className="text-xs font-bold text-[#1c1410]/50 mb-1">今日から給料日まで、1日に使えるお金</p>
+                <p className="text-3xl font-extrabold text-[#1c1410]" aria-label="1日予算">
+                    {formatAmount(dailyBudget)}
+                </p>
+                <p className="text-xs text-[#1c1410]/40 mt-1">給料日まで あと {daysUntilPayday} 日</p>
+            </div>
+
+            {/* 入力値サマリー */}
+            <ul className="space-y-2 text-sm">
+                <li className="flex justify-between">
+                    <span className="text-[#1c1410]/60">給料日</span>
+                    <span className="font-bold text-[#1c1410]">毎月 {data.paydayDay} 日</span>
+                </li>
+                <li className="flex justify-between">
+                    <span className="text-[#1c1410]/60">月収</span>
+                    <span className="font-bold text-[#1c1410]">{formatAmount(data.monthlyIncome)}</span>
+                </li>
+                <li className="flex justify-between">
+                    <span className="text-[#1c1410]/60">固定費</span>
+                    <span className="font-bold text-[#1c1410]">{formatAmount(data.fixedExpenses)}</span>
+                </li>
+                <li className="flex justify-between">
+                    <span className="text-[#1c1410]/60">現在の残高</span>
+                    <span className="font-bold text-[#1c1410]">{formatAmount(data.totalAssets)}</span>
+                </li>
+            </ul>
+
+            {error && (
+                <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
+                    {error}
+                </p>
+            )}
+
+            <div className="flex gap-3">
+                <button type="button" onClick={onBack} className="btn-ghost" disabled={isPending}>
+                    <ChevronLeft size={18} />
+                </button>
+                <button type="button" onClick={onSubmit} disabled={isPending} className="btn-candy flex-1">
+                    <Check size={18} />
+                    <span>{isPending ? "保存中..." : "はじめる"}</span>
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/apps/web/src/lib/actions/settings.ts
+++ b/apps/web/src/lib/actions/settings.ts
@@ -1,11 +1,42 @@
 "use server";
 
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
 import { putSettings } from "@/lib/api/settings";
+import type { UpsertUserSettingsBody } from "@budget/api-client";
+
+/** オンボーディング完了 Cookie の有効期間（1年） */
+const ONBOARDING_COOKIE_MAX_AGE = 365 * 24 * 60 * 60;
 
 export type SettingsActionState = {
   error: string | null;
   success: boolean;
 };
+
+/**
+ * オンボーディング用: ユーザー設定を保存し、完了 Cookie をセットしてホームへリダイレクト。
+ * エラー時は { error: string } を返す（redirect は try/catch 外で実行する Next.js の作法に従う）。
+ */
+export async function saveUserSettingsAction(
+    data: UpsertUserSettingsBody,
+): Promise<{ error: string } | null> {
+    try {
+        await putSettings(data);
+        const cookieStore = await cookies();
+        cookieStore.set("onboarding_completed", "1", {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === "production",
+            sameSite: "strict",
+            maxAge: ONBOARDING_COOKIE_MAX_AGE,
+            path: "/",
+        });
+    } catch (e) {
+        return {
+            error: e instanceof Error ? e.message : "設定の保存に失敗しました",
+        };
+    }
+    redirect("/");
+}
 
 /** ユーザー設定をサーバーに保存する Server Action */
 export async function upsertSettingsAction(

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -16,17 +16,31 @@ async function getPublicKey(): Promise<CryptoKey | null> {
   return cachedPublicKey;
 }
 
+/** オンボーディングをスキップしてよいルート（設定・オンボーディング自身） */
+const ONBOARDING_EXEMPT_PATHS = ["/onboarding", "/settings"];
+
+/** 認証済みユーザーに対してオンボーディング未完了チェックを行い、必要ならリダイレクトを返す */
+function getOnboardingRedirect(request: NextRequest): NextResponse | null {
+  const isCompleted = request.cookies.has("onboarding_completed");
+  if (isCompleted) return null;
+  const isExempt = ONBOARDING_EXEMPT_PATHS.some((p) =>
+    request.nextUrl.pathname.startsWith(p),
+  );
+  if (isExempt) return null;
+  return NextResponse.redirect(new URL("/onboarding", request.url));
+}
+
 export async function middleware(request: NextRequest) {
   const accessToken = request.cookies.get("access_token")?.value;
   const refreshToken = request.cookies.get("refresh_token")?.value;
 
   const publicKey = await getPublicKey();
 
-  // アクセストークンが有効なら通過
+  // アクセストークンが有効なら通過（オンボーディング未完了チェック付き）
   if (accessToken && publicKey) {
     try {
       await jwtVerify(accessToken, publicKey, { algorithms: [ALGORITHM] });
-      return NextResponse.next();
+      return getOnboardingRedirect(request) ?? NextResponse.next();
     } catch {
       // 期限切れ等 → リフレッシュを試みる
     }
@@ -50,7 +64,7 @@ export async function middleware(request: NextRequest) {
           };
 
         const secure = process.env.NODE_ENV === "production";
-        const response = NextResponse.next();
+        const response = getOnboardingRedirect(request) ?? NextResponse.next();
 
         response.cookies.set("access_token", newAccess, {
           httpOnly: true,
@@ -81,6 +95,6 @@ export async function middleware(request: NextRequest) {
 
 export const config = {
   // /register, /forgot-password は公開ルートのため除外
-  // /settings は認証が必要なため含める
-  matcher: ["/expenses/:path*", "/report", "/report/:path*", "/settings", "/settings/:path*", "/analysis", "/analysis/:path*"],
+  // /onboarding は認証が必要なため含める
+  matcher: ["/expenses/:path*", "/report", "/report/:path*", "/settings", "/settings/:path*", "/analysis", "/analysis/:path*", "/onboarding"],
 };


### PR DESCRIPTION
## 概要

新規ユーザーが初めてアプリを開いたときの心理的ハードルを下げるため、3ステップのウィザード UI を追加。
給料日・固定費・現在残高を入力するだけで1日予算が即時提示され、そのままホームへ遷移できる。

## 変更内容

- `apps/web/src/app/onboarding/page.tsx` — `/onboarding` ページを新規作成（Server Component）
  - `onboarding_completed` cookie がセット済みなら `/` にリダイレクト
- `apps/web/src/components/onboarding/OnboardingWizard.tsx` — ウィザード Client Component
  - 4ステップ構成: 給料日+月収 → 固定費 → 現在残高 → 完了サマリー
  - `key={step}` + CSS `@keyframes slideIn` でスライドアニメーション（外部ライブラリ追加なし）
  - `calcDailyBudget` で1日予算をリアルタイム計算・表示
  - 「あとで設定する」スキップ機能（デフォルト値で保存して skip）
- `apps/web/src/lib/actions/settings.ts` — `saveUserSettingsAction` を追加
  - `putSettings` を呼び出し後、`onboarding_completed=1` cookie をセット
  - 成功時は `/` へ redirect、失敗時は `{ error: string }` を返却
- `apps/web/src/middleware.ts` — オンボーディング未完了チェックを追加
  - `onboarding_completed` cookie がない認証済みユーザーを `/onboarding` へリダイレクト
  - `/onboarding` と `/settings` はリダイレクト対象外
  - matcher に `/onboarding` を追加
- `apps/sandbox/src/pages/OnboardingPrototype.tsx` — Sandbox プロトタイプを追加
- Gallery にエントリを追加

## 影響範囲

- 既存ユーザー: `onboarding_completed` cookie がないとオンボーディングにリダイレクトされる。`/settings` からも設定変更は可能
- `/settings` からのアクセスは免除（既存ユーザーが設定を変更したい場合の導線を維持）
- middleware のリフレッシュ処理では redirect response にも cookie を引き継ぐよう修正

## テスト内容

Vitest + RTL で 9 ケース追加（全件グリーン確認済み）:
- 初期表示: ステップ1（給料日・月収）が表示されること
- 次へボタンでステップ2に進むこと
- ステップ2→3→サマリーへの遷移
- 戻るボタンで前のステップへ
- 「はじめる」で saveUserSettingsAction が呼ばれること
- エラー時にメッセージを表示すること
- 「あとで設定する」で saveUserSettingsAction が呼ばれること
- 完了サマリーに入力値が表示されること

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか（ONBOARDING_COOKIE_MAX_AGE を定数化）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- 新規 UI のため、Sandbox プロトタイプ（/onboarding ルート）でご確認ください -->

Closes #132
Sprint: 5