### PR TITLE
chore: デプロイ失敗時 Issue 自動作成と PR ビルド検証を追加する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ on:
 permissions:
   id-token: write  # OIDC トークン取得に必要
   contents: read
+  issues: write    # デプロイ失敗時の Issue 自動作成に必要
 
 jobs:
   # ─── 変更ファイルの検出 ──────────────────────────────────────────────────────
@@ -446,3 +447,75 @@ jobs:
           SERVICE: ${{ secrets.ECS_SERVICE_WEB }}
           CLOUDFRONT_DIST_ID: ${{ secrets.CLOUDFRONT_DIST_ID }}
         run: bash scripts/update-cloudfront-origin.sh
+
+  # ─── デプロイ失敗時に GitHub Issue を自動作成 ──────────────────────────────
+  notify-failure:
+    name: Notify Deploy Failure
+    runs-on: ubuntu-latest
+    needs: [build-and-push, db-migrate, db-seed, deploy-ecs, update-cloudfront]
+    # いずれかの重要ジョブが失敗した場合にのみ実行
+    if: |
+      always() &&
+      (needs.build-and-push.result == 'failure' ||
+       needs.db-migrate.result == 'failure' ||
+       needs.db-seed.result == 'failure' ||
+       needs.deploy-ecs.result == 'failure')
+    steps:
+      - name: Create deploy failure issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BUILD_RESULT: ${{ needs.build-and-push.result }}
+          MIGRATE_RESULT: ${{ needs.db-migrate.result }}
+          SEED_RESULT: ${{ needs.db-seed.result }}
+          DEPLOY_RESULT: ${{ needs.deploy-ecs.result }}
+        run: |
+          # 失敗したジョブ名を収集
+          FAILED_JOBS=""
+          [ "${BUILD_RESULT}"   = "failure" ] && FAILED_JOBS="${FAILED_JOBS} build-and-push"
+          [ "${MIGRATE_RESULT}" = "failure" ] && FAILED_JOBS="${FAILED_JOBS} db-migrate"
+          [ "${SEED_RESULT}"    = "failure" ] && FAILED_JOBS="${FAILED_JOBS} db-seed"
+          [ "${DEPLOY_RESULT}"  = "failure" ] && FAILED_JOBS="${FAILED_JOBS} deploy-ecs"
+
+          SHORT_SHA="${SHA:0:7}"
+          TITLE="deploy: デプロイ失敗 (${SHORT_SHA}) —${FAILED_JOBS}"
+
+          # 同一 SHA の重複 Issue を作成しない
+          EXISTING=$(gh issue list \
+            --state open \
+            --search "${SHORT_SHA} in:title" \
+            --label "deploy-alert" \
+            --json number --jq 'length')
+          if [ "${EXISTING}" != "0" ]; then
+            echo "同一 SHA の deploy-alert Issue が既に存在するためスキップします。"
+            exit 0
+          fi
+
+          gh issue create \
+            --title "${TITLE}" \
+            --label "deploy-alert" \
+            --label "priority: P0" \
+            --body "## デプロイ失敗通知
+
+          commit \`${SHORT_SHA}\` のデプロイが失敗しました。
+
+          ## 失敗したジョブ
+
+          \`\`\`
+          ${FAILED_JOBS}
+          \`\`\`
+
+          ## 詳細
+
+          - ワークフロー実行: ${RUN_URL}
+          - コミット SHA: \`${SHA}\`
+
+          ## 対応方針
+
+          1. 上記リンクから Actions ログを確認し、エラー原因を特定する
+          2. 修正ブランチを切って PR を作成する
+          3. 修正後にこの Issue をクローズする
+
+          _自動作成: deploy.yml notify-failure_"
+          echo "deploy-alert Issue を作成しました。"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,15 +3,18 @@
 #
 # フロー（全ジョブ並列実行）:
 #   1. lint-typecheck    — lint + 型チェック
-#   2. unit-test         — ユニットテスト
-#   3. integration-test  — 統合テスト（MySQL サービスコンテナ使用）
-#   4. security-scan     — Trivy FS スキャン（Docker ビルド不要）
-#   5. migration-check   — Prisma スキーマ検証 + 破壊的変更の検出
-#   6. infra-check       — Terraform 構文・フォーマットチェック
+#   2. nextjs-build      — Next.js プロダクションビルド（型エラーの早期検出）
+#   3. storybook-build   — Storybook ビルド確認
+#   4. unit-test         — ユニットテスト
+#   5. integration-test  — 統合テスト（MySQL サービスコンテナ使用）
+#   6. security-scan     — Trivy FS スキャン（Docker ビルド不要）
+#   7. migration-check   — Prisma スキーマ検証 + 破壊的変更の検出
+#   8. infra-check       — Terraform 構文・フォーマットチェック
 #
 # ブランチ保護設定（GitHub Settings > Branches > main）:
 #   Require status checks to pass before merging に以下を登録すること:
 #   - Lint & Type Check
+#   - Next.js Build
 #   - Unit Test
 #   - Integration Test
 #   - Security Scan (FS)
@@ -53,6 +56,39 @@ jobs:
 
       - name: Lint & type-check
         run: pnpm turbo run lint type-check
+
+  # ─── Next.js プロダクションビルド確認 ───────────────────────────────────────
+  # Docker ビルドと同等の next build を PR 時点で実行し、型エラーを事前検出する。
+  # pnpm turbo run type-check（tsc --noEmit）はインクリメンタルキャッシュを使用するため
+  # next build が検出する型エラーを見逃すケースがある。本ジョブで補完する。
+  nextjs-build:
+    name: Next.js Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build common & api-client
+        run: |
+          pnpm --filter @budget/common build
+          pnpm --filter @budget/api-client build
+
+      - name: Generate Prisma client
+        run: pnpm --filter @budget/api exec prisma generate
+
+      - name: Next.js production build
+        run: pnpm --filter web build
 
   # ─── Storybook ビルド確認 ─────────────────────────────────────────────────
   storybook-build:


### PR DESCRIPTION
## Summary

- `deploy.yml`: `build-and-push` / `db-migrate` / `db-seed` / `deploy-ecs` のいずれかが失敗した際に `deploy-alert` + `priority: P0` ラベル付き GitHub Issue を自動作成
- 同一 SHA の重複 Issue は作成しない
- `pr-checks.yml`: `nextjs-build` ジョブを追加し、`next build` を PR 時点で実行。`pnpm turbo type-check` のインクリメンタルキャッシュで見逃される型エラーを補完

## Test plan

- [ ] deploy.yml の `notify-failure` job が `build-and-push` 失敗時に Issue を作成すること（Actions 画面でシミュレーション確認）
- [ ] `deploy-alert` ラベルが GitHub に作成済みであること
- [ ] pr-checks.yml の `nextjs-build` job が新たなジョブとして CI に追加されること
- [ ] `Next.js Build` を GitHub Settings のブランチ保護 status checks に追加する

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)