### PR TITLE
feat: スマホ版カレンダーページのUI/UX刷新と操作動線統合

### DIFF
--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -13,7 +13,8 @@
     "lucide-react": "^1.8.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "react-router-dom": "^7.15.0"
+    "react-router-dom": "^7.15.0",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -8,6 +8,7 @@ import { QuickEntryPrototype } from './pages/QuickEntryPrototype'
 import { NavLayoutPrototype } from './pages/NavLayoutPrototype'
 import { AccountSectionPrototype } from './pages/AccountSectionPrototype'
 import { OnboardingPrototype } from './pages/OnboardingPrototype'
+import { CalendarPagePrototype } from './pages/CalendarPagePrototype'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -19,6 +20,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/nav-layout" element={<NavLayoutPrototype />} />
         <Route path="/account-section" element={<AccountSectionPrototype />} />
         <Route path="/onboarding" element={<OnboardingPrototype />} />
+        <Route path="/calendar-page" element={<CalendarPagePrototype />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/apps/sandbox/src/pages/CalendarPagePrototype.tsx
+++ b/apps/sandbox/src/pages/CalendarPagePrototype.tsx
@@ -1,0 +1,359 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { ArrowLeft, ChevronLeft, ChevronRight, Plus, FileText, X } from 'lucide-react'
+
+const WEEK_DAYS = ['日', '月', '火', '水', '木', '金', '土'] as const
+
+// ダミーデータ
+const DUMMY_EXPENSES = [
+  { id: '1', date: '2026-05-05', balanceType: 0, amount: 850, category: '食費', note: 'コンビニ' },
+  { id: '2', date: '2026-05-05', balanceType: 0, amount: 3200, category: '日用品', note: 'ドラッグストア' },
+  { id: '3', date: '2026-05-07', balanceType: 0, amount: 12000, category: '交通費', note: '定期代' },
+  { id: '4', date: '2026-05-07', balanceType: 1, amount: 250000, category: '給料', note: '5月分給料' },
+  { id: '5', date: '2026-05-10', balanceType: 0, amount: 4500, category: '食費', note: 'スーパー' },
+  { id: '6', date: '2026-05-10', balanceType: 0, amount: 980, category: '食費', note: 'ランチ' },
+  { id: '7', date: '2026-05-12', balanceType: 0, amount: 15000, category: '衣服', note: 'ユニクロ' },
+  { id: '8', date: '2026-05-15', balanceType: 0, amount: 2800, category: '食費', note: 'まとめ買い' },
+  { id: '9', date: '2026-05-18', balanceType: 0, amount: 500, category: '娯楽', note: 'コーヒー' },
+  { id: '10', date: '2026-05-20', balanceType: 0, amount: 8000, category: '医療費', note: '歯科' },
+]
+
+type DayData = {
+  date: Date
+  dateStr: string
+  isCurrentMonth: boolean
+  isToday: boolean
+  outgo: number
+  income: number
+}
+
+function buildCalendarDays(year: number, month: number): DayData[] {
+  const today = new Date(2026, 4, 10) // デモ用固定日付
+  const firstDay = new Date(year, month, 1)
+  const lastDay = new Date(year, month + 1, 0)
+  const startPad = firstDay.getDay()
+  const days: DayData[] = []
+
+  for (let i = startPad - 1; i >= 0; i--) {
+    const d = new Date(year, month, -i)
+    days.push({ date: d, dateStr: d.toISOString().split('T')[0], isCurrentMonth: false, isToday: false, outgo: 0, income: 0 })
+  }
+
+  for (let day = 1; day <= lastDay.getDate(); day++) {
+    const d = new Date(year, month, day)
+    const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+    const dayExpenses = DUMMY_EXPENSES.filter((e) => e.date === dateStr)
+    const outgo = dayExpenses.filter((e) => e.balanceType === 0).reduce((s, e) => s + e.amount, 0)
+    const income = dayExpenses.filter((e) => e.balanceType === 1).reduce((s, e) => s + e.amount, 0)
+    days.push({ date: d, dateStr, isCurrentMonth: true, isToday: d.getDate() === today.getDate() && month === today.getMonth(), outgo, income })
+  }
+
+  const remaining = 42 - days.length
+  for (let i = 1; i <= remaining; i++) {
+    const d = new Date(year, month + 1, i)
+    days.push({ date: d, dateStr: d.toISOString().split('T')[0], isCurrentMonth: false, isToday: false, outgo: 0, income: 0 })
+  }
+
+  return days
+}
+
+// コンパクト版カレンダー（モバイル向け: ドット表示のみ）
+function CompactCalendar({
+  year, month, days, selectedDate, onDaySelect, onPrevMonth, onNextMonth,
+}: {
+  year: number; month: number; days: DayData[]
+  selectedDate: string | null; onDaySelect: (dateStr: string) => void
+  onPrevMonth: () => void; onNextMonth: () => void
+}) {
+  return (
+    <div className="rounded-2xl border-2 border-[#1c1410] bg-white overflow-hidden" style={{ boxShadow: 'var(--shadow-pop)' }}>
+      {/* ヘッダー */}
+      <div className="flex items-center justify-between border-b-2 border-[#1c1410] bg-[#f18840] px-4 py-2.5 text-white">
+        <button type="button" onClick={onPrevMonth} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-white/40 bg-white/10">
+          <ChevronLeft size={14} />
+        </button>
+        <h2 className="text-sm font-extrabold">{year}年{month + 1}月</h2>
+        <button type="button" onClick={onNextMonth} className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-white/40 bg-white/10">
+          <ChevronRight size={14} />
+        </button>
+      </div>
+
+      {/* 曜日ヘッダー */}
+      <div className="grid grid-cols-7 border-b border-[#e8c8b0] bg-[#fffdf5]">
+        {WEEK_DAYS.map((d, i) => (
+          <div key={d} className={['py-1.5 text-center text-xs font-extrabold', i === 0 ? 'text-[#f87171]' : i === 6 ? 'text-[#35b5a2]' : 'text-[#1c1410]/50'].join(' ')}>
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* 日付グリッド（コンパクト: h-9 per row, dots only） */}
+      <div className="grid grid-cols-7">
+        {days.map((day, idx) => {
+          const isSelected = day.dateStr === selectedDate
+          return (
+            <button
+              key={day.dateStr + (day.isCurrentMonth ? '' : `-pad${idx}`)}
+              type="button"
+              onClick={() => day.isCurrentMonth && onDaySelect(day.dateStr)}
+              disabled={!day.isCurrentMonth}
+              className={[
+                'relative flex flex-col items-center justify-center border-b border-r border-[#e8c8b0] py-1 transition-colors',
+                day.isCurrentMonth ? 'cursor-pointer hover:bg-[#fff6ee]' : 'cursor-default',
+                isSelected ? 'bg-[#fff1e5]' : day.isToday ? 'bg-[#fff5ec]' : '',
+              ].join(' ')}
+              style={{ height: 44 }}
+            >
+              {/* 選択インジケーター */}
+              {isSelected && (
+                <span className="absolute inset-0 border-2 border-[#f18840] rounded-sm pointer-events-none" />
+              )}
+              {/* 日付 */}
+              <span className={[
+                'text-xs font-bold leading-none',
+                !day.isCurrentMonth ? 'text-[#1c1410]/20'
+                  : day.isToday ? 'rounded-full bg-[#f18840] px-1 text-white'
+                  : 'text-[#1c1410]',
+              ].join(' ')}>
+                {day.date.getDate()}
+              </span>
+              {/* ドットのみ（数値なし） */}
+              <div className="flex items-center gap-0.5 mt-0.5">
+                {day.outgo > 0 && <span className="h-1.5 w-1.5 rounded-full bg-[#f18840]" />}
+                {day.income > 0 && <span className="h-1.5 w-1.5 rounded-full bg-[#35b5a2]" />}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// 選択日の収支サマリー
+function DaySummary({ dateStr }: { dateStr: string }) {
+  const expenses = DUMMY_EXPENSES.filter((e) => e.date === dateStr)
+  const outgo = expenses.filter((e) => e.balanceType === 0).reduce((s, e) => s + e.amount, 0)
+  const income = expenses.filter((e) => e.balanceType === 1).reduce((s, e) => s + e.amount, 0)
+  const date = new Date(dateStr + 'T00:00:00')
+  const label = date.toLocaleDateString('ja-JP', { month: 'long', day: 'numeric', weekday: 'short' })
+
+  return (
+    <div className="rounded-2xl border-2 border-[#1c1410] bg-white overflow-hidden" style={{ boxShadow: 'var(--shadow-pop-sm)' }}>
+      <div className="px-4 py-3 border-b border-[#e8c8b0]">
+        <p className="text-sm font-extrabold text-[#1c1410]">{label}</p>
+      </div>
+      <div className="flex gap-0 divide-x divide-[#e8c8b0]">
+        <div className="flex-1 px-4 py-3 text-center">
+          <p className="text-xs text-[#1c1410]/50 mb-0.5">支出</p>
+          <p className="text-lg font-extrabold" style={{ color: outgo > 0 ? 'var(--color-expense)' : '#1c1410' }}>
+            {outgo > 0 ? `¥${outgo.toLocaleString()}` : '—'}
+          </p>
+        </div>
+        <div className="flex-1 px-4 py-3 text-center">
+          <p className="text-xs text-[#1c1410]/50 mb-0.5">収入</p>
+          <p className="text-lg font-extrabold" style={{ color: income > 0 ? 'var(--color-income)' : '#1c1410' }}>
+            {income > 0 ? `¥${income.toLocaleString()}` : '—'}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// 選択日の明細リスト
+function DayExpenseList({ dateStr }: { dateStr: string }) {
+  const expenses = DUMMY_EXPENSES.filter((e) => e.date === dateStr)
+  if (expenses.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-[#1c1410]/30">
+        <FileText size={32} className="mb-2 opacity-40" />
+        <p className="text-sm">この日の記録はありません</p>
+      </div>
+    )
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {expenses.map((e) => (
+        <div key={e.id} className="flex items-center gap-3 rounded-xl border border-[#e8c8b0] bg-white px-4 py-3">
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-[#1c1410]/50">{e.category}</p>
+            <p className="text-sm font-semibold text-[#1c1410] truncate">{e.note}</p>
+          </div>
+          <p className={['text-sm font-extrabold tabular-nums', e.balanceType === 0 ? '' : ''].join('')}
+            style={{ color: e.balanceType === 0 ? 'var(--color-expense)' : 'var(--color-income)' }}>
+            {e.balanceType === 0 ? '-' : '+'}¥{e.amount.toLocaleString()}
+          </p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// クイック入力ボトムシート（#184）
+function QuickEntrySheet({ onClose }: { onClose: () => void }) {
+  const [amount, setAmount] = useState('')
+  const [category, setCategory] = useState('食費')
+  const [type, setType] = useState<0 | 1>(0) // 0:支出 1:収入
+
+  const categories = type === 0
+    ? ['食費', '日用品', '交通費', '医療費', '衣服', '娯楽', 'その他']
+    : ['給料', '副収入', 'その他']
+
+  const color = type === 0 ? 'var(--color-expense)' : 'var(--color-income)'
+
+  return (
+    <div className="absolute inset-0 z-10 flex flex-col justify-end" style={{ background: 'rgba(28,20,16,0.4)' }}>
+      <div className="rounded-t-3xl bg-white border-t-2 border-[#1c1410] overflow-hidden" style={{ boxShadow: '0 -4px 16px rgba(28,20,16,0.12)' }}>
+        {/* シートハンドル */}
+        <div className="flex items-center justify-between px-5 pt-4 pb-2">
+          <h3 className="text-sm font-extrabold text-[#1c1410]">クイック記録</h3>
+          <button type="button" onClick={onClose} className="flex h-7 w-7 items-center justify-center rounded-full bg-[#f5f0eb]">
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="px-5 pb-6 flex flex-col gap-4">
+          {/* 種別タブ */}
+          <div className="flex rounded-xl border border-[#1c1410]/12 bg-[#f5f0eb] p-1">
+            {([0, 1] as const).map((t) => (
+              <button key={t} type="button" onClick={() => { setType(t); setCategory(t === 0 ? '食費' : '給料') }}
+                className="flex-1 rounded-lg py-2 text-sm font-bold transition-all"
+                style={type === t ? { background: t === 0 ? 'var(--color-expense)' : 'var(--color-income)', color: '#fff' } : { color: 'rgba(28,20,16,0.4)' }}>
+                {t === 0 ? '支出' : '収入'}
+              </button>
+            ))}
+          </div>
+
+          {/* 金額 */}
+          <div className="rounded-xl border border-[#1c1410]/12 bg-[#fafaf8] px-4 py-3">
+            <div className="flex items-baseline gap-1">
+              <span className="text-xl font-extrabold" style={{ color }}>¥</span>
+              <input type="number" inputMode="numeric" placeholder="0" value={amount}
+                onChange={(e) => setAmount(e.target.value)}
+                className="flex-1 bg-transparent text-3xl font-extrabold tabular-nums outline-none placeholder:text-[#1c1410]/20"
+                style={{ color }} autoFocus />
+            </div>
+          </div>
+
+          {/* カテゴリ（横スクロール選択） */}
+          <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+            {categories.map((c) => (
+              <button key={c} type="button" onClick={() => setCategory(c)}
+                className="shrink-0 rounded-full border px-3 py-1.5 text-xs font-bold transition-all"
+                style={category === c
+                  ? { background: color, borderColor: color, color: '#fff' }
+                  : { background: '#fff', borderColor: 'rgba(28,20,16,0.12)', color: 'rgba(28,20,16,0.6)' }}>
+                {c}
+              </button>
+            ))}
+          </div>
+
+          {/* 送信ボタン */}
+          <button type="button" disabled={!amount || Number(amount) <= 0}
+            onClick={onClose}
+            className="w-full rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
+            style={{ background: 'var(--color-brand-primary)' }}>
+            記録する
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function CalendarPagePrototype() {
+  const now = new Date(2026, 4, 1) // デモ用固定
+  const [year, setYear] = useState(now.getFullYear())
+  const [month, setMonth] = useState(now.getMonth())
+  const [selectedDate, setSelectedDate] = useState<string | null>('2026-05-10')
+  const [showQuickEntry, setShowQuickEntry] = useState(false)
+
+  const days = buildCalendarDays(year, month)
+
+  const prevMonth = () => { if (month === 0) { setYear(y => y - 1); setMonth(11) } else { setMonth(m => m - 1) } }
+  const nextMonth = () => { if (month === 11) { setYear(y => y + 1); setMonth(0) } else { setMonth(m => m + 1) } }
+
+  return (
+    <div className="flex flex-col items-center" style={{ background: 'var(--color-surface-default)', minHeight: '100svh' }}>
+      {/* Sandbox ナビ */}
+      <div className="w-full max-w-sm px-4 pt-4 pb-2 flex-shrink-0">
+        <Link to="/" className="flex items-center gap-1.5 text-xs text-[#1c1410]/50 hover:text-[var(--color-brand-primary)] transition-colors">
+          <ArrowLeft size={14} />Gallery に戻る
+        </Link>
+        <h1 className="mt-2 text-base font-bold text-[#1c1410]">カレンダーページ試作</h1>
+        <p className="text-xs text-[#1c1410]/50">Issue #183 + #184 — モバイルファーストレイアウト</p>
+      </div>
+
+      {/* モバイル画面シミュレーター */}
+      <div
+        className="relative mx-auto flex flex-col overflow-hidden rounded-3xl border-4 border-[#1c1410]/20"
+        style={{ width: 390, height: 720, background: 'var(--color-surface-default)' }}
+      >
+        {/* 疑似ヘッダー */}
+        <div className="flex-shrink-0 flex items-center justify-between px-4 py-3 border-b border-[#e8c8b0] bg-white">
+          <span className="text-sm font-extrabold text-[#1c1410]">カレンダー</span>
+          <Link to="/expenses/new" onClick={(e) => e.preventDefault()}
+            className="flex items-center gap-1 rounded-full border-2 border-[#1c1410] bg-[#f18840] px-3 py-1 text-xs font-bold text-white">
+            詳細記録
+          </Link>
+        </div>
+
+        {/* スクロール可能コンテンツ */}
+        <div className="flex-1 overflow-y-auto">
+          {/* カレンダー（上部固定ゾーン） */}
+          <div className="px-3 pt-3">
+            <CompactCalendar
+              year={year} month={month} days={days}
+              selectedDate={selectedDate} onDaySelect={setSelectedDate}
+              onPrevMonth={prevMonth} onNextMonth={nextMonth}
+            />
+          </div>
+
+          {/* 日付選択エリア */}
+          {selectedDate ? (
+            <div className="px-3 pt-3 pb-24 flex flex-col gap-3">
+              <DaySummary dateStr={selectedDate} />
+              <p className="text-xs font-bold text-[#1c1410]/40 px-1">明細</p>
+              <DayExpenseList dateStr={selectedDate} />
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-16 text-[#1c1410]/30">
+              <p className="text-sm">日付をタップして明細を表示</p>
+            </div>
+          )}
+        </div>
+
+        {/* フローティング「+」ボタン（クイック記録） */}
+        <div className="absolute bottom-4 right-4">
+          <button
+            type="button"
+            onClick={() => setShowQuickEntry(true)}
+            className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-[#1c1410] text-white transition-all active:scale-95"
+            style={{ background: 'var(--color-brand-primary)', boxShadow: 'var(--shadow-pop)' }}
+          >
+            <Plus size={24} />
+          </button>
+        </div>
+
+        {/* クイック入力シート */}
+        {showQuickEntry && <QuickEntrySheet onClose={() => setShowQuickEntry(false)} />}
+      </div>
+
+      {/* 説明 */}
+      <div className="mt-4 w-full max-w-sm px-4 pb-8">
+        <div className="rounded-xl border border-[#1c1410]/10 bg-white p-4 text-xs text-[#1c1410]/50 space-y-2">
+          <p className="font-bold text-[#1c1410]/70">このプロトタイプの特徴（#183 + #184）</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li><b>カレンダー最上部固定</b>: スクロールの起点がカレンダー</li>
+            <li><b>ドット表示</b>: 金額の数値は非表示。赤=支出・青=収入ドットのみ</li>
+            <li><b>日付タップ → 明細表示</b>: ページ遷移なし、State 更新で下に出る</li>
+            <li><b>「詳細記録」ボタン</b>: ヘッダー右上 → 従来の詳細フォームへ</li>
+            <li><b>「+」フローティングボタン</b>: クイック記録 (金額 + カテゴリのみ) のボトムシートが開く</li>
+            <li><b>入力フォーム削除</b>: カレンダーページ内のフォームを排除</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/sandbox/src/pages/CalendarPagePrototype.tsx
+++ b/apps/sandbox/src/pages/CalendarPagePrototype.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { ArrowLeft, ChevronLeft, ChevronRight, Plus, FileText, X } from 'lucide-react'
+import { ArrowLeft, ChevronLeft, ChevronRight, Plus, FileText, Home, Calendar, BarChart2, Settings } from 'lucide-react'
+import { Drawer } from 'vaul'
 
 const WEEK_DAYS = ['日', '月', '火', '水', '木', '金', '土'] as const
 
@@ -100,19 +101,16 @@ function CompactCalendar({
               className={[
                 'relative flex flex-col items-center justify-center border-b border-r border-[#e8c8b0] py-1 transition-colors',
                 day.isCurrentMonth ? 'cursor-pointer hover:bg-[#fff6ee]' : 'cursor-default',
-                isSelected ? 'bg-[#fff1e5]' : day.isToday ? 'bg-[#fff5ec]' : '',
+                isSelected ? 'bg-[#fff1e5]' : '',
               ].join(' ')}
               style={{ height: 44 }}
             >
-              {/* 選択インジケーター */}
-              {isSelected && (
-                <span className="absolute inset-0 border-2 border-[#f18840] rounded-sm pointer-events-none" />
-              )}
               {/* 日付 */}
               <span className={[
-                'text-xs font-bold leading-none',
+                'flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold leading-none transition-colors',
                 !day.isCurrentMonth ? 'text-[#1c1410]/20'
-                  : day.isToday ? 'rounded-full bg-[#f18840] px-1 text-white'
+                  : isSelected ? 'bg-[#f18840] text-white'
+                  : day.isToday ? 'border-2 border-[#f18840] text-[#f18840]'
                   : 'text-[#1c1410]',
               ].join(' ')}>
                 {day.date.getDate()}
@@ -190,11 +188,22 @@ function DayExpenseList({ dateStr }: { dateStr: string }) {
   )
 }
 
-// クイック入力ボトムシート（#184）
-function QuickEntrySheet({ onClose }: { onClose: () => void }) {
+// ボトムナビ個別アイテム
+function BottomNavItem({ icon: Icon, label, active }: { icon: React.ElementType; label: string; active: boolean }) {
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-0.5 py-2"
+      style={{ color: active ? 'var(--color-brand-primary)' : 'rgba(28,20,16,0.4)' }}>
+      <Icon size={22} />
+      <span className="text-[10px] font-semibold">{label}</span>
+    </div>
+  )
+}
+
+// クイック入力ドロワー（vaul）
+function QuickEntryDrawer({ open, onOpenChange }: { open: boolean; onOpenChange: (v: boolean) => void }) {
   const [amount, setAmount] = useState('')
   const [category, setCategory] = useState('食費')
-  const [type, setType] = useState<0 | 1>(0) // 0:支出 1:収入
+  const [type, setType] = useState<0 | 1>(0)
 
   const categories = type === 0
     ? ['食費', '日用品', '交通費', '医療費', '衣服', '娯楽', 'その他']
@@ -203,62 +212,70 @@ function QuickEntrySheet({ onClose }: { onClose: () => void }) {
   const color = type === 0 ? 'var(--color-expense)' : 'var(--color-income)'
 
   return (
-    <div className="absolute inset-0 z-10 flex flex-col justify-end" style={{ background: 'rgba(28,20,16,0.4)' }}>
-      <div className="rounded-t-3xl bg-white border-t-2 border-[#1c1410] overflow-hidden" style={{ boxShadow: '0 -4px 16px rgba(28,20,16,0.12)' }}>
-        {/* シートハンドル */}
-        <div className="flex items-center justify-between px-5 pt-4 pb-2">
-          <h3 className="text-sm font-extrabold text-[#1c1410]">クイック記録</h3>
-          <button type="button" onClick={onClose} className="flex h-7 w-7 items-center justify-center rounded-full bg-[#f5f0eb]">
-            <X size={14} />
-          </button>
-        </div>
+    <Drawer.Root open={open} onOpenChange={onOpenChange}>
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-40" style={{ background: 'rgba(28,20,16,0.4)' }} />
+        <Drawer.Content
+          className="fixed bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-3xl bg-white outline-none"
+          style={{ boxShadow: '0 -4px 32px rgba(28,20,16,0.16)' }}
+        >
+          {/* ドラッグハンドル */}
+          <div className="mx-auto mt-3 mb-1 h-1.5 w-12 rounded-full bg-[#1c1410]/20" />
 
-        <div className="px-5 pb-6 flex flex-col gap-4">
-          {/* 種別タブ */}
-          <div className="flex rounded-xl border border-[#1c1410]/12 bg-[#f5f0eb] p-1">
-            {([0, 1] as const).map((t) => (
-              <button key={t} type="button" onClick={() => { setType(t); setCategory(t === 0 ? '食費' : '給料') }}
-                className="flex-1 rounded-lg py-2 text-sm font-bold transition-all"
-                style={type === t ? { background: t === 0 ? 'var(--color-expense)' : 'var(--color-income)', color: '#fff' } : { color: 'rgba(28,20,16,0.4)' }}>
-                {t === 0 ? '支出' : '収入'}
-              </button>
-            ))}
-          </div>
+          <Drawer.Title className="px-5 pt-2 pb-1 text-sm font-extrabold text-[#1c1410]">
+            クイック記録
+          </Drawer.Title>
 
-          {/* 金額 */}
-          <div className="rounded-xl border border-[#1c1410]/12 bg-[#fafaf8] px-4 py-3">
-            <div className="flex items-baseline gap-1">
-              <span className="text-xl font-extrabold" style={{ color }}>¥</span>
-              <input type="number" inputMode="numeric" placeholder="0" value={amount}
-                onChange={(e) => setAmount(e.target.value)}
-                className="flex-1 bg-transparent text-3xl font-extrabold tabular-nums outline-none placeholder:text-[#1c1410]/20"
-                style={{ color }} autoFocus />
+          <div className="px-5 pb-8 pt-2 flex flex-col gap-4">
+            {/* 種別タブ */}
+            <div className="flex rounded-xl border border-[#1c1410]/12 bg-[#f5f0eb] p-1">
+              {([0, 1] as const).map((t) => (
+                <button key={t} type="button"
+                  onClick={() => { setType(t); setCategory(t === 0 ? '食費' : '給料') }}
+                  className="flex-1 rounded-lg py-2 text-sm font-bold transition-all"
+                  style={type === t
+                    ? { background: t === 0 ? 'var(--color-expense)' : 'var(--color-income)', color: '#fff' }
+                    : { color: 'rgba(28,20,16,0.4)' }}>
+                  {t === 0 ? '支出' : '収入'}
+                </button>
+              ))}
             </div>
-          </div>
 
-          {/* カテゴリ（横スクロール選択） */}
-          <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
-            {categories.map((c) => (
-              <button key={c} type="button" onClick={() => setCategory(c)}
-                className="shrink-0 rounded-full border px-3 py-1.5 text-xs font-bold transition-all"
-                style={category === c
-                  ? { background: color, borderColor: color, color: '#fff' }
-                  : { background: '#fff', borderColor: 'rgba(28,20,16,0.12)', color: 'rgba(28,20,16,0.6)' }}>
-                {c}
-              </button>
-            ))}
-          </div>
+            {/* 金額 */}
+            <div className="rounded-xl border border-[#1c1410]/12 bg-[#fafaf8] px-4 py-3">
+              <div className="flex items-baseline gap-1">
+                <span className="text-xl font-extrabold" style={{ color }}>¥</span>
+                <input type="number" inputMode="numeric" placeholder="0" value={amount}
+                  onChange={(e) => setAmount(e.target.value)}
+                  className="flex-1 bg-transparent text-3xl font-extrabold tabular-nums outline-none placeholder:text-[#1c1410]/20"
+                  style={{ color }} autoFocus />
+              </div>
+            </div>
 
-          {/* 送信ボタン */}
-          <button type="button" disabled={!amount || Number(amount) <= 0}
-            onClick={onClose}
-            className="w-full rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
-            style={{ background: 'var(--color-brand-primary)' }}>
-            記録する
-          </button>
-        </div>
-      </div>
-    </div>
+            {/* カテゴリ（横スクロール） */}
+            <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+              {categories.map((c) => (
+                <button key={c} type="button" onClick={() => setCategory(c)}
+                  className="shrink-0 rounded-full border px-3 py-1.5 text-xs font-bold transition-all"
+                  style={category === c
+                    ? { background: color, borderColor: color, color: '#fff' }
+                    : { background: '#fff', borderColor: 'rgba(28,20,16,0.12)', color: 'rgba(28,20,16,0.6)' }}>
+                  {c}
+                </button>
+              ))}
+            </div>
+
+            {/* 送信ボタン */}
+            <button type="button" disabled={!amount || Number(amount) <= 0}
+              onClick={() => { setAmount(''); onOpenChange(false) }}
+              className="w-full rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
+              style={{ background: 'var(--color-brand-primary)' }}>
+              記録する
+            </button>
+          </div>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
   )
 }
 
@@ -300,7 +317,7 @@ export function CalendarPagePrototype() {
         </div>
 
         {/* スクロール可能コンテンツ */}
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto pb-16">
           {/* カレンダー（上部固定ゾーン） */}
           <div className="px-3 pt-3">
             <CompactCalendar
@@ -312,7 +329,7 @@ export function CalendarPagePrototype() {
 
           {/* 日付選択エリア */}
           {selectedDate ? (
-            <div className="px-3 pt-3 pb-24 flex flex-col gap-3">
+            <div className="px-3 pt-3 pb-4 flex flex-col gap-3">
               <DaySummary dateStr={selectedDate} />
               <p className="text-xs font-bold text-[#1c1410]/40 px-1">明細</p>
               <DayExpenseList dateStr={selectedDate} />
@@ -324,20 +341,30 @@ export function CalendarPagePrototype() {
           )}
         </div>
 
-        {/* フローティング「+」ボタン（クイック記録） */}
-        <div className="absolute bottom-4 right-4">
-          <button
-            type="button"
-            onClick={() => setShowQuickEntry(true)}
-            className="flex h-14 w-14 items-center justify-center rounded-full border-2 border-[#1c1410] text-white transition-all active:scale-95"
-            style={{ background: 'var(--color-brand-primary)', boxShadow: 'var(--shadow-pop)' }}
-          >
-            <Plus size={24} />
-          </button>
+        {/* 既存ボトムナビ（中央FABでクイック入力を開く） */}
+        <div
+          className="absolute bottom-0 left-0 right-0 z-10 flex items-center border-t border-[#1c1410]/10 bg-white"
+          style={{ height: 64 }}
+        >
+          <BottomNavItem icon={Home} label="ホーム" active={false} />
+          <BottomNavItem icon={Calendar} label="カレンダー" active={true} />
+          {/* 中央FAB */}
+          <div className="flex flex-1 items-center justify-center">
+            <button
+              type="button"
+              onClick={() => setShowQuickEntry(true)}
+              className="relative -top-4 flex h-14 w-14 items-center justify-center rounded-full transition-transform active:scale-95"
+              style={{ background: 'var(--color-brand-primary)', boxShadow: '0 4px 16px rgba(240,128,48,0.4)' }}
+            >
+              <Plus size={22} className="text-white" />
+            </button>
+          </div>
+          <BottomNavItem icon={BarChart2} label="レポート" active={false} />
+          <BottomNavItem icon={Settings} label="設定" active={false} />
         </div>
 
-        {/* クイック入力シート */}
-        {showQuickEntry && <QuickEntrySheet onClose={() => setShowQuickEntry(false)} />}
+        {/* クイック入力ドロワー（vaul） */}
+        <QuickEntryDrawer open={showQuickEntry} onOpenChange={setShowQuickEntry} />
       </div>
 
       {/* 説明 */}

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle } from 'lucide-react'
+import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle, CalendarDays } from 'lucide-react'
 
 type PrototypeCard = {
   path: string
@@ -49,6 +49,14 @@ const prototypes: PrototypeCard[] = [
     description: '3ステップで給料日・固定費・残高を入力し1日予算を即時提示するフリップUI。',
     icon: PlayCircle,
     issue: '#132',
+    status: 'ready',
+  },
+  {
+    path: '/calendar-page',
+    title: 'カレンダーページ刷新',
+    description: 'ドット表示・日付タップで明細表示・クイック入力ボトムシート。モバイルファーストレイアウト。',
+    icon: CalendarDays,
+    issue: '#183 #184',
     status: 'ready',
   },
 ]

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "next": "16.2.4",
     "react": "19.2.4",
     "react-dom": "19.2.4",
+    "vaul": "^1.1.2",
     "zxcvbn": "^4.4.2"
   },
   "devDependencies": {

--- a/apps/web/src/__tests__/components/CalendarView.test.tsx
+++ b/apps/web/src/__tests__/components/CalendarView.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CalendarView } from "@/components/calendar/CalendarView";
+import type { ExpenseResponse } from "@/lib/api/types";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => "/calendar",
+}));
+
+const todayStr = new Date().toISOString().split("T")[0];
+
+const mockExpenses: ExpenseResponse[] = [
+  {
+    id: "1",
+    date: todayStr,
+    balanceType: 0,
+    amount: 1500,
+    categoryId: 1,
+    content: "スーパー",
+    userId: "user-1",
+    createdDate: todayStr,
+    updatedDate: todayStr,
+    deletedDate: null,
+  },
+  {
+    id: "2",
+    date: todayStr,
+    balanceType: 1,
+    amount: 250000,
+    categoryId: 1,
+    content: "給料",
+    userId: "user-1",
+    createdDate: todayStr,
+    updatedDate: todayStr,
+    deletedDate: null,
+  },
+];
+
+describe("CalendarView", () => {
+  it("カレンダーと選択日のサマリーが表示される", () => {
+    render(<CalendarView expenses={mockExpenses} userId="user-1" />);
+    // カレンダーヘッダー（月表示）
+    const now = new Date();
+    expect(
+      screen.getByText(`${now.getFullYear()}年${now.getMonth() + 1}月`),
+    ).toBeInTheDocument();
+  });
+
+  it("今日の支出・収入サマリーが表示される", () => {
+    render(<CalendarView expenses={mockExpenses} userId="user-1" />);
+    expect(screen.getByText("¥1,500")).toBeInTheDocument();
+    expect(screen.getByText("¥250,000")).toBeInTheDocument();
+  });
+
+  it("今日の明細が表示される", () => {
+    render(<CalendarView expenses={mockExpenses} userId="user-1" />);
+    expect(screen.getByText("スーパー")).toBeInTheDocument();
+    // 「給料」はカテゴリ名にも出るため getAllByText で件数を確認する
+    expect(screen.getAllByText("給料").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("記録がない日をタップすると「記録はありません」が表示される", () => {
+    render(<CalendarView expenses={[]} userId="user-1" />);
+    expect(screen.getByText("この日の記録はありません")).toBeInTheDocument();
+  });
+
+  it("「詳細記録」リンクが今日の日付を含む href を持つ", () => {
+    render(<CalendarView expenses={mockExpenses} userId="user-1" />);
+    const link = screen.getByRole("link", { name: /詳細記録/ });
+    expect(link).toHaveAttribute("href", `/expenses/new?date=${todayStr}`);
+  });
+
+  it("初期表示で今日が選択されており明細が表示される", () => {
+    render(<CalendarView expenses={mockExpenses} userId="user-1" />);
+    // 今日が選択状態のため今日の明細が初期表示される
+    expect(screen.getByText("スーパー")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuickEntryDrawer } from "@/components/expense/QuickEntryDrawer";
+
+// vaul の Drawer はポータルを使うため、テスト環境では DOM への描画を確認する
+vi.mock("@/lib/actions/expense", () => ({
+  createExpenseAction: vi.fn().mockResolvedValue({ error: null, success: false }),
+}));
+
+// useActionState のモック
+vi.mock("react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react")>();
+  return {
+    ...actual,
+    useActionState: vi.fn().mockReturnValue([
+      { error: null, success: false },
+      vi.fn(),
+      false,
+    ]),
+  };
+});
+
+describe("QuickEntryDrawer", () => {
+  const defaultProps = {
+    userId: "user-1",
+    open: true,
+    onOpenChange: vi.fn(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("openがtrueのとき、ドロワーが表示される", () => {
+    render(<QuickEntryDrawer {...defaultProps} />);
+    expect(screen.getByText("クイック記録")).toBeInTheDocument();
+  });
+
+  it("openがfalseのとき、ドロワーが表示されない", () => {
+    render(<QuickEntryDrawer {...defaultProps} open={false} />);
+    expect(screen.queryByText("クイック記録")).not.toBeInTheDocument();
+  });
+
+  it("支出タブが初期選択されている", () => {
+    render(<QuickEntryDrawer {...defaultProps} />);
+    const expenseBtn = screen.getByRole("button", { name: "支出" });
+    expect(expenseBtn).toBeInTheDocument();
+  });
+
+  it("収入タブをクリックすると収入カテゴリが表示される", () => {
+    render(<QuickEntryDrawer {...defaultProps} />);
+    fireEvent.click(screen.getByRole("button", { name: "収入" }));
+    expect(screen.getByRole("button", { name: "給料" })).toBeInTheDocument();
+  });
+
+  it("記録するボタンが存在する", () => {
+    render(<QuickEntryDrawer {...defaultProps} />);
+    expect(screen.getByRole("button", { name: "記録する" })).toBeInTheDocument();
+  });
+
+  it("エラーが返ったとき、エラーメッセージが表示される", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: "登録に失敗しました", success: false },
+      vi.fn(),
+      false,
+    ]);
+    render(<QuickEntryDrawer {...defaultProps} />);
+    expect(screen.getByText("登録に失敗しました")).toBeInTheDocument();
+  });
+
+  it("成功したとき、成功メッセージが表示される", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: true },
+      vi.fn(),
+      false,
+    ]);
+    render(<QuickEntryDrawer {...defaultProps} />);
+    expect(screen.getByText("登録しました")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/calendar/page.tsx
+++ b/apps/web/src/app/calendar/page.tsx
@@ -5,16 +5,15 @@ import { redirect } from "next/navigation";
 import { getExpenses } from "@/lib/api/expense";
 import { ApiError } from "@/lib/api/client";
 import { AppShell } from "@/components/layout/AppShell";
-import { TodayReport } from "@/components/report/TodayReport";
-import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
-import { MonthlyCalendar } from "@/components/calendar/MonthlyCalendar";
+import type { ExpenseResponse } from "@/lib/api/types";
+import { CalendarView } from "@/components/calendar/CalendarView";
 
 export const metadata: Metadata = {
   title: "カレンダー | 家計管理",
 };
 
 async function CalendarContent({ userId }: { userId: string }) {
-  let expenses;
+  let expenses: ExpenseResponse[];
   try {
     const data = await getExpenses();
     expenses = data.expense ?? [];
@@ -25,20 +24,7 @@ async function CalendarContent({ userId }: { userId: string }) {
     throw err;
   }
 
-  return (
-    <main className="mx-auto w-full max-w-6xl flex-1 px-4 py-6 bg-[#fffdf5]">
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-[2fr_3fr]">
-        {/* 左カラム：今日のレポート + 入力フォーム */}
-        <div className="flex flex-col gap-4">
-          <TodayReport expenses={expenses} />
-          <ExpenseCreateForm userId={userId} />
-        </div>
-
-        {/* 右カラム：月次カレンダー */}
-        <MonthlyCalendar expenses={expenses} />
-      </div>
-    </main>
-  );
+  return <CalendarView expenses={expenses} userId={userId} />;
 }
 
 export default async function CalendarPage() {

--- a/apps/web/src/components/calendar/CalendarView.tsx
+++ b/apps/web/src/components/calendar/CalendarView.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { FileText, PenLine } from "lucide-react";
+import { MonthlyCalendar } from "@/components/calendar/MonthlyCalendar";
+import type { ExpenseResponse } from "@/lib/api/types";
+import { getCategoryById } from "@/lib/constants/categories";
+
+type Props = {
+  expenses: ExpenseResponse[];
+  userId: string;
+};
+
+export function CalendarView({ expenses }: Props) {
+  const todayStr = new Date().toISOString().split("T")[0];
+  const [selectedDate, setSelectedDate] = useState<string>(todayStr);
+
+  const selectedExpenses = expenses.filter((e) => e.date === selectedDate);
+  const outgo = selectedExpenses
+    .filter((e) => e.balanceType === 0)
+    .reduce((s, e) => s + e.amount, 0);
+  const income = selectedExpenses
+    .filter((e) => e.balanceType === 1)
+    .reduce((s, e) => s + e.amount, 0);
+
+  const selectedLabel = new Date(selectedDate + "T00:00:00").toLocaleDateString(
+    "ja-JP",
+    { month: "long", day: "numeric", weekday: "short" },
+  );
+
+  return (
+    <main className="mx-auto w-full max-w-lg flex-1 px-3 py-3 bg-[#fffdf5]">
+      {/* ページヘッダー */}
+      <div className="flex items-center justify-between mb-3">
+        <h1 className="text-sm font-extrabold text-[#1c1410]">カレンダー</h1>
+        <Link
+          href={`/expenses/new?date=${selectedDate}`}
+          className="flex items-center gap-1.5 rounded-full border-2 border-[#1c1410] bg-[#f18840] px-3 py-1.5 text-xs font-bold text-white transition-opacity active:opacity-70"
+        >
+          <PenLine size={12} />
+          詳細記録
+        </Link>
+      </div>
+
+      {/* カレンダー（コンパクトモード） */}
+      <MonthlyCalendar
+        expenses={expenses}
+        compactMode
+        onDaySelect={setSelectedDate}
+        selectedDate={selectedDate}
+      />
+
+      {/* 選択日の収支サマリー */}
+      <div className="mt-3 rounded-2xl border-2 border-[#1c1410] bg-white overflow-hidden" style={{ boxShadow: "var(--shadow-pop-sm)" }}>
+        <div className="px-4 py-2.5 border-b border-[#e8c8b0]">
+          <p className="text-sm font-extrabold text-[#1c1410]">{selectedLabel}</p>
+        </div>
+        <div className="flex divide-x divide-[#e8c8b0]">
+          <div className="flex-1 px-4 py-3 text-center">
+            <p className="text-xs text-[#1c1410]/50 mb-0.5">支出</p>
+            <p
+              className="text-lg font-extrabold tabular-nums"
+              style={{ color: outgo > 0 ? "var(--color-expense)" : "#1c1410" }}
+            >
+              {outgo > 0 ? `¥${outgo.toLocaleString()}` : "—"}
+            </p>
+          </div>
+          <div className="flex-1 px-4 py-3 text-center">
+            <p className="text-xs text-[#1c1410]/50 mb-0.5">収入</p>
+            <p
+              className="text-lg font-extrabold tabular-nums"
+              style={{ color: income > 0 ? "var(--color-income)" : "#1c1410" }}
+            >
+              {income > 0 ? `¥${income.toLocaleString()}` : "—"}
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* 選択日の明細リスト */}
+      <div className="mt-3">
+        <p className="text-xs font-bold text-[#1c1410]/40 px-1 mb-2">明細</p>
+        {selectedExpenses.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-10 text-[#1c1410]/30">
+            <FileText size={32} className="mb-2 opacity-40" />
+            <p className="text-sm">この日の記録はありません</p>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-2 pb-4">
+            {selectedExpenses.map((e) => {
+              const cat = getCategoryById(
+                e.balanceType as 0 | 1,
+                e.categoryId,
+              );
+              return (
+                <div
+                  key={e.id}
+                  className="flex items-center gap-3 rounded-xl border border-[#e8c8b0] bg-white px-4 py-3"
+                >
+                  <div className="flex-1 min-w-0">
+                    <p className="text-xs text-[#1c1410]/50">
+                      {cat?.name ?? "未分類"}
+                    </p>
+                    <p className="text-sm font-semibold text-[#1c1410] truncate">
+                      {e.content ?? "—"}
+                    </p>
+                  </div>
+                  <p
+                    className="text-sm font-extrabold tabular-nums shrink-0"
+                    style={{
+                      color:
+                        e.balanceType === 0
+                          ? "var(--color-expense)"
+                          : "var(--color-income)",
+                    }}
+                  >
+                    {e.balanceType === 0 ? "-" : "+"}¥
+                    {e.amount.toLocaleString()}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/components/calendar/MonthlyCalendar.tsx
+++ b/apps/web/src/components/calendar/MonthlyCalendar.tsx
@@ -7,6 +7,12 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 
 type Props = {
   expenses: ExpenseResponse[];
+  /** trueのとき金額数値を非表示にしてドットのみ表示する（モバイル向け） */
+  compactMode?: boolean;
+  /** 指定するとページ遷移の代わりにコールバックが呼ばれる */
+  onDaySelect?: (dateStr: string) => void;
+  /** 選択中の日付（onDaySelect と組み合わせて使う） */
+  selectedDate?: string | null;
 };
 
 type DayData = {
@@ -79,7 +85,7 @@ function buildCalendarDays(year: number, month: number, expenses: ExpenseRespons
   return days;
 }
 
-export function MonthlyCalendar({ expenses }: Props) {
+export function MonthlyCalendar({ expenses, compactMode = false, onDaySelect, selectedDate }: Props) {
   const now = new Date();
   const [year, setYear] = useState(now.getFullYear());
   const [month, setMonth] = useState(now.getMonth());
@@ -107,7 +113,11 @@ export function MonthlyCalendar({ expenses }: Props) {
 
   const handleDayClick = (day: DayData) => {
     if (!day.isCurrentMonth) return;
-    router.push(`/expenses/new?date=${day.dateStr}`);
+    if (onDaySelect) {
+      onDaySelect(day.dateStr);
+    } else {
+      router.push(`/expenses/new?date=${day.dateStr}`);
+    }
   };
 
   return (
@@ -154,60 +164,92 @@ export function MonthlyCalendar({ expenses }: Props) {
       </div>
 
       {/* 日付グリッド */}
-      <div className="grid flex-1 grid-cols-7 grid-rows-6">
-        {days.map((day, idx) => (
-          <button
-            key={day.dateStr + (day.isCurrentMonth ? "" : `-pad${idx}`)}
-            type="button"
-            onClick={() => handleDayClick(day)}
-            disabled={!day.isCurrentMonth}
-            className={[
-              "relative flex flex-col items-start border-b border-r border-[#e8c8b0] p-1 text-left text-xs transition-colors",
-              day.isCurrentMonth
-                ? "hover:bg-[#fff6ee] cursor-pointer"
-                : "cursor-default",
-              day.isToday ? "bg-[#fff5ec]" : "",
-            ].join(" ")}
-          >
-            {/* 日付数字 */}
-            <span
+      <div className={["grid flex-1 grid-cols-7", compactMode ? "grid-rows-6" : "grid-rows-6"].join(" ")}>
+        {days.map((day, idx) => {
+          const isSelected = selectedDate != null && day.dateStr === selectedDate;
+          return (
+            <button
+              key={day.dateStr + (day.isCurrentMonth ? "" : `-pad${idx}`)}
+              type="button"
+              onClick={() => handleDayClick(day)}
+              disabled={!day.isCurrentMonth}
               className={[
-                "mb-0.5 text-xs font-bold",
-                !day.isCurrentMonth
-                  ? "text-[#1c1410]/20"
-                  : day.isToday
-                  ? "rounded-full bg-[#f18840] px-1 text-white"
-                  : "text-[#1c1410]",
+                "relative flex flex-col items-center justify-center border-b border-r border-[#e8c8b0] transition-colors",
+                compactMode ? "py-1" : "items-start p-1 text-left",
+                day.isCurrentMonth
+                  ? "hover:bg-[#fff6ee] cursor-pointer"
+                  : "cursor-default",
+                isSelected ? "bg-[#fff1e5]" : "",
               ].join(" ")}
+              style={compactMode ? { height: 44 } : {}}
             >
-              {day.date.getDate()}
-            </span>
-
-            {/* 支出 */}
-            {day.outgo > 0 && (
-              <div className="flex items-center gap-0.5">
-                <span className="h-1.5 w-1.5 rounded-full bg-[#f18840]" />
-                <span className="text-[9px] font-bold text-[#1c1410]/60">
-                  {day.outgo >= 1000
-                    ? `${Math.floor(day.outgo / 1000)}k`
-                    : day.outgo}
-                </span>
-              </div>
-            )}
-
-            {/* 収入 */}
-            {day.income > 0 && (
-              <div className="flex items-center gap-0.5">
-                <span className="h-1.5 w-1.5 rounded-full bg-[#35b5a2]" />
-                <span className="text-[9px] font-bold text-[#1c1410]/60">
-                  {day.income >= 1000
-                    ? `${Math.floor(day.income / 1000)}k`
-                    : day.income}
-                </span>
-              </div>
-            )}
-          </button>
-        ))}
+              {compactMode ? (
+                <>
+                  {/* コンパクト: 日付数字を丸で強調 */}
+                  <span
+                    className={[
+                      "flex h-7 w-7 items-center justify-center rounded-full text-xs font-bold leading-none transition-colors",
+                      !day.isCurrentMonth
+                        ? "text-[#1c1410]/20"
+                        : isSelected
+                        ? "bg-[#f18840] text-white"
+                        : day.isToday
+                        ? "border-2 border-[#f18840] text-[#f18840]"
+                        : "text-[#1c1410]",
+                    ].join(" ")}
+                  >
+                    {day.date.getDate()}
+                  </span>
+                  {/* ドットのみ */}
+                  <div className="flex items-center gap-0.5 mt-0.5">
+                    {day.outgo > 0 && (
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#f18840]" />
+                    )}
+                    {day.income > 0 && (
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#35b5a2]" />
+                    )}
+                  </div>
+                </>
+              ) : (
+                <>
+                  {/* 通常: 日付数字 + 金額表示 */}
+                  <span
+                    className={[
+                      "mb-0.5 text-xs font-bold",
+                      !day.isCurrentMonth
+                        ? "text-[#1c1410]/20"
+                        : day.isToday
+                        ? "rounded-full bg-[#f18840] px-1 text-white"
+                        : "text-[#1c1410]",
+                    ].join(" ")}
+                  >
+                    {day.date.getDate()}
+                  </span>
+                  {day.outgo > 0 && (
+                    <div className="flex items-center gap-0.5">
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#f18840]" />
+                      <span className="text-[9px] font-bold text-[#1c1410]/60">
+                        {day.outgo >= 1000
+                          ? `${Math.floor(day.outgo / 1000)}k`
+                          : day.outgo}
+                      </span>
+                    </div>
+                  )}
+                  {day.income > 0 && (
+                    <div className="flex items-center gap-0.5">
+                      <span className="h-1.5 w-1.5 rounded-full bg-[#35b5a2]" />
+                      <span className="text-[9px] font-bold text-[#1c1410]/60">
+                        {day.income >= 1000
+                          ? `${Math.floor(day.income / 1000)}k`
+                          : day.income}
+                      </span>
+                    </div>
+                  )}
+                </>
+              )}
+            </button>
+          );
+        })}
       </div>
     </section>
   );

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import { useActionState, useState } from "react";
+import { Drawer } from "vaul";
+import { createExpenseAction } from "@/lib/actions/expense";
+import type { ExpenseActionState } from "@/lib/actions/expense";
+import { getCategoriesByType } from "@/lib/constants/categories";
+
+type Props = {
+  userId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+const initialState: ExpenseActionState = { error: null, success: false };
+
+export function QuickEntryDrawer({ userId, open, onOpenChange }: Props) {
+  const [balanceType, setBalanceType] = useState<0 | 1>(0);
+  const [categoryId, setCategoryId] = useState<number>(1);
+  const [state, formAction, isPending] = useActionState(
+    createExpenseAction,
+    initialState,
+  );
+
+  const categories = getCategoriesByType(balanceType);
+  const accentColor =
+    balanceType === 0 ? "var(--color-expense)" : "var(--color-income)";
+  const today = new Date().toISOString().split("T")[0];
+
+  function handleTypeChange(type: 0 | 1) {
+    setBalanceType(type);
+    // カテゴリをリセット（支出:1=食費, 収入:1=給料）
+    setCategoryId(1);
+  }
+
+  return (
+    <Drawer.Root open={open} onOpenChange={onOpenChange}>
+      <Drawer.Portal>
+        <Drawer.Overlay className="fixed inset-0 z-40 bg-[#1c1410]/40" />
+        <Drawer.Content
+          className="fixed bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-3xl bg-white outline-none"
+          style={{ boxShadow: "0 -4px 32px rgba(28,20,16,0.16)" }}
+          aria-describedby={undefined}
+        >
+          {/* ドラッグハンドル */}
+          <div className="mx-auto mt-3 mb-1 h-1.5 w-12 rounded-full bg-[#1c1410]/20" />
+
+          <Drawer.Title className="px-5 pt-2 pb-1 text-sm font-extrabold text-[#1c1410]">
+            クイック記録
+          </Drawer.Title>
+
+          <form action={formAction} className="px-5 pb-8 pt-2 flex flex-col gap-4">
+            <input type="hidden" name="userId" value={userId} />
+            <input type="hidden" name="balanceType" value={balanceType} />
+            <input type="hidden" name="date" value={today} />
+            <input type="hidden" name="categoryId" value={categoryId} />
+
+            {/* 種別タブ */}
+            <div className="flex rounded-xl border border-[#1c1410]/12 bg-[#f5f0eb] p-1">
+              {([0, 1] as const).map((t) => (
+                <button
+                  key={t}
+                  type="button"
+                  onClick={() => handleTypeChange(t)}
+                  className="flex-1 rounded-lg py-2 text-sm font-bold transition-all"
+                  style={
+                    balanceType === t
+                      ? {
+                          background:
+                            t === 0
+                              ? "var(--color-expense)"
+                              : "var(--color-income)",
+                          color: "#fff",
+                        }
+                      : { color: "rgba(28,20,16,0.4)" }
+                  }
+                >
+                  {t === 0 ? "支出" : "収入"}
+                </button>
+              ))}
+            </div>
+
+            {/* 金額 */}
+            <div className="rounded-xl border border-[#1c1410]/12 bg-[#fafaf8] px-4 py-3">
+              <div className="flex items-baseline gap-1">
+                <span
+                  className="text-xl font-extrabold"
+                  style={{ color: accentColor }}
+                >
+                  ¥
+                </span>
+                <input
+                  name="amount"
+                  type="number"
+                  inputMode="numeric"
+                  placeholder="0"
+                  min={1}
+                  required
+                  className="flex-1 bg-transparent text-3xl font-extrabold tabular-nums outline-none placeholder:text-[#1c1410]/20"
+                  style={{ color: accentColor }}
+                  autoFocus
+                />
+              </div>
+              {state.fieldErrors?.amount && (
+                <p className="mt-1 text-xs font-medium text-[#f87171]">
+                  {state.fieldErrors.amount[0]}
+                </p>
+              )}
+            </div>
+
+            {/* カテゴリ（横スクロール） */}
+            <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
+              {categories.map((c) => (
+                <button
+                  key={c.id}
+                  type="button"
+                  onClick={() => setCategoryId(c.id)}
+                  className="shrink-0 rounded-full border px-3 py-1.5 text-xs font-bold transition-all"
+                  style={
+                    categoryId === c.id
+                      ? {
+                          background: accentColor,
+                          borderColor: accentColor,
+                          color: "#fff",
+                        }
+                      : {
+                          background: "#fff",
+                          borderColor: "rgba(28,20,16,0.12)",
+                          color: "rgba(28,20,16,0.6)",
+                        }
+                  }
+                >
+                  {c.name}
+                </button>
+              ))}
+            </div>
+
+            {state.error && (
+              <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
+                {state.error}
+              </p>
+            )}
+
+            {state.success && (
+              <p className="rounded-xl border border-[#4caf82]/40 bg-[#f0fdf6] px-3 py-2 text-sm font-bold text-[#4caf82]">
+                登録しました
+              </p>
+            )}
+
+            {/* 送信ボタン */}
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
+              style={{ background: "var(--color-brand-primary)" }}
+            >
+              {isPending ? "登録中..." : "記録する"}
+            </button>
+          </form>
+        </Drawer.Content>
+      </Drawer.Portal>
+    </Drawer.Root>
+  );
+}

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -21,7 +21,7 @@ export function AppShell({ userName, children }: Props) {
       <div className="flex flex-1 flex-col min-w-0">
         {/* モバイルのボトムナビ分の余白 */}
         <div className="flex-1 pb-16 md:pb-0">{children}</div>
-        <BottomNav />
+        <BottomNav userId={userName} />
       </div>
     </div>
   );

--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -4,14 +4,17 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Plus, X } from "lucide-react";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { NAV_ITEMS } from "./navItems";
 import type { NavItem } from "./navItems";
+import { QuickEntryDrawer } from "@/components/expense/QuickEntryDrawer";
 
-export function BottomNav() {
+type Props = {
+  userId?: string;
+};
+
+export function BottomNav({ userId }: Props) {
   const pathname = usePathname();
-  const router = useRouter();
-  const [fabOpen, setFabOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const isActive = (href: string) =>
     href === "/" ? pathname === "/" : pathname.startsWith(href);
@@ -20,43 +23,13 @@ export function BottomNav() {
   const leftItems = NAV_ITEMS.slice(0, 2);
   const rightItems = NAV_ITEMS.slice(2);
 
-  function handleFabSelect(type: "expense" | "income") {
-    setFabOpen(false);
-    router.push(`/expenses/new?type=${type}`);
-  }
-
   return (
     <>
-      {/* FAB展開時のオーバーレイ */}
-      {fabOpen && (
-        <div
-          className="fixed inset-0 z-30 bg-[#1c1410]/50"
-          onClick={() => setFabOpen(false)}
-        >
-          {/* 選択メニュー */}
-          <div
-            className="absolute bottom-24 left-1/2 flex -translate-x-1/2 flex-col items-center gap-3"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <button
-              type="button"
-              onClick={() => handleFabSelect("income")}
-              className="rounded-2xl px-8 py-3 text-sm font-bold text-white shadow-lg transition-transform active:scale-95"
-              style={{ background: "var(--color-income, #4caf82)" }}
-            >
-              収入を記録
-            </button>
-            <button
-              type="button"
-              onClick={() => handleFabSelect("expense")}
-              className="rounded-2xl px-8 py-3 text-sm font-bold text-white shadow-lg transition-transform active:scale-95"
-              style={{ background: "var(--color-expense, #e05c5c)" }}
-            >
-              支出を記録
-            </button>
-          </div>
-        </div>
-      )}
+      <QuickEntryDrawer
+        userId={userId ?? ""}
+        open={drawerOpen}
+        onOpenChange={setDrawerOpen}
+      />
 
       {/* ボトムナビゲーションバー（モバイルのみ表示） */}
       <nav
@@ -77,16 +50,16 @@ export function BottomNav() {
         <div className="flex flex-1 items-center justify-center">
           <button
             type="button"
-            aria-label={fabOpen ? "メニューを閉じる" : "記録する"}
-            aria-expanded={fabOpen}
-            onClick={() => setFabOpen(!fabOpen)}
+            aria-label={drawerOpen ? "メニューを閉じる" : "クイック記録"}
+            aria-expanded={drawerOpen}
+            onClick={() => setDrawerOpen(!drawerOpen)}
             className="relative -top-3 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
             style={{
               background: "var(--color-brand-primary, #f08030)",
               boxShadow: "0 4px 16px rgba(240,128,48,0.4)",
             }}
           >
-            {fabOpen ? (
+            {drawerOpen ? (
               <X size={22} className="text-white" />
             ) : (
               <Plus size={22} className="text-white" />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       react-router-dom:
         specifier: ^7.15.0
         version: 7.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -183,6 +186,9 @@ importers:
       react-dom:
         specifier: 19.2.4
         version: 19.2.4(react@19.2.4)
+      vaul:
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       zxcvbn:
         specifier: ^4.4.2
         version: 4.4.2
@@ -1499,6 +1505,177 @@ packages:
   '@prisma/prisma-schema-wasm@4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584':
     resolution: {integrity: sha512-JFdsnSgBPN8reDTLOI9Vh/6ccCb2aD1LbY/LWQnkcIgNo6IdpzvuM+qRVbBuA6IZP2SdqQI8Lu6RL2P8EFBQUA==}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@redocly/ajv@8.11.2':
     resolution: {integrity: sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg==}
 
@@ -2475,6 +2652,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.0:
     resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
@@ -3023,6 +3204,9 @@ packages:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   dir-glob@3.0.1:
     resolution: {integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==}
     engines: {node: '>=8'}
@@ -3521,6 +3705,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
@@ -4964,6 +5152,26 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-router-dom@7.15.0:
     resolution: {integrity: sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==}
     engines: {node: '>=20.0.0'}
@@ -4979,6 +5187,16 @@ packages:
       react-dom: '>=18'
     peerDependenciesMeta:
       react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
         optional: true
 
   react@19.2.4:
@@ -5643,6 +5861,26 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -5665,6 +5903,12 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vaul@1.1.2:
+    resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
+    peerDependencies:
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
 
   vite@8.0.3:
     resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
@@ -7568,6 +7812,149 @@ snapshots:
 
   '@prisma/prisma-schema-wasm@4.17.0-26.6b0aef69b7cdfc787f822ecd7cdc76d5f1991584': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   '@redocly/ajv@8.11.2':
     dependencies:
       fast-deep-equal: 3.1.3
@@ -8595,6 +8982,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -9183,6 +9574,8 @@ snapshots:
 
   detect-libc@2.1.2: {}
 
+  detect-node-es@1.1.0: {}
+
   dir-glob@3.0.1:
     dependencies:
       path-type: 4.0.0
@@ -9406,8 +9799,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.4
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -9429,7 +9822,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -9440,21 +9833,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9465,7 +9858,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9876,6 +10269,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -11267,6 +11662,25 @@ snapshots:
 
   react-is@17.0.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react-router-dom@7.15.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -11280,6 +11694,14 @@ snapshots:
       set-cookie-parser: 2.7.2
     optionalDependencies:
       react-dom: 19.2.4(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.4: {}
 
@@ -12107,6 +12529,21 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   util-deprecate@1.0.2: {}
 
   uuid@3.4.0: {}
@@ -12121,6 +12558,15 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vaul@1.1.2(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
 
   vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3):
     dependencies:


### PR DESCRIPTION
## 📋 概要

Issue #183・#184 の実装。スマホ版カレンダーページを刷新し、操作動線をボトムナビFABに統合した。

- カレンダーをコンパクトモード（ドット表示）に変更し、日付タップで収支サマリー＋明細をインライン表示
- 既存BottomNavの中央FABクリックでvaulドロワー形式のクイック入力を開くよう変更
- サンドボックスプロトタイプでスマホレビュー後に本番実装

Closes #183
Closes #184
Sprint: 6

## 🛠 変更内容

- `apps/web/src/components/expense/QuickEntryDrawer.tsx`（新規）: vaulドロワー形式のクイック入力コンポーネント。支出/収入タブ・金額入力・カテゴリ選択・createExpenseAction呼び出しを含む
- `apps/web/src/components/calendar/CalendarView.tsx`（新規）: カレンダーページのクライアントコンポーネント。selectedDate State管理・収支サマリー・明細リスト・詳細記録リンクを提供
- `apps/web/src/components/calendar/MonthlyCalendar.tsx`（更新）: `compactMode`・`onDaySelect`・`selectedDate` propsを追加。compactMode=trueでドット表示のみに切り替え、選択日はオレンジ塗りつぶし丸で強調
- `apps/web/src/components/layout/BottomNav.tsx`（更新）: FABクリック時にページ遷移ではなくQuickEntryDrawerを開くよう変更。`userId` propを追加
- `apps/web/src/components/layout/AppShell.tsx`（更新）: BottomNavに`userId`を渡すよう変更
- `apps/web/src/app/calendar/page.tsx`（更新）: ExpenseCreateForm・TodayReportを削除し、CalendarViewを使用するServer Component構成に変更
- `apps/sandbox/src/pages/CalendarPagePrototype.tsx`（新規）: スマホレビュー用プロトタイプ
- `apps/sandbox/src/main.tsx`・`Gallery.tsx`（更新）: プロトタイプルートを追加

テスト:
- `apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx`（新規）: 7テスト
- `apps/web/src/__tests__/components/CalendarView.test.tsx`（新規）: 6テスト

## 🔍 影響範囲

- カレンダーページ（`/calendar`）の全体UI刷新
- BottomNavのFAB動作変更（全ページ共通）: 以前はrouter.pushでフォーム遷移→現在はドロワー表示
- MonthlyCalendarをcompactMode=falseで使用している他の画面への影響なし（デフォルト値を維持）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- UI変更を含むため、マージ前にレビュー担当者がローカルで確認の上チェックを入れてください -->

## 📸 スクリーンショット

> UI/UX の変更を含むため、マージ前にレビュー担当者が実際の画面を確認してください。
> ローカルで `pnpm --filter web dev` を起動し、変更箇所を確認することを推奨します。
>
> サンドボックスプロトタイプ（`/calendar-page`）でスマホレビュー済み。

| | Before | After |
|---|---|---|
| SP（375px）カレンダー | カレンダー＋フォーム＋今日の収支サマリー縦並び | カレンダー（ドット表示）＋日付タップで明細インライン表示 |
| SP（375px）クイック入力 | FABタップ → /expenses/new にページ遷移 | FABタップ → vaulドロワーでインライン入力 |

## 🧪 テスト内容

- QuickEntryDrawer: open/close・初期状態・収入タブ切り替え・記録ボタン・エラー/成功メッセージ表示（7件）
- CalendarView: カレンダーヘッダー・収支サマリー・明細表示・空日メッセージ・詳細記録リンクhref・初期表示（6件）
- 全体: 154テストパス（既存テスト含む）
- 型チェック・lint: クリーン

## ⚠️ 備考

vaulライブラリを新規インストール済み（`pnpm add vaul --filter web`）。