### PR TITLE
feat: ダッシュボードに「今日使えるお金」カードを追加する (#133)

### DIFF
--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -9,6 +9,7 @@ import { NavLayoutPrototype } from './pages/NavLayoutPrototype'
 import { AccountSectionPrototype } from './pages/AccountSectionPrototype'
 import { OnboardingPrototype } from './pages/OnboardingPrototype'
 import { CalendarPagePrototype } from './pages/CalendarPagePrototype'
+import { DailyBudgetCardPrototype } from './pages/DailyBudgetCardPrototype'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -21,6 +22,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/account-section" element={<AccountSectionPrototype />} />
         <Route path="/onboarding" element={<OnboardingPrototype />} />
         <Route path="/calendar-page" element={<CalendarPagePrototype />} />
+        <Route path="/daily-budget-card" element={<DailyBudgetCardPrototype />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/apps/sandbox/src/pages/DailyBudgetCardPrototype.tsx
+++ b/apps/sandbox/src/pages/DailyBudgetCardPrototype.tsx
@@ -1,0 +1,228 @@
+/**
+ * DailyBudgetCard プロトタイプ
+ *
+ * 「今日使えるお金」カードのピンチ度別 3 ステートを確認できる。
+ * Issue #133 の信号機カラー設計を検証するためのページ。
+ */
+
+type PinchLevel = "safe" | "caution" | "danger";
+
+type PinchStyle = {
+  bg: string;
+  border: string;
+  heroColor: string;
+  badgeBg: string;
+  badgeText: string;
+  label: string;
+};
+
+const PINCH_STYLES: Record<PinchLevel, PinchStyle> = {
+  safe: {
+    bg: "var(--color-safe-light, #eff6ff)",
+    border: "var(--color-safe, #3b82f6)",
+    heroColor: "var(--color-safe, #3b82f6)",
+    badgeBg: "var(--color-safe, #3b82f6)",
+    badgeText: "#ffffff",
+    label: "余裕",
+  },
+  caution: {
+    bg: "var(--color-caution-light, #fffbeb)",
+    border: "var(--color-caution, #f59e0b)",
+    heroColor: "var(--color-caution, #f59e0b)",
+    badgeBg: "var(--color-caution, #f59e0b)",
+    badgeText: "#1c1410",
+    label: "注意",
+  },
+  danger: {
+    bg: "var(--color-danger-light, #fef2f2)",
+    border: "var(--color-danger, #ef4444)",
+    heroColor: "var(--color-danger, #ef4444)",
+    badgeBg: "var(--color-danger, #ef4444)",
+    badgeText: "#ffffff",
+    label: "ピンチ",
+  },
+};
+
+function formatYen(amount: number): string {
+  return `¥${Math.abs(amount).toLocaleString("ja-JP")}`;
+}
+
+type CardProps = {
+  pinchLevel: PinchLevel;
+  dailyBudget: number;
+  todayExpense: number;
+  daysUntilPayday: number;
+};
+
+function DailyBudgetCardDemo({ pinchLevel, dailyBudget, todayExpense, daysUntilPayday }: CardProps) {
+  const style = PINCH_STYLES[pinchLevel];
+  const remaining = dailyBudget - todayExpense;
+  const isOverBudget = remaining < 0;
+
+  return (
+    <div
+      className="rounded-2xl border-2 p-5"
+      style={{
+        background: style.bg,
+        borderColor: style.border,
+        boxShadow: "0 1px 4px 0 rgba(28, 20, 16, 0.07)",
+      }}
+    >
+      {/* ヘッダー行 */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-bold text-[#1c1410]/60 uppercase tracking-wide">
+          今日使えるお金
+        </span>
+        <span
+          className="rounded-full px-2 py-0.5 text-xs font-bold"
+          style={{ background: style.badgeBg, color: style.badgeText }}
+        >
+          {style.label}
+        </span>
+      </div>
+
+      {/* ヒーローナンバー */}
+      <div className="mb-4">
+        <p
+          className="text-4xl font-extrabold leading-none"
+          style={{ color: isOverBudget ? "var(--color-danger, #ef4444)" : style.heroColor }}
+        >
+          {isOverBudget ? `-${formatYen(Math.abs(remaining))}` : formatYen(remaining)}
+        </p>
+        {isOverBudget && (
+          <p className="mt-1 text-xs font-medium text-[#1c1410]/60">
+            予算を{formatYen(Math.abs(remaining))}超過
+          </p>
+        )}
+      </div>
+
+      {/* 内訳行 */}
+      <div className="flex items-center gap-3 text-xs text-[#1c1410]/60">
+        <span>
+          1日予算{" "}
+          <span className="font-bold text-[#1c1410]/80">{formatYen(dailyBudget)}</span>
+        </span>
+        <span className="text-[#1c1410]/30">|</span>
+        <span>
+          本日支出{" "}
+          <span className="font-bold text-[#1c1410]/80">{formatYen(todayExpense)}</span>
+        </span>
+      </div>
+
+      {/* 給料日カウントダウン */}
+      <div
+        className="mt-3 pt-3 border-t flex items-center gap-1.5"
+        style={{ borderColor: `${style.border}40` }}
+      >
+        <span
+          className="inline-block h-1.5 w-1.5 rounded-full"
+          style={{ background: style.heroColor }}
+        />
+        <span className="text-xs text-[#1c1410]/60">
+          給料日まで{" "}
+          <span className="font-bold text-[#1c1410]/80">あと{daysUntilPayday}日</span>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function FallbackCard() {
+  return (
+    <div
+      className="rounded-2xl border-2 border-dashed p-5"
+      style={{ borderColor: "#e8c8b0", background: "#fffdf5" }}
+    >
+      <p className="text-sm font-medium text-[#1c1410]/50 text-center">
+        設定を完了すると「今日使えるお金」が表示されます
+      </p>
+    </div>
+  );
+}
+
+export function DailyBudgetCardPrototype() {
+  return (
+    <div className="min-h-screen p-6" style={{ background: "var(--color-surface-subtle, #fffdf5)" }}>
+      {/* ヘッダー */}
+      <div className="mb-6 max-w-sm">
+        <h1 className="text-xl font-extrabold text-[#1c1410]">DailyBudgetCard プロトタイプ</h1>
+        <p className="mt-1 text-xs text-[#1c1410]/50">Issue #133 — 信号機カラーによるピンチ度表現</p>
+      </div>
+
+      <div className="flex flex-col gap-8 max-w-sm">
+        {/* 余裕ステート */}
+        <section>
+          <p className="mb-2 text-xs font-bold text-[#1c1410]/50 uppercase tracking-wide">
+            Safe（余裕）— 残予算 ≥ 80%
+          </p>
+          <DailyBudgetCardDemo
+            pinchLevel="safe"
+            dailyBudget={3200}
+            todayExpense={300}
+            daysUntilPayday={12}
+          />
+        </section>
+
+        {/* 注意ステート */}
+        <section>
+          <p className="mb-2 text-xs font-bold text-[#1c1410]/50 uppercase tracking-wide">
+            Caution（注意）— 残予算 20〜80%
+          </p>
+          <DailyBudgetCardDemo
+            pinchLevel="caution"
+            dailyBudget={3200}
+            todayExpense={1800}
+            daysUntilPayday={12}
+          />
+        </section>
+
+        {/* ピンチステート */}
+        <section>
+          <p className="mb-2 text-xs font-bold text-[#1c1410]/50 uppercase tracking-wide">
+            Danger（ピンチ）— 残予算 &lt; 20%
+          </p>
+          <DailyBudgetCardDemo
+            pinchLevel="danger"
+            dailyBudget={3200}
+            todayExpense={3100}
+            daysUntilPayday={12}
+          />
+        </section>
+
+        {/* 予算超過ステート */}
+        <section>
+          <p className="mb-2 text-xs font-bold text-[#1c1410]/50 uppercase tracking-wide">
+            Danger（予算超過）— 支出 &gt; 1日予算
+          </p>
+          <DailyBudgetCardDemo
+            pinchLevel="danger"
+            dailyBudget={3200}
+            todayExpense={4500}
+            daysUntilPayday={12}
+          />
+        </section>
+
+        {/* 設定未完了フォールバック */}
+        <section>
+          <p className="mb-2 text-xs font-bold text-[#1c1410]/50 uppercase tracking-wide">
+            未設定フォールバック
+          </p>
+          <FallbackCard />
+        </section>
+
+        {/* 給料日当日ステート */}
+        <section>
+          <p className="mb-2 text-xs font-bold text-[#1c1410]/50 uppercase tracking-wide">
+            給料日当日（daysUntilPayday=1）
+          </p>
+          <DailyBudgetCardDemo
+            pinchLevel="safe"
+            dailyBudget={5000}
+            todayExpense={200}
+            daysUntilPayday={1}
+          />
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle, CalendarDays } from 'lucide-react'
+import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle, CalendarDays, Wallet } from 'lucide-react'
 
 type PrototypeCard = {
   path: string
@@ -57,6 +57,14 @@ const prototypes: PrototypeCard[] = [
     description: 'ドット表示・日付タップで明細表示・クイック入力ボトムシート。モバイルファーストレイアウト。',
     icon: CalendarDays,
     issue: '#183 #184',
+    status: 'ready',
+  },
+  {
+    path: '/daily-budget-card',
+    title: '今日使えるお金カード',
+    description: '給料日までの1日予算をヒーローナンバーで表示。信号機カラーによるピンチ度の視覚化。',
+    icon: Wallet,
+    issue: '#133',
     status: 'ready',
   },
 ]

--- a/apps/web/src/__tests__/components/DailyBudgetCard.test.tsx
+++ b/apps/web/src/__tests__/components/DailyBudgetCard.test.tsx
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { DailyBudgetCard } from '../../components/dashboard/DailyBudgetCard'
+import type { DailyBudgetResult } from '@budget/common'
+
+/** calcDailyBudget の結果ダミー（1日予算 ¥3,200 / 給料日まで12日） */
+const mockBudgetResult: DailyBudgetResult = {
+  dailyBudget: 3200,
+  daysUntilPayday: 12,
+  availableBalance: 38400,
+}
+
+describe('DailyBudgetCard', () => {
+  describe('設定未完了のとき（budgetResult=null）', () => {
+    it('フォールバックメッセージを表示する', () => {
+      render(<DailyBudgetCard todayExpense={0} budgetResult={null} />)
+      expect(screen.getByText('設定を完了すると「今日使えるお金」が表示されます')).toBeInTheDocument()
+    })
+  })
+
+  describe('余裕ステート（残予算 ≥ 80%）', () => {
+    it('支出が少ないとき「余裕」バッジを表示する', () => {
+      // 残予算 = 3200 - 200 = 3000 → ratio = 0.9375 ≥ 0.8
+      render(<DailyBudgetCard todayExpense={200} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('余裕')).toBeInTheDocument()
+    })
+
+    it('残予算をヒーローナンバーとして表示する', () => {
+      render(<DailyBudgetCard todayExpense={200} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('¥3,000')).toBeInTheDocument()
+    })
+
+    it('今日の支出と1日予算の内訳を表示する', () => {
+      render(<DailyBudgetCard todayExpense={200} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('¥3,200')).toBeInTheDocument()
+      expect(screen.getByText('¥200')).toBeInTheDocument()
+    })
+
+    it('給料日カウントダウンを表示する', () => {
+      render(<DailyBudgetCard todayExpense={200} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText(/あと12日/)).toBeInTheDocument()
+    })
+  })
+
+  describe('注意ステート（残予算 20〜80%）', () => {
+    it('残予算が50%のとき「注意」バッジを表示する', () => {
+      // 残予算 = 3200 - 1600 = 1600 → ratio = 0.5 → caution
+      render(<DailyBudgetCard todayExpense={1600} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('注意')).toBeInTheDocument()
+    })
+
+    it('残予算が境界値 20% ちょうどのとき「注意」バッジを表示する', () => {
+      // 残予算 = 3200 - 2560 = 640 → ratio = 0.2 → caution
+      render(<DailyBudgetCard todayExpense={2560} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('注意')).toBeInTheDocument()
+    })
+  })
+
+  describe('ピンチステート（残予算 < 20%）', () => {
+    it('残予算が 10% 未満のとき「ピンチ」バッジを表示する', () => {
+      // 残予算 = 3200 - 3100 = 100 → ratio ≈ 0.03 → danger
+      render(<DailyBudgetCard todayExpense={3100} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('ピンチ')).toBeInTheDocument()
+    })
+  })
+
+  describe('予算超過のとき', () => {
+    it('「ピンチ」バッジと超過額メッセージを表示する', () => {
+      // 残予算 = 3200 - 4500 = -1300 → over budget
+      render(<DailyBudgetCard todayExpense={4500} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('ピンチ')).toBeInTheDocument()
+      expect(screen.getByText(/予算を.*超過/)).toBeInTheDocument()
+    })
+
+    it('マイナス残予算を負号付きで表示する', () => {
+      render(<DailyBudgetCard todayExpense={4500} budgetResult={mockBudgetResult} />)
+      expect(screen.getByText('-¥1,300')).toBeInTheDocument()
+    })
+  })
+
+  describe('支出ゼロのとき', () => {
+    it('1日予算の全額がヒーローナンバーになる', () => {
+      render(<DailyBudgetCard todayExpense={0} budgetResult={mockBudgetResult} />)
+      // 残予算 = 3200 - 0 = 3200 → ratio = 1.0 → safe
+      // ¥3,200 はヒーローナンバーと内訳欄に2回登場するため getAllByText を使う
+      expect(screen.getAllByText('¥3,200').length).toBeGreaterThanOrEqual(1)
+      expect(screen.getByText('余裕')).toBeInTheDocument()
+    })
+  })
+
+  describe('給料日当日のとき（daysUntilPayday=1）', () => {
+    it('あと1日と表示する', () => {
+      const paydayResult: DailyBudgetResult = {
+        dailyBudget: 5000,
+        daysUntilPayday: 1,
+        availableBalance: 5000,
+      }
+      render(<DailyBudgetCard todayExpense={200} budgetResult={paydayResult} />)
+      expect(screen.getByText(/あと1日/)).toBeInTheDocument()
+    })
+  })
+
+  describe('1日予算が0円のとき', () => {
+    it('ピンチと判定される', () => {
+      const zeroBudgetResult: DailyBudgetResult = {
+        dailyBudget: 0,
+        daysUntilPayday: 5,
+        availableBalance: 0,
+      }
+      render(<DailyBudgetCard todayExpense={0} budgetResult={zeroBudgetResult} />)
+      expect(screen.getByText('ピンチ')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -47,6 +47,18 @@
   --background: #fffdf5;
   --foreground: #1c1410;
 
+  /* ピンチ度カラー（1日予算カード用）
+   *  safe    : 余裕あり（残予算 ≥ 80%）→ 青系
+   *  caution : 注意（残予算 20〜80%）→ 黄系
+   *  danger  : ピンチ / 予算超過（残予算 < 20% or マイナス）→ 赤系
+   */
+  --color-safe: #3b82f6;
+  --color-safe-light: #eff6ff;
+  --color-caution: #f59e0b;
+  --color-caution-light: #fffbeb;
+  --color-danger: #ef4444;
+  --color-danger-light: #fef2f2;
+
   /* ボーダー */
   --border-default: #e8c8b0;
   --border-strong: #1c1410;
@@ -96,6 +108,13 @@
     --color-playful-coral-light: #3a1010;
     --color-playful-amber: #fbbf24;
     --color-playful-amber-light: #3a2a00;
+
+    --color-safe: #60a5fa;
+    --color-safe-light: #1e2a3a;
+    --color-caution: #fbbf24;
+    --color-caution-light: #2a2000;
+    --color-danger: #f87171;
+    --color-danger-light: #2a1010;
   }
 }
 
@@ -121,6 +140,13 @@
   --color-playful-coral-light: var(--color-playful-coral-light);
   --color-playful-amber: var(--color-playful-amber);
   --color-playful-amber-light: var(--color-playful-amber-light);
+
+  --color-safe: var(--color-safe);
+  --color-safe-light: var(--color-safe-light);
+  --color-caution: var(--color-caution);
+  --color-caution-light: var(--color-caution-light);
+  --color-danger: var(--color-danger);
+  --color-danger-light: var(--color-danger-light);
 
   --font-sans: var(--font-outfit);
   --font-display: var(--font-outfit);

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import { calcDailyBudget } from "@budget/common";
 import { getExpenses } from "@/lib/api/expense";
 import { getSettings } from "@/lib/api/settings";
 import { ApiError } from "@/lib/api/client";
@@ -10,6 +11,7 @@ import { ExpenseCreateForm } from "@/components/expense/ExpenseCreateForm";
 import { XDayDisplay } from "@/components/dashboard/XDayDisplay";
 import { MonthlyOverviewCard } from "@/components/dashboard/MonthlyOverviewCard";
 import { RecentExpenseList } from "@/components/dashboard/RecentExpenseList";
+import { DailyBudgetCard } from "@/components/dashboard/DailyBudgetCard";
 
 export const metadata: Metadata = {
   title: "ホーム | 家計管理",
@@ -83,34 +85,55 @@ async function DashboardContent({ userId }: { userId: string }) {
 
   // 設定取得失敗はデフォルト値で続行（マイグレーション未適用等でもホーム画面を表示する）
   const settingsData = settingsResult.status === "fulfilled" ? settingsResult.value : null;
+  const isSettingsConfigured =
+    settingsData !== null &&
+    !(settingsData.totalAssets === 0 && settingsData.monthlyIncome === 0);
   const settings = {
-    totalAssets: settingsData && !(settingsData.totalAssets === 0 && settingsData.monthlyIncome === 0)
-      ? settingsData.totalAssets
-      : null,
+    totalAssets: isSettingsConfigured ? settingsData.totalAssets : null,
     monthlyIncome: settingsData?.monthlyIncome ?? 0,
+    paydayDay: settingsData?.paydayDay ?? 25,
+    fixedExpenses: settingsData?.fixedExpenses ?? 0,
   };
 
   const { todayExpense, yesterdayExpense, zeroStreakDays, avgDailyExpense, recordedDays, recordingStreak } =
     computeXDayInputs(expenses);
 
+  // 1日予算を算出（設定が揃っている場合のみ）
+  const dailyBudgetResult =
+    settings.totalAssets !== null
+      ? calcDailyBudget({
+          totalAssets: settings.totalAssets,
+          fixedExpenses: settings.fixedExpenses,
+          paydayDay: settings.paydayDay,
+          today: new Date(),
+        })
+      : null;
+
   return (
     <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-4 bg-[#fffdf5]">
       {/*
         Mobile (default): stacked single column
-          1. 今月の収支サマリー（現状把握）
-          2. クイック入力（スクロールなしで操作可能）
-          3. 家計の寿命（中心指標）
-          4. 最近の記録5件
+          1. 今日使えるお金（主要指標 → 行動変容の即時フィードバック）
+          2. 今月の収支サマリー（現状把握）
+          3. クイック入力（スクロールなしで操作可能）
+          4. 家計の寿命（補助指標 → 段階的廃止予定）
+          5. 最近の記録5件
 
         Desktop (lg): 2-column
-          Left: 今月の収支 + 家計の寿命
+          Left: 今日使えるお金 + 今月の収支 + 家計の寿命
           Right: クイック入力 + 最近の記録
       */}
+      {/* 今日使えるお金: 全幅で最上位に配置 */}
+      <div className="mb-4">
+        <DailyBudgetCard todayExpense={todayExpense} budgetResult={dailyBudgetResult} />
+      </div>
+
       <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:items-start">
-        {/* 左カラム（desktop）/ 先頭2カード（mobile） */}
+        {/* 左カラム（desktop）/ 先頭カード（mobile） */}
         <div className="flex flex-col gap-4">
           <MonthlyOverviewCard expenses={expenses} />
-          <div className="lg:block">
+          {/* 家計の寿命: 段階的廃止フェーズ1 — 表示は維持するが priority を下げる */}
+          <div className="lg:block opacity-80">
             <XDayDisplay
               todayExpense={todayExpense}
               yesterdayExpense={yesterdayExpense}
@@ -124,7 +147,7 @@ async function DashboardContent({ userId }: { userId: string }) {
           </div>
         </div>
 
-        {/* 右カラム（desktop）/ 後続2カード（mobile） */}
+        {/* 右カラム（desktop）/ 後続カード（mobile） */}
         <div className="flex flex-col gap-4">
           <ExpenseCreateForm userId={userId} />
           <RecentExpenseList expenses={expenses} />

--- a/apps/web/src/components/dashboard/DailyBudgetCard.tsx
+++ b/apps/web/src/components/dashboard/DailyBudgetCard.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import type { DailyBudgetResult } from "@budget/common";
+
+/** ピンチ度レベル */
+type PinchLevel = "safe" | "caution" | "danger";
+
+/**
+ * 残予算比率からピンチ度を判定する。
+ *
+ * remaining = dailyBudget - todayExpense
+ * ratio     = remaining / dailyBudget
+ *   >= 0.8  → safe    (残予算80%以上 = 余裕)
+ *   >= 0.2  → caution (残予算20〜80% = 注意)
+ *   < 0.2   → danger  (残予算20%未満 or 予算超過 = ピンチ)
+ */
+function calcPinchLevel(dailyBudget: number, todayExpense: number): PinchLevel {
+  if (dailyBudget <= 0) return "danger";
+  const remaining = dailyBudget - todayExpense;
+  const ratio = remaining / dailyBudget;
+  if (ratio >= 0.8) return "safe";
+  if (ratio >= 0.2) return "caution";
+  return "danger";
+}
+
+/** 金額を ¥X,XXX 形式にフォーマット */
+function formatYen(amount: number): string {
+  return `¥${Math.abs(amount).toLocaleString("ja-JP")}`;
+}
+
+type PinchStyle = {
+  bg: string;
+  border: string;
+  heroColor: string;
+  badgeBg: string;
+  badgeText: string;
+  label: string;
+};
+
+const PINCH_STYLES: Record<PinchLevel, PinchStyle> = {
+  safe: {
+    bg: "var(--color-safe-light)",
+    border: "var(--color-safe)",
+    heroColor: "var(--color-safe)",
+    badgeBg: "var(--color-safe)",
+    badgeText: "#ffffff",
+    label: "余裕",
+  },
+  caution: {
+    bg: "var(--color-caution-light)",
+    border: "var(--color-caution)",
+    heroColor: "var(--color-caution)",
+    badgeBg: "var(--color-caution)",
+    badgeText: "#1c1410",
+    label: "注意",
+  },
+  danger: {
+    bg: "var(--color-danger-light)",
+    border: "var(--color-danger)",
+    heroColor: "var(--color-danger)",
+    badgeBg: "var(--color-danger)",
+    badgeText: "#ffffff",
+    label: "ピンチ",
+  },
+};
+
+type Props = {
+  /** 今日の支出合計（円） */
+  todayExpense: number;
+  /**
+   * calcDailyBudget の結果。設定未完了の場合は null。
+   */
+  budgetResult: DailyBudgetResult | null;
+};
+
+/**
+ * 「今日使えるお金」をヒーローナンバーで表示するダッシュボードカード。
+ * ピンチ度に応じて信号機カラーで背景色が変わる。
+ */
+export function DailyBudgetCard({ todayExpense, budgetResult }: Props) {
+  // 設定未完了のフォールバック表示
+  if (!budgetResult) {
+    return (
+      <div
+        className="rounded-2xl border-2 border-dashed p-5"
+        style={{ borderColor: "var(--border-default)", background: "var(--color-surface-subtle)" }}
+      >
+        <p className="text-sm font-medium text-[#1c1410]/50 text-center">
+          設定を完了すると「今日使えるお金」が表示されます
+        </p>
+      </div>
+    );
+  }
+
+  const { dailyBudget, daysUntilPayday } = budgetResult;
+  const remaining = dailyBudget - todayExpense;
+  const isOverBudget = remaining < 0;
+  const pinchLevel = calcPinchLevel(dailyBudget, todayExpense);
+  const style = PINCH_STYLES[pinchLevel];
+
+  return (
+    <div
+      className="rounded-2xl border-2 p-5"
+      style={{
+        background: style.bg,
+        borderColor: style.border,
+        boxShadow: "var(--shadow-card)",
+      }}
+    >
+      {/* ヘッダー行 */}
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-bold text-[#1c1410]/60 uppercase tracking-wide">
+          今日使えるお金
+        </span>
+        <span
+          className="rounded-full px-2 py-0.5 text-xs font-bold"
+          style={{ background: style.badgeBg, color: style.badgeText }}
+        >
+          {style.label}
+        </span>
+      </div>
+
+      {/* ヒーローナンバー */}
+      <div className="mb-4">
+        <p
+          className="text-4xl font-extrabold leading-none"
+          style={{ color: isOverBudget ? "var(--color-danger)" : style.heroColor }}
+        >
+          {isOverBudget ? `-${formatYen(Math.abs(remaining))}` : formatYen(remaining)}
+        </p>
+        {isOverBudget && (
+          <p className="mt-1 text-xs font-medium text-[#1c1410]/60">
+            予算を{formatYen(Math.abs(remaining))}超過
+          </p>
+        )}
+      </div>
+
+      {/* 内訳行 */}
+      <div className="flex items-center gap-3 text-xs text-[#1c1410]/60">
+        <span>
+          1日予算{" "}
+          <span className="font-bold text-[#1c1410]/80">{formatYen(dailyBudget)}</span>
+        </span>
+        <span className="text-[#1c1410]/30">|</span>
+        <span>
+          本日支出{" "}
+          <span className="font-bold text-[#1c1410]/80">{formatYen(todayExpense)}</span>
+        </span>
+      </div>
+
+      {/* 給料日カウントダウン */}
+      <div
+        className="mt-3 pt-3 border-t flex items-center gap-1.5"
+        style={{ borderColor: `${style.border}40` }}
+      >
+        <span
+          className="inline-block h-1.5 w-1.5 rounded-full"
+          style={{ background: style.heroColor }}
+        />
+        <span className="text-xs text-[#1c1410]/60">
+          給料日まで{" "}
+          <span className="font-bold text-[#1c1410]/80">あと{daysUntilPayday}日</span>
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

Issue #133 の実装。ダッシュボードの主要指標を「家計の寿命（Xデー）」から「今日使えるお金」へ転換し、即時行動フィードバックを強化する。

給料日までの1日予算と今日の支出を比較し、信号機カラー（青/黄/赤）でピンチ度を視覚化することで、ユーザーが「今日どう行動すべきか」を直感的に把握できるようにした。

## 変更内容

### 新規コンポーネント
- `DailyBudgetCard.tsx`: 「今日使えるお金」をヒーローナンバーで表示するカード
  - 残予算 ≥ 80% → 青（余裕）
  - 残予算 20〜80% → 黄（注意）
  - 残予算 < 20% / 予算超過 → 赤（ピンチ）
  - 給料日カウントダウン（あとX日）を内蔵
  - 設定未完了時はフォールバック表示

### ページ更新
- `page.tsx`: DailyBudgetCard を全幅で最上位に配置
  - `calcDailyBudget`（UserSettings の paydayDay / fixedExpenses）と接続
  - XDayDisplay は段階的廃止フェーズ1として opacity-80 で de-emphasis

### デザイントークン追加
- `globals.css` 手動管理セクションにピンチ度カラーを追加
  - `--color-safe` / `--color-safe-light`
  - `--color-caution` / `--color-caution-light`
  - `--color-danger` / `--color-danger-light`
  - ダークモード対応済み・Tailwind @theme マッピング追加

### Sandbox プロトタイプ
- `/daily-budget-card` ページを追加（全5ステート確認可能）
  - 余裕 / 注意 / ピンチ / 予算超過 / 設定未完了フォールバック / 給料日当日

### テスト
- `DailyBudgetCard.test.tsx`: 13テストケースを追加
  - 余裕/注意/ピンチ各ステートのバッジ表示
  - 予算超過時の負号表示とメッセージ
  - 設定未完了フォールバック
  - 給料日当日（daysUntilPayday=1）
  - 1日予算0円のピンチ判定

## 影響範囲

- ホーム画面のレイアウト変更（DailyBudgetCard が最上位に追加）
- XDayDisplay は引き続き表示（段階的廃止フェーズ1: 次スプリント以降で完全削除予定）
- UserSettings の paydayDay / fixedExpenses フィールドを新たにフロントで利用
- BE に変更なし

## テスト内容

- Vitest + RTL: DailyBudgetCard の13ケースを新規追加（全167テスト通過）
- 統合テスト: 全34ケース通過（BE 変更なし）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか（ピンチ度閾値 0.8 / 0.2 はコード内コメントで意味を明記）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- Sandbox プロトタイプ（/daily-budget-card）で全ステートを確認可能。マージ前にローカルでご確認ください -->

Closes #133
Sprint: 9