### PR TITLE
fix: SelectField.stories.tsx zodResolver型エラーとnotify-failureのgit未初期化エラーを修正する

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -461,6 +461,8 @@ jobs:
        needs.db-seed.result == 'failure' ||
        needs.deploy-ecs.result == 'failure')
     steps:
+      - uses: actions/checkout@v4
+
       - name: Create deploy failure issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/web/src/components/common/SelectField.stories.tsx
+++ b/apps/web/src/components/common/SelectField.stories.tsx
@@ -2,8 +2,6 @@
 
 import type { Meta, StoryObj } from '@storybook/nextjs-vite'
 import { useForm } from 'react-hook-form'
-import { zodResolver } from '@hookform/resolvers/zod'
-import { z } from 'zod'
 import { Form } from '@/components/ui/form'
 import { SelectField } from './SelectField'
 import { Button } from './Button'
@@ -40,17 +38,21 @@ export const Basic: Story = {
   },
 }
 
-const schema = z.object({ category: z.string().min(1, 'カテゴリを選択してください') })
-
+// デモ用インラインバリデーション（zodResolver は Zod v4 との型互換性問題のため stories では使用しない）
 export const WithValidation: Story = {
   render: () => {
-    const form = useForm<z.infer<typeof schema>>({
-      resolver: zodResolver(schema),
+    const form = useForm<{ category: string }>({
       defaultValues: { category: '' },
+      mode: 'onSubmit',
     })
+    function onSubmit(data: { category: string }) {
+      if (!data.category) {
+        form.setError('category', { message: 'カテゴリを選択してください' })
+      }
+    }
     return (
       <Form {...form}>
-        <form className="w-80 flex flex-col gap-4" onSubmit={form.handleSubmit(() => {})}>
+        <form className="w-80 flex flex-col gap-4" onSubmit={form.handleSubmit(onSubmit)}>
           <SelectField
             name="category"
             label="カテゴリ"


### PR DESCRIPTION
## Summary

- `SelectField.stories.tsx` の `WithValidation` ストーリーが `zodResolver`（Zod v4.4.x との型非互換）を使用していたため Docker ビルドで型エラーが発生。`form.setError` によるインラインバリデーションに変更
- `notify-failure` ジョブに `actions/checkout` が欠落しており `gh` CLI が「fatal: not a git repository」で失敗していた。checkout ステップを追加

## Test plan

- [ ] `pnpm --filter web build` がローカルで成功すること（確認済み）
- [ ] 全ユニットテスト 168/168 通過（確認済み）
- [ ] デプロイ Actions が Build & Push を通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)