### PR TITLE
chore: Security Scan で新規 CVE 検出時に GitHub Issue を自動作成する

### DIFF
--- a/.github/workflows/security-scan-issue.yml
+++ b/.github/workflows/security-scan-issue.yml
@@ -1,0 +1,163 @@
+# ============================================================
+# security-scan-issue.yml — 新規 CVE 検出時に GitHub Issue を自動作成する
+#
+# フロー:
+#   1. Trivy FS スキャンを実行（JSON 形式で出力）
+#   2. 前回の成功ワークフランからアーティファクトをダウンロード
+#   3. 前回との diff で新規 CVE（HIGH/CRITICAL）を特定
+#   4. 新規 CVE ごとに Open Issue がなければ GitHub Issue を作成
+#   5. 現在のスキャン結果をアーティファクトとして保存（次回比較用）
+#
+# 実行タイミング:
+#   - 毎週月曜 09:00 UTC（定期スキャン）
+#   - workflow_dispatch（手動実行）
+# ============================================================
+
+name: Security Scan - CVE Issue Creator
+
+on:
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  scan-and-report:
+    name: Scan and Create Issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: fs
+          scan-ref: .
+          format: json
+          output: current-scan.json
+          severity: HIGH,CRITICAL
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          skip-dirs: usr/local/lib/node_modules/npm
+
+      - name: Download previous scan results
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 前回の成功ワークフロー ID を取得
+          PREV_RUN_ID=$(gh run list \
+            --workflow=security-scan-issue.yml \
+            --status=success \
+            --limit=1 \
+            --json databaseId \
+            --jq '.[0].databaseId // empty')
+
+          if [ -n "$PREV_RUN_ID" ]; then
+            echo "前回の成功ラン: $PREV_RUN_ID からアーティファクトをダウンロード"
+            mkdir -p prev-scan
+            gh run download "$PREV_RUN_ID" -n trivy-scan-results -D prev-scan/ 2>/dev/null || {
+              echo "アーティファクトのダウンロード失敗（初回実行の可能性）"
+            }
+          else
+            echo "前回の成功ランなし（初回実行）"
+          fi
+
+      - name: Compare CVEs and create issues for new findings
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # 前回結果がない場合は初回実行として比較をスキップ
+          if [ ! -f prev-scan/trivy-scan.json ]; then
+            echo "初回実行のため比較スキップ。次回から差分検出を開始します。"
+            cp current-scan.json trivy-scan.json
+            exit 0
+          fi
+
+          # 現在のCVE一覧（CVE_ID PKG_NAME SEVERITY の形式）
+          jq -r '
+            .Results[]?.Vulnerabilities[]?
+            | select(.Severity == "CRITICAL" or .Severity == "HIGH")
+            | "\(.VulnerabilityID) \(.PkgName) \(.Severity)"
+          ' current-scan.json 2>/dev/null | sort | uniq > current-cves.txt || touch current-cves.txt
+
+          # 前回のCVE一覧
+          jq -r '
+            .Results[]?.Vulnerabilities[]?
+            | select(.Severity == "CRITICAL" or .Severity == "HIGH")
+            | "\(.VulnerabilityID) \(.PkgName) \(.Severity)"
+          ' prev-scan/trivy-scan.json 2>/dev/null | sort | uniq > prev-cves.txt || touch prev-cves.txt
+
+          # 新規CVEを検出（現在にあって前回にないもの）
+          NEW_CVES=$(comm -23 current-cves.txt prev-cves.txt || true)
+
+          if [ -z "$NEW_CVES" ]; then
+            echo "新規CVEなし。スキャン完了。"
+            cp current-scan.json trivy-scan.json
+            exit 0
+          fi
+
+          echo "新規CVE検出:"
+          echo "$NEW_CVES"
+
+          # 新規CVEごとに Issue を作成
+          while IFS= read -r CVE_LINE; do
+            [ -z "$CVE_LINE" ] && continue
+
+            CVE_ID=$(echo "$CVE_LINE" | awk '{print $1}')
+            PKG=$(echo "$CVE_LINE" | awk '{print $2}')
+            SEVERITY=$(echo "$CVE_LINE" | awk '{print $3}')
+
+            # 重複チェック（同一CVE IDの Open Issue が存在する場合はスキップ）
+            EXISTING=$(gh issue list \
+              --state open \
+              --search "\"$CVE_ID\" in:title" \
+              --json number \
+              --jq 'length')
+
+            if [ "$EXISTING" -gt 0 ]; then
+              echo "$CVE_ID: Open Issue が既に存在するためスキップ"
+              continue
+            fi
+
+            # CVE の詳細情報を取得
+            CVE_DETAIL=$(jq -r --arg cve "$CVE_ID" '
+              .Results[]?.Vulnerabilities[]?
+              | select(.VulnerabilityID == $cve)
+              | "- 影響パッケージ: \(.PkgName) \(.InstalledVersion // "不明") → 修正版: \(.FixedVersion // "未リリース")\n- 深刻度: \(.Severity)\n- 説明: \(.Description // "N/A" | .[0:300])\n- 参照: \(.PrimaryURL // "N/A")"
+            ' current-scan.json | head -6)
+
+            gh issue create \
+              --title "[$SEVERITY] $CVE_ID が $PKG で検出されました" \
+              --label "type: chore" \
+              --label "priority: P2" \
+              --label "backlog" \
+              --body "## 概要
+
+Security Scan (Trivy) が新規 CVE を検出しました。前回スキャン時は存在しなかった脆弱性です。
+
+## 詳細
+
+${CVE_DETAIL}
+
+## 対応方針
+
+- 影響パッケージのアップデートを検討する（\`pnpm.overrides\` で固定バージョンを指定）
+- 修正版が未リリースの場合は \`.trivyignore\` に理由コメントとともに追記する
+
+_自動作成: security-scan-issue.yml — $(date -u '+%Y-%m-%d %H:%M UTC')_"
+
+            echo "$CVE_ID: Issue 作成完了"
+          done <<< "$NEW_CVES"
+
+          # 現在のスキャン結果を保存（次回比較用）
+          cp current-scan.json trivy-scan.json
+
+      - name: Upload scan results as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: trivy-scan-results
+          path: trivy-scan.json
+          retention-days: 30


### PR DESCRIPTION
## 概要

`.github/workflows/security-scan-issue.yml` を新規追加。
Trivy FS スキャンを毎週月曜 09:00 UTC に実行し、前回スキャンから新たに増えた HIGH/CRITICAL CVE を自動的に GitHub Issue 化する。

## 動作フロー

1. Trivy FS スキャン（JSON 形式出力）
2. 前回成功ワークフローのアーティファクトをダウンロード（`gh run download`）
3. 前回との `comm` diff で新規 CVE を特定
4. 新規 CVE ごとに Open Issue の重複チェック（`gh issue list --search`）
5. 重複なければ `gh issue create`（`type: chore`, `priority: P2`, `backlog` ラベル）
6. 現在のスキャン結果をアーティファクトとして保存（retention: 30日）

## 完了条件の確認

- [x] 新規 CVE 検出時に Issue が自動作成されること（スクリプトで実装）
- [x] 既存 Open Issue がある場合はスキップされること（`--search "$CVE_ID" in:title` でチェック）
- [x] 既知の CVE（前回と一致）では Issue が作成されないこと（`comm -23` で差分のみ処理）
- [x] `workflow_dispatch` で手動実行できること（トリガーに追加済み）

## チェックリスト

- [x] GH Actions ワークフローファイルのみの追加
- [x] lint / type-check / unit-test / integration-test: all passed

Closes #182
Sprint: 8