### PR TITLE
fix: Storybook Pages デプロイ失敗でも CI を成功とする

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -67,6 +67,9 @@ jobs:
     name: Deploy to GitHub Pages
     needs: build
     runs-on: ubuntu-latest
+    # GitHub Pages が Settings で有効化されていない場合にデプロイが失敗しても
+    # CI 全体を失敗とみなさない。Storybook Build が成功すれば完了とする。
+    continue-on-error: true
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

- GitHub Pages が Settings で有効化されていない場合に `actions/deploy-pages@v4` が 404 で失敗し CI 全体が失敗していた
- `deploy` ジョブに `continue-on-error: true` を追加し、Storybook Build が成功すれば CI 完了とみなすよう変更
- Pages を有効化した場合はそのままデプロイも動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)