### PR TITLE
chore: GitHub Issue Forms で priority を必須選択フィールドにする

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,95 @@
+name: バグ報告
+description: 動作の不具合・予期しない挙動を報告する
+labels:
+  - "type: bug"
+  - "backlog"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグ報告ありがとうございます。以下の情報を入力してください。
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度
+      description: このバグの影響範囲・緊急度を選択してください
+      options:
+        - "P0 — 即日対応必須（本番障害・データ損失）"
+        - "P1 — 今スプリント対応（主要機能が使えない）"
+        - "P2 — 次スプリント対応（機能低下だが代替手段あり）"
+        - "P3 — 余裕があれば対応（軽微・UX 改善レベル）"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: 見積もりサイズ
+      description: 修正の難易度・規模を選択してください（不明な場合は「不明」）
+      options:
+        - "XS — 30分以内"
+        - "S — 1〜2時間"
+        - "M — 2〜4時間"
+        - "L — 半日"
+        - "XL — 1日以上"
+        - "不明"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: バグの概要
+      description: 何が起きているか、どうあるべきかを簡潔に記述してください
+      placeholder: |
+        例: カテゴリを「交通費」で保存しても「食費」として記録される
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: バグを再現するための手順を記述してください
+      placeholder: |
+        1. ホーム画面を開く
+        2. 支出を入力する
+        3. カテゴリを「交通費」に変更する
+        4. 保存する
+        5. レポートを確認すると「食費」になっている
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する動作
+      placeholder: "カテゴリが「交通費」として保存されること"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の動作
+      placeholder: "カテゴリが「食費（デフォルト）」として保存される"
+    validations:
+      required: true
+
+  - type: textarea
+    id: done-criteria
+    attributes:
+      label: 完了条件
+      description: このバグが「修正完了」と判断できる基準を記述してください
+      placeholder: |
+        - 指定したカテゴリで支出が保存されること
+        - 統合テストがパスすること
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: 補足情報
+      description: スクリーンショット、ブラウザ、OS などの補足情報があれば記入してください

--- a/.github/ISSUE_TEMPLATE/feature-pbi.yml
+++ b/.github/ISSUE_TEMPLATE/feature-pbi.yml
@@ -1,0 +1,104 @@
+name: 機能追加・改善（PBI）
+description: 新機能・UX改善・技術的改善の要求を起票する
+labels:
+  - "backlog"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        機能要求・改善提案を起票します。以下の情報を入力してください。
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: 種別
+      options:
+        - "feature — 新機能"
+        - "tech-debt — 技術的改善・リファクタ"
+        - "chore — ビルド・インフラ・プロセス改善"
+        - "design — UI/UX デザイン"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 優先度
+      description: プロダクト目標への貢献度・緊急度を選択してください
+      options:
+        - "P0 — 今すぐ必要（ブロッカー）"
+        - "P1 — 今スプリントで実装したい"
+        - "P2 — 近いうちに実装（標準バックログ）"
+        - "P3 — あれば嬉しい（低優先）"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: size
+    attributes:
+      label: 見積もりサイズ
+      description: 実装の規模を選択してください（不明な場合は「不明」）
+      options:
+        - "XS — 30分以内"
+        - "S — 1〜2時間"
+        - "M — 2〜4時間"
+        - "L — 半日"
+        - "XL — 1日以上"
+        - "不明"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: 影響エリア
+      multiple: true
+      options:
+        - "frontend"
+        - "backend"
+        - "common"
+        - "infra"
+        - "design"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 概要
+      description: 何を作るか・何を改善するかを簡潔に記述してください
+      placeholder: |
+        例: レポート画面にカテゴリ別グラフを追加して支出傾向を可視化する
+    validations:
+      required: true
+
+  - type: textarea
+    id: background
+    attributes:
+      label: 背景・目的
+      description: なぜこれが必要か、どんな課題を解決するかを記述してください
+      placeholder: |
+        現状: レポートに合計金額しか表示されず、どのカテゴリで使いすぎているかがわからない
+        課題: ユーザーが支出の内訳を把握できず、節約行動につながらない
+        目的: カテゴリ別の可視化で「どこを削るか」の判断を促す
+    validations:
+      required: true
+
+  - type: textarea
+    id: done-criteria
+    attributes:
+      label: 完了条件（AC）
+      description: 実装完了を判断するための受け入れ基準を記述してください
+      placeholder: |
+        - カテゴリ別の支出グラフが表示されること
+        - 月次・年次で切り替えできること
+        - モバイル・デスクトップ両方で正しく表示されること
+        - 単体テスト・E2Eテストがパスすること
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 実装メモ・依存関係
+      description: 技術的な注意事項や、先に完了すべき Issue があれば記述してください


### PR DESCRIPTION
## 📋 概要

バグ報告・機能追加PBI 用の GitHub Issue Forms（YAML形式）を新規作成。`priority` フィールドを必須（`required: true`）の dropdown として定義することで、Issue 起票時に P0〜P3 の優先度選択を強制し、priority 付け忘れを構造的に防止する。

## 🛠 変更内容

- `.github/ISSUE_TEMPLATE/bug-report.yml`: バグ報告フォームを新規作成
  - 必須フィールド: priority, size, バグの概要, 再現手順, 期待する動作, 実際の動作, 完了条件
  - ラベル自動付与: `type: bug`, `backlog`
- `.github/ISSUE_TEMPLATE/feature-pbi.yml`: 機能・改善PBI フォームを新規作成
  - 必須フィールド: type（種別）, priority, size, area, 概要, 背景・目的, 完了条件
  - ラベル自動付与: `backlog`
- 既存の `retrospective.md`（レトロ自動生成用）は変更しない

## 🔍 影響範囲

- GitHub の「New Issue」ボタンをクリックしたとき、テンプレート選択画面にバグ報告・PBI フォームが表示される
- フォーム経由で起票した Issue には自動で `backlog` ラベルが付与され、`auto-priority.yml` と連携して priority も自動付与される
- 既存 Issue には影響しない

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界を跨ぐ不正な依存はないか（該当なし: GitHub 設定ファイルのみ）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（該当なし: YAML のみ）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし: GitHub UI の変更のみ）

## 📸 スクリーンショット

該当なし（GitHub Issue 画面の変更のみ）

## 🧪 テスト内容

- ユニットテスト: 167件 全通過
- 統合テスト: 38件 全通過
- Issue Forms の動作確認は GitHub 上でのみ可能

## ⚠️ 備考

Closes #233

Sprint: 11