### PR TITLE
chore: shadcn/ui ラッパーコンポーネント強制ルールを ESLint・規約・フックで整備する

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,10 @@
                     {
                         "type": "command",
                         "command": "bash \"$(git rev-parse --show-toplevel)/.github/hooks/enforce-flow.sh\""
+                    },
+                    {
+                        "type": "command",
+                        "command": "bash \"$(git rev-parse --show-toplevel)/.github/hooks/enforce-ui-wrapper.sh\""
                     }
                 ]
             }

--- a/.github/ai-agent-workflow.md
+++ b/.github/ai-agent-workflow.md
@@ -87,6 +87,21 @@
 
 ---
 
+## shadcn/ui ラッパー規約（UI コンポーネント実装時の必須事項）
+
+> この規約は **ESLint `no-restricted-imports`** によって自動強制される。違反はコミット時に `lefthook` でブロックされる。
+> 詳細は `.github/coding-conventions.md` の「shadcn/ui ラッパーコンポーネント規約」を参照すること。
+
+### AI エージェントへの行動指針
+
+1. **プリミティブを直接使わない**: `@radix-ui/*`・`vaul`・`sonner` の `Toaster` を `src/components/ui/` 以外から直接インポートしてはならない
+2. **ラッパーが存在するか確認する**: UI コンポーネントを実装する前に `src/components/ui/` を確認し、既存ラッパーを使用する
+3. **ラッパーがなければ先に作る**: 既存ラッパーがない場合は `src/components/ui/{component}.tsx` を先に作成し、その後で使用する
+4. **ネイティブ要素を避ける**: `<button>`, `<input>`, `<select>`, `<dialog>` などのネイティブ HTML 要素は、対応する shadcn/ui ラッパーが存在する場合は使用禁止（ただし `<input type="hidden">` など shadcn/ui に相当なしの場合は可）
+5. **例外を乱用しない**: 「shadcn/ui で再現できない」と判断する場合はユーザーに理由を説明し承認を得てから使用すること
+
+---
+
 ## コード品質制約
 
 - **正確な情報源の提示**: 根拠を明示すること

--- a/.github/coding-conventions.md
+++ b/.github/coding-conventions.md
@@ -45,6 +45,34 @@
 - ローディング状態とエラー状態の表示を必ず考慮する
 - 破壊的な操作の前には必ず確認（モーダル等）を挟む
 
+### shadcn/ui ラッパーコンポーネント規約（必須）
+
+> **この規約は ESLint ルール（`no-restricted-imports`）によって自動強制される。違反はコミット時に `lefthook` でブロックされる。**
+
+| ルール | 内容 |
+|--------|------|
+| **プリミティブ直接インポート禁止** | `@radix-ui/*`・`vaul`・`sonner(Toaster)` を `src/` から直接インポートしてはならない |
+| **ラッパー経由の義務** | `src/components/ui/` 配下のラッパーコンポーネントを使用すること |
+| **ネイティブ要素の制限** | `<button>`, `<input>`, `<select>` 等は shadcn/ui 相当ラッパーが存在する場合は使用禁止 |
+| **新規コンポーネントの追加** | UI プリミティブが必要な場合は先に `src/components/ui/` にラッパーを作成してから使用する |
+| **例外** | `toast()` 関数など UI 以外の API は `sonner` から直接インポート可。`__tests__/` 内はモック目的のため除外 |
+
+**現在のラッパー一覧** (`src/components/ui/`):
+
+| ラッパー | 内部ライブラリ | 用途 |
+|----------|--------------|------|
+| `button.tsx` | `@radix-ui/react-slot` | ボタン |
+| `dialog.tsx` | `@radix-ui/react-dialog` | モーダル |
+| `drawer.tsx` | `vaul` | ドロワー |
+| `select.tsx` | `@radix-ui/react-select` | セレクトボックス |
+| `sonner.tsx` | `sonner` | トースト通知 |
+| `form.tsx` | `@radix-ui/react-label` | フォームフィールド |
+| `tabs.tsx` | `@radix-ui/react-tabs` | タブ |
+| `popover.tsx` | `@radix-ui/react-popover` | ポップオーバー |
+| `tooltip.tsx` | `@radix-ui/react-tooltip` | ツールチップ |
+| `checkbox.tsx` | `@radix-ui/react-checkbox` | チェックボックス |
+| `sheet.tsx` | `@radix-ui/react-dialog` | サイドシート |
+
 ---
 
 ## アイコン規約

--- a/.github/hooks/enforce-ui-wrapper.sh
+++ b/.github/hooks/enforce-ui-wrapper.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# ============================================================
+# enforce-ui-wrapper.sh — shadcn/ui ラッパー強制フック
+#
+# Claude Code の PreToolUse フックとして動作する。
+# Write / Edit ツール実行前に、書き込まれるコンテンツを検査し、
+# @radix-ui/* や vaul を src/components/ui/ 外から直接インポートしようとした場合に
+# exit 1 でツール実行をブロックし、ラッパーの使用を促す。
+#
+# stdin には Claude Code から JSON 形式でツール入力が渡される。
+#
+# Cursor / GitHub Copilot: 自動実行は不可。
+# lefthook の pre-commit lint チェックで同等の強制が行われる。
+# ============================================================
+
+set -euo pipefail
+
+# stdin から JSON ツール入力を読み込む
+INPUT=$(cat)
+
+# ファイルパスを取得（Write: file_path / Edit: file_path）
+FILE_PATH=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('file_path') or '')
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+# 書き込みコンテンツを取得（Write: content / Edit: new_string）
+CONTENT=$(echo "$INPUT" | python3 -c "
+import sys, json
+try:
+    d = json.load(sys.stdin)
+    print(d.get('content') or d.get('new_string') or '')
+except Exception:
+    print('')
+" 2>/dev/null || echo "")
+
+# apps/web/src 配下かつ components/ui/ と __tests__/ 以外のファイルのみチェック
+if [[ "$FILE_PATH" == *"apps/web/src"* ]] && \
+   [[ "$FILE_PATH" != *"components/ui"* ]] && \
+   [[ "$FILE_PATH" != *"__tests__"* ]] && \
+   [[ "$FILE_PATH" != *".stories."* ]]; then
+
+  # @radix-ui/* または vaul の直接インポートを検出
+  if echo "$CONTENT" | grep -qE "from ['\"]@radix-ui/|from ['\"]vaul['\"]"; then
+    echo "ERROR: shadcn/ui ラッパー規約違反を検出しました。" >&2
+    echo "" >&2
+    echo "  対象ファイル: $FILE_PATH" >&2
+    echo "" >&2
+    echo "  @radix-ui/* または vaul を src/components/ui/ 外から直接インポートしてはなりません。" >&2
+    echo "  @/components/ui/* のラッパーコンポーネントを使用してください。" >&2
+    echo "" >&2
+    echo "  ラッパーが存在しない場合は先に src/components/ui/{component}.tsx を作成してください。" >&2
+    echo "  詳細: .github/coding-conventions.md「shadcn/ui ラッパーコンポーネント規約」" >&2
+    exit 1
+  fi
+
+  # sonner から Toaster を直接インポートしようとした場合を検出
+  if echo "$CONTENT" | grep -qE "import.*\{[^}]*Toaster[^}]*\}.*from ['\"]sonner['\"]"; then
+    echo "ERROR: shadcn/ui ラッパー規約違反を検出しました。" >&2
+    echo "" >&2
+    echo "  対象ファイル: $FILE_PATH" >&2
+    echo "" >&2
+    echo "  sonner から Toaster を直接インポートしてはなりません。" >&2
+    echo "  @/components/ui/sonner の Toaster を使用してください。" >&2
+    echo "  (toast() 関数は sonner から直接インポート可です)" >&2
+    exit 1
+  fi
+fi
+
+exit 0

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -18,7 +18,42 @@ const eslintConfig = defineConfig([
     // Storybook ビルド出力（コミットしないが lint 対象外にする）
     "storybook-static/**",
   ]),
-  ...storybook.configs["flat/recommended"]
+  ...storybook.configs["flat/recommended"],
+  // shadcn/ui ラッパー強制ルール:
+  // src/components/ui/ 配下のラッパーを経由せず Radix UI プリミティブや vaul を直接インポートすることを禁止する。
+  // src/components/ui/ 自体はラッパー実装のため除外する。
+  {
+    files: ["**/*.{ts,tsx}"],
+    // src/components/ui/ はラッパー実装のため除外。__tests__/**はモック目的のnamespace importが必要なため除外。
+    ignores: ["**/components/ui/**", "**/__tests__/**", "**/*.stories.tsx"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "sonner",
+              importNames: ["Toaster"],
+              message:
+                "Toaster を直接インポートせず @/components/ui/sonner の Toaster を使用してください。toast() 関数は直接インポート可です。",
+            },
+          ],
+          patterns: [
+            {
+              group: ["@radix-ui/*"],
+              message:
+                "@radix-ui/* を直接インポートせず @/components/ui/* のラッパーコンポーネントを使用してください。新規コンポーネントが必要な場合は先に src/components/ui/ にラッパーを作成してください。",
+            },
+            {
+              group: ["vaul"],
+              message:
+                "vaul を直接インポートせず @/components/ui/drawer を使用してください。",
+            },
+          ],
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;


### PR DESCRIPTION
## 概要

- `@radix-ui/*` / `vaul` / `sonner(Toaster)` の直接インポートを ESLint で自動禁止
- `src/components/ui/` のラッパー経由を強制（`__tests__/` / `*.stories.tsx` は除外）
- coding-conventions.md に shadcn/ui ラッパー規約セクションを追加
- ai-agent-workflow.md に AI エージェント向け行動指針を追記
- Claude Code PreToolUse フック（`enforce-ui-wrapper.sh`）を新規作成・登録

## テスト計画

- [x] `pnpm turbo run lint` でエラーなし（既存コードに違反なし）
- [x] `pnpm turbo run test:unit` 全件パス（165 tests）
- [x] `pnpm turbo run type-check` エラーなし

Closes #262
Sprint: 13