### PR TITLE
feat: DailyBudgetCard に Pattern D カラーパレットを適用する

### DIFF
--- a/apps/web/src/components/dashboard/DailyBudgetCard.tsx
+++ b/apps/web/src/components/dashboard/DailyBudgetCard.tsx
@@ -37,28 +37,34 @@ type PinchStyle = {
   label: string;
 };
 
+/**
+ * Pattern D カラーパレット（#247）
+ *   SAFE    — ウォームグレー（余裕時は目立たせない）
+ *   CAUTION — コーラル #f87171（ブランドオレンジと競合しない注意色）
+ *   DANGER  — ローズ #f43f5e（より濃くエスカレートしピンチ感を強調）
+ */
 const PINCH_STYLES: Record<PinchLevel, PinchStyle> = {
   safe: {
-    bg: "var(--color-safe-light)",
-    border: "var(--color-safe)",
-    heroColor: "var(--color-safe)",
-    badgeBg: "var(--color-safe)",
+    bg: "#fafaf8",
+    border: "#c4b5a5",
+    heroColor: "#6b5b52",
+    badgeBg: "#c4b5a5",
     badgeText: "#ffffff",
     label: "余裕",
   },
   caution: {
-    bg: "var(--color-caution-light)",
-    border: "var(--color-caution)",
-    heroColor: "var(--color-caution)",
-    badgeBg: "var(--color-caution)",
-    badgeText: "#1c1410",
+    bg: "#fef2f2",
+    border: "#f87171",
+    heroColor: "#b91c1c",
+    badgeBg: "#f87171",
+    badgeText: "#ffffff",
     label: "注意",
   },
   danger: {
-    bg: "var(--color-danger-light)",
-    border: "var(--color-danger)",
-    heroColor: "var(--color-danger)",
-    badgeBg: "var(--color-danger)",
+    bg: "#fff1f2",
+    border: "#f43f5e",
+    heroColor: "#9f1239",
+    badgeBg: "#f43f5e",
     badgeText: "#ffffff",
     label: "ピンチ",
   },
@@ -124,7 +130,7 @@ export function DailyBudgetCard({ todayExpense, budgetResult }: Props) {
       <div className="mb-4">
         <p
           className="text-4xl font-extrabold leading-none"
-          style={{ color: isOverBudget ? "var(--color-danger)" : style.heroColor }}
+          style={{ color: isOverBudget ? PINCH_STYLES.danger.heroColor : style.heroColor }}
         >
           {isOverBudget ? `-${formatYen(Math.abs(remaining))}` : formatYen(remaining)}
         </p>


### PR DESCRIPTION
## 📋 概要

Issue #247 の対応。`DailyBudgetCard` の SAFE/CAUTION/DANGER 配色を Pattern D（ローズ系）に変更し、ブランドオレンジ（#f18840）との競合を解消する。

## 🛠 変更内容

`src/components/dashboard/DailyBudgetCard.tsx` の `PINCH_STYLES` を更新:

| 状態 | 変更前 | 変更後 |
|---|---|---|
| SAFE bg | `var(--color-safe-light)` | `#fafaf8`（ウォームグレー） |
| SAFE border/hero | `var(--color-safe)` | `#c4b5a5` / `#6b5b52` |
| CAUTION bg | `var(--color-caution-light)` | `#fef2f2`（コーラル系） |
| CAUTION border/hero | `var(--color-caution)` | `#f87171` / `#b91c1c` |
| CAUTION badgeText | `#1c1410`（ダーク） | `#ffffff`（白） |
| DANGER bg | `var(--color-danger-light)` | `#fff1f2`（ローズ系） |
| DANGER border/hero | `var(--color-danger)` | `#f43f5e` / `#9f1239` |
| isOverBudget hero | `var(--color-danger)` | `PINCH_STYLES.danger.heroColor` |

## 🔍 影響範囲

- `DailyBudgetCard` を使用している全画面（ダッシュボード）に反映
- CSS 変数（`--color-safe` 等）への依存をなくし、値をコンポーネント内に集約
- 既存テスト全件パス（CSS 変数の値に依存したテストなし）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（ID 操作なし）
- [x] マジックナンバーを排除し、定数化されているか（`PINCH_STYLES` 定数にまとめた）
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- Storybook `Catalog/DailyBudgetCardV2 (Pattern D) > BeforeAfterComparison` で確認済み（#257 PR参照） -->

## 🧪 テスト内容

- `pnpm test:unit`: 167 テスト全件パス

Closes #247
Sprint: 12