### PR TITLE
chore: スプリント開始時に前スプリントの Retro Issue を自動クローズする Workflow を追加する

### DIFF
--- a/.github/workflows/close-prev-retro.yml
+++ b/.github/workflows/close-prev-retro.yml
@@ -1,0 +1,80 @@
+name: 前スプリントの Retro Issue を自動クローズする
+
+# スプリント開始時（velocity-log.json の next_sprint_number が更新されたとき）に起動する。
+# main ブランチへの push で velocity-log.json が変更された場合のみ実行する。
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/velocity-log.json
+
+jobs:
+  close-prev-retro:
+    name: 前スプリントの Retro Issue をクローズ
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+
+    steps:
+      - name: リポジトリをチェックアウト
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: next_sprint_number が増加したか確認
+        id: check
+        run: |
+          PREV=$(git show HEAD^:.github/velocity-log.json 2>/dev/null \
+            | python3 -c "import json,sys; d=json.load(sys.stdin); print(d['meta']['next_sprint_number'])" \
+            || echo "0")
+          CURR=$(python3 -c "import json; d=json.load(open('.github/velocity-log.json')); print(d['meta']['next_sprint_number'])")
+          echo "prev=$PREV, curr=$CURR"
+          if [ "$CURR" -gt "$PREV" ]; then
+            SPRINT_NUM=$((CURR - 1))
+            echo "sprint_started=true" >> "$GITHUB_OUTPUT"
+            echo "sprint_number=$SPRINT_NUM" >> "$GITHUB_OUTPUT"
+          else
+            echo "sprint_started=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 前スプリントの Retro Issue をクローズ
+        if: steps.check.outputs.sprint_started == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPRINT_NUMBER: ${{ steps.check.outputs.sprint_number }}
+        run: |
+          echo "Sprint #${SPRINT_NUMBER} の Retro Issue を検索してクローズします..."
+
+          # retro ラベルかつタイトルに Sprint #N を含む OPEN Issue を検索
+          ISSUES=$(gh issue list \
+            --repo "$GITHUB_REPOSITORY" \
+            --label "retro" \
+            --state open \
+            --json number,title \
+            --limit 50 \
+            | python3 -c "
+          import json, sys, os
+          sprint = os.environ['SPRINT_NUMBER']
+          issues = json.load(sys.stdin)
+          targets = [
+              i for i in issues
+              if f'Sprint #{sprint}' in i['title'] or f'Sprint #0{sprint}' in i['title']
+          ]
+          for t in targets:
+              print(t['number'])
+          ")
+
+          if [ -z "$ISSUES" ]; then
+            echo "クローズ対象の Retro Issue が見つかりませんでした（Sprint #${SPRINT_NUMBER}）"
+            exit 0
+          fi
+
+          for ISSUE_NUM in $ISSUES; do
+            echo "Closing #${ISSUE_NUM}..."
+            gh issue close "$ISSUE_NUM" \
+              --repo "$GITHUB_REPOSITORY" \
+              --comment "Sprint #${SPRINT_NUMBER} のレトロスペクティブは完了済みです。Sprint #$((SPRINT_NUMBER + 1)) 開始に伴い自動クローズしました。"
+          done
+          echo "完了: $(echo "$ISSUES" | wc -w) 件の Retro Issue をクローズしました。"


### PR DESCRIPTION
## 変更内容

`.github/workflows/close-prev-retro.yml` を新規追加。

## 動作

1. `main` ブランチへの push で `.github/velocity-log.json` が変更された場合に起動
2. `next_sprint_number` が前コミットより増加していれば「スプリント開始」と判定
3. `retro` ラベルかつタイトルに `Sprint #N`（前スプリント番号）を含む OPEN Issue を検索
4. 対象 Issue を自動クローズ（完了コメント付き）

## 背景

Sprint #1〜#8 の Retro Issue が OPEN のまま Backlog に積み上がっていた（今回 9件を手動クローズ）。次スプリント以降は自動クローズで防止する。

Closes #216
Sprint: 10