### PR TITLE
chore: Sprint #6 Retroをバックフィル作成し #184 のCTを補記する

### DIFF
--- a/.github/velocity-log.json
+++ b/.github/velocity-log.json
@@ -339,7 +339,7 @@
           "pbi_type": "feature",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.7,
           "pr": 185
         }
       ]


### PR DESCRIPTION
## 概要

Sprint #7 クロージング時に Sprint #6 の Retroが未作成だったことが判明したため、バックフィルとして作成。
合わせて velocity-log.json の #184（クイック入力ドロワー）の CT が null だったのを 0.7h（PR #185 と同値）に補記する。

## 変更内容

- `.github/velocity-log.json`: Sprint #6 #184 の `cycle_time_hours: null` → `0.7` に補記
- GitHub Issue #205「Retro: Sprint #6」を作成し、プロジェクトボードに登録（Sprint #=6, Status=Done）
- #183/#184 に Retro リンクのコメントを投稿済み

## チェックリスト

- [x] velocity-log.json の変更のみ（コードへの影響なし）
- [x] lint / type-check / unit-test / integration-test: all passed

Closes #202
Sprint: 8