### PR TITLE
fix: 初期設定未完了時に SetupModal が開けない不具合を修正する

### DIFF
--- a/apps/web/src/__tests__/components/XDayDisplay.test.tsx
+++ b/apps/web/src/__tests__/components/XDayDisplay.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { XDayDisplay } from '../../components/dashboard/XDayDisplay'
 
 // upsertSettingsAction をモック（useActionState 内で使用）
@@ -90,8 +90,27 @@ describe('XDayDisplay', () => {
 
         it('initialAssets=null のとき設定促進フォールバックが表示される', () => {
             render(<XDayDisplay {...defaultProps} initialAssets={null} />)
-            // 設定促進フォールバックメッセージが表示される
             expect(screen.getByText('設定を完了すると「家計の寿命」が表示されます')).toBeInTheDocument()
+        })
+
+        it('initialAssets=null のとき「設定する」ボタンが表示される', () => {
+            render(<XDayDisplay {...defaultProps} initialAssets={null} />)
+            expect(screen.getByRole('button', { name: '設定する' })).toBeInTheDocument()
+        })
+
+        it('initialAssets=null のとき「設定する」ボタンを押すと SetupModal が開く', () => {
+            render(<XDayDisplay {...defaultProps} initialAssets={null} />)
+            const button = screen.getByRole('button', { name: '設定する' })
+            fireEvent.click(button)
+            // SetupModal の Dialog タイトルが表示される
+            expect(screen.getByRole('dialog')).toBeInTheDocument()
+        })
+
+        it('initialAssets=null のとき SetupModal に閉じるボタンが表示されない', () => {
+            render(<XDayDisplay {...defaultProps} initialAssets={null} />)
+            fireEvent.click(screen.getByRole('button', { name: '設定する' }))
+            // 初期設定時は onClose を渡さないため、モーダルに閉じるボタンがない
+            expect(screen.queryByRole('button', { name: /閉じる|close/i })).not.toBeInTheDocument()
         })
     })
 })

--- a/apps/web/src/components/dashboard/XDayDisplay.tsx
+++ b/apps/web/src/components/dashboard/XDayDisplay.tsx
@@ -155,32 +155,39 @@ export function XDayDisplay({
         return () => clearInterval(id);
     }, [totalAssets, netDailyExpense, snapshotAt]);
 
-    if (totalAssets === null) {
-        // 設定未完了のフォールバック表示（DailyBudgetCard と同様の方針）
-        // SetupModal は opacity 親要素によるバックドロップ描画不具合があるため使用しない。
-        // 設定入力は設定ページ（/settings）から行う。
-        return (
-            <div
-                className="rounded-2xl border-2 border-dashed p-5"
-                style={{ borderColor: "var(--border-default)", background: "var(--color-surface-subtle)" }}
-            >
-                <p className="text-sm font-medium text-[#1c1410]/50 text-center">
-                    設定を完了すると「家計の寿命」が表示されます
-                </p>
-            </div>
-        );
-    }
-
     if (showSetup) {
         return (
             <SetupModal
                 onSave={handleSetup}
                 formAction={formAction}
                 actionState={state}
-                defaultAssets={totalAssets}
+                defaultAssets={totalAssets ?? undefined}
                 defaultIncome={monthlyIncome}
-                onClose={() => setShowSetup(false)}
+                onClose={totalAssets !== null ? () => setShowSetup(false) : undefined}
             />
+        );
+    }
+
+    if (totalAssets === null) {
+        // 設定未完了のフォールバック表示
+        return (
+            <div
+                className="rounded-2xl border-2 border-dashed p-5"
+                style={{ borderColor: "var(--border-default)", background: "var(--color-surface-subtle)" }}
+            >
+                <p className="mb-3 text-sm font-medium text-[#1c1410]/50 text-center">
+                    設定を完了すると「家計の寿命」が表示されます
+                </p>
+                <div className="text-center">
+                    <button
+                        type="button"
+                        onClick={() => setShowSetup(true)}
+                        className="rounded-xl bg-[#f18840] px-4 py-2 text-sm font-bold text-white transition-opacity hover:opacity-80"
+                    >
+                        設定する
+                    </button>
+                </div>
+            </div>
         );
     }
 


### PR DESCRIPTION
## Summary

- `totalAssets === null` のアーリーリターンが `showSetup` チェックより前にあり、「設定する」ボタンが存在せず初期設定が完了できない不具合を修正
- `showSetup` チェックを `totalAssets === null` の前に移動し、フォールバック表示に「設定する」ボタンを追加
- 初期設定時（`totalAssets=null`）は `onClose` を渡さず、モーダルを必ず完了させる設計に変更
- 誤ったコメント（Dialog Portal 修正済みにもかかわらず "使用しない" と記載）を削除

## Test plan

- [ ] `initialAssets=null` のとき「設定する」ボタンが表示されること
- [ ] 「設定する」ボタンを押すと SetupModal が開くこと
- [ ] 初期設定時の SetupModal に閉じるボタンがないこと
- [ ] `initialAssets` が設定済みの場合、従来通り「資産データを更新」ボタンから SetupModal が開くこと
- [ ] 全ユニットテスト通過（168/168）

Closes #265

🤖 Generated with [Claude Code](https://claude.com/claude-code)