### PR TITLE
fix: asset-outlook-ab スワイプ切り替え・ブランドカラー統一、テンキー縮小・iOS zoom 抑制（Sprint #18）

### DIFF
--- a/apps/sandbox/src/pages/AssetOutlookABPrototype.tsx
+++ b/apps/sandbox/src/pages/AssetOutlookABPrototype.tsx
@@ -1,5 +1,8 @@
 /**
- * AssetOutlookABPrototype — 長期指標 リッチデザイン（Sprint #17 ブラッシュアップ版）
+ * AssetOutlookABPrototype — 長期指標 リッチデザイン（Sprint #18）
+ *
+ * - タブ廃止 → ドットインジケーター + スワイプ切り替え
+ * - ヒーローカード配色をブランドカラー（ウォームダークブラウン × オレンジ / ティール）に統一
  *
  * Pattern A: 資産ランウェイ
  * Pattern B: 今月の貯蓄額（先月比付き）
@@ -15,6 +18,7 @@ import {
   useMotionValue,
   useTransform,
   useSpring as useMotionSpring,
+  type PanInfo,
 } from 'framer-motion'
 import {
   ChevronLeft,
@@ -29,52 +33,48 @@ import {
 
 // ─── Spring プリセット ───────────────────────────────────────────────────
 const SPRING = {
-  SNAP: { type: 'spring', stiffness: 600, damping: 35 },
-  QUICK: { type: 'spring', stiffness: 400, damping: 30 },
-  BASE: { type: 'spring', stiffness: 300, damping: 28 },
+  SNAP:   { type: 'spring', stiffness: 600, damping: 35 },
+  QUICK:  { type: 'spring', stiffness: 400, damping: 30 },
+  BASE:   { type: 'spring', stiffness: 300, damping: 28 },
   SMOOTH: { type: 'spring', stiffness: 200, damping: 26 },
 } as const
 
 // ─── デザイントークン ─────────────────────────────────────────────────────
 const D = {
-  bg: '#f5f3ef',
-  card: '#ffffff',
-  text: '#1c1410',
-  muted: 'rgba(28,20,16,0.45)',
+  bg:     '#f5f3ef',
+  card:   '#ffffff',
+  text:   '#1c1410',
+  muted:  'rgba(28,20,16,0.45)',
   border: '#e8ddd5',
   shadow: '0 2px 12px rgba(28,20,16,0.08), 0 0 0 1px rgba(28,20,16,0.06)',
-  brand: '#f18840',
+  brand:  '#f18840',
   income: '#35b5a2',
   danger: '#f43f5e',
-  // ヒーローカード
-  heroBg: 'linear-gradient(145deg, #1e1a3a 0%, #2a2354 45%, #1b1635 100%)',
+  // ヒーローカード — ブランドウォームダーク
+  heroBg:   'linear-gradient(145deg, #1a0c04 0%, #2c1608 42%, #1a0c04 100%)',
   heroText: '#ffffff',
-  heroMuted: 'rgba(255,255,255,0.50)',
-  accentGreen: '#34d399',
-  accentPurple: '#a78bfa',
-  accentOrange: '#fb923c',
-  accentPink: '#f472b6',
+  heroMuted: 'rgba(255,255,255,0.48)',
 } as const
 
 // ─── モックデータ ────────────────────────────────────────────────────────
 const MOCK = {
-  totalAssets: 999853,
-  monthlyIncome: 252600,
+  totalAssets:      999853,
+  monthlyIncome:    252600,
   thisMonthExpense: 148700,
-  thisMonthIncome: 252600,
+  thisMonthIncome:  252600,
   lastMonthExpense: 136300,
-  lastMonthIncome: 252600,
-  netDailyExpense: 9800 - 252600 / 30,
-  recordedMonths: 4,
+  lastMonthIncome:  252600,
+  netDailyExpense:  9800 - 252600 / 30,
+  recordedMonths:   4,
 }
 
-const thisMonthSavings = MOCK.thisMonthIncome - MOCK.thisMonthExpense       // 103,900
-const lastMonthSavings = MOCK.lastMonthIncome - MOCK.lastMonthExpense       // 116,300
-const savingsDiff = thisMonthSavings - lastMonthSavings                     // −12,400
-const annualSavingsPace = thisMonthSavings * 12                             // 1,246,800
-const savingsRate = Math.round((thisMonthSavings / MOCK.thisMonthIncome) * 100) // 41%
-const assetRunwayDays = Math.floor(MOCK.totalAssets / MOCK.netDailyExpense) // 724日
-const assetRunwayDate = (() => {
+const thisMonthSavings  = MOCK.thisMonthIncome - MOCK.thisMonthExpense       // 103,900
+const lastMonthSavings  = MOCK.lastMonthIncome - MOCK.lastMonthExpense       // 116,300
+const savingsDiff       = thisMonthSavings - lastMonthSavings                // −12,400
+const annualSavingsPace = thisMonthSavings * 12                              // 1,246,800
+const savingsRate       = Math.round((thisMonthSavings / MOCK.thisMonthIncome) * 100)
+const assetRunwayDays   = Math.floor(MOCK.totalAssets / MOCK.netDailyExpense)
+const assetRunwayDate   = (() => {
   const d = new Date(2026, 4, 15)
   d.setDate(d.getDate() + assetRunwayDays)
   return `${d.getFullYear()}年${d.getMonth() + 1}月`
@@ -82,7 +82,7 @@ const assetRunwayDate = (() => {
 
 const SCORE_FACTORS = [
   { label: '予算遵守率', score: 72, weight: 30, note: '過去7日で5日が予算内' },
-  { label: '貯蓄率', score: 82, weight: 40, note: `今月 ${savingsRate}%（目安: 20% 以上）` },
+  { label: '貯蓄率',     score: 82, weight: 40, note: `今月 ${savingsRate}%（目安: 20% 以上）` },
   { label: '支出トレンド', score: 55, weight: 30, note: '食費 +23%、医療費 +173% が押し下げ' },
 ]
 const TOTAL_SCORE = Math.round(
@@ -90,6 +90,40 @@ const TOTAL_SCORE = Math.round(
 )
 
 function yen(n: number) { return `¥${Math.round(n).toLocaleString('ja-JP')}` }
+
+// ─── パターン定義 ─────────────────────────────────────────────────────────
+type PatternId = 'A' | 'B' | 'C' | 'D'
+const PATTERNS: PatternId[] = ['A', 'B', 'C', 'D']
+
+// ブランドカラーに準じたアクセント割り当て
+const PATTERN_META: Record<PatternId, { name: string; accent: string }> = {
+  A: { name: '資産ランウェイ',    accent: D.brand  },   // ブランドオレンジ
+  B: { name: '今月の貯蓄額',      accent: D.income },   // ブランドティール
+  C: { name: '年間ペース予測',    accent: D.brand  },   // ブランドオレンジ
+  D: { name: '財政健全スコア',    accent: '#fbbf24' },  // アンバー（スコア中立色）
+}
+
+// ─── コンテンツスライドアニメーション ─────────────────────────────────────
+// direction > 0 = 次へ（左スワイプ）, direction < 0 = 前へ（右スワイプ）
+const slideVariants = {
+  enter: (dir: number) => ({
+    x: dir > 0 ? 56 : -56,
+    opacity: 0,
+    filter: 'blur(4px)',
+  }),
+  center: {
+    x: 0,
+    opacity: 1,
+    filter: 'blur(0px)',
+    transition: SPRING.BASE,
+  },
+  exit: (dir: number) => ({
+    x: dir > 0 ? -56 : 56,
+    opacity: 0,
+    filter: 'blur(4px)',
+    transition: { duration: 0.12 },
+  }),
+}
 
 // ─── SpringNumber ─────────────────────────────────────────────────────────
 function SpringNumber({
@@ -102,9 +136,7 @@ function SpringNumber({
   const mv = useMotionValue(0)
   const spring = useMotionSpring(mv, { stiffness: 70, damping: 18 })
   const display = useTransform(spring, (v) => format(Math.round(v)))
-
   useEffect(() => { mv.set(value) }, [mv, value])
-
   return <motion.span>{display}</motion.span>
 }
 
@@ -114,18 +146,16 @@ function ProgressBar({
   color,
   height = 6,
   delay = 0,
-  trackColor = 'rgba(255,255,255,0.12)',
 }: {
   pct: number
   color: string
   height?: number
   delay?: number
-  trackColor?: string
 }) {
   return (
     <div
       className="overflow-hidden"
-      style={{ height, borderRadius: 9999, background: trackColor }}
+      style={{ height, borderRadius: 9999, background: 'rgba(255,255,255,0.14)' }}
     >
       <motion.div
         className="h-full"
@@ -138,83 +168,51 @@ function ProgressBar({
   )
 }
 
-// ─── パターン定義 ─────────────────────────────────────────────────────────
-type PatternId = 'A' | 'B' | 'C' | 'D'
-
-const PATTERN_META: Record<PatternId, { name: string; accent: string }> = {
-  A: { name: '資産ランウェイ', accent: D.accentGreen },
-  B: { name: '今月の貯蓄額', accent: D.accentPurple },
-  C: { name: '年間ペース予測', accent: D.accentOrange },
-  D: { name: '財政健全スコア', accent: D.accentPink },
-}
-
-// ─── 共通ヒーローカードアニメーション ─────────────────────────────────────
-const heroVariants = {
-  hidden: { opacity: 0, y: 10, filter: 'blur(6px)' },
-  visible: { opacity: 1, y: 0, filter: 'blur(0px)', transition: SPRING.BASE },
-  exit: { opacity: 0, y: -8, filter: 'blur(4px)', transition: { duration: 0.15 } },
-}
-
-const itemVariants = (delay: number) => ({
-  hidden: { opacity: 0, y: 8 },
-  visible: { opacity: 1, y: 0, transition: { ...SPRING.BASE, delay } },
+// ─── スタッガーアイテム ───────────────────────────────────────────────────
+const staggerItem = (i: number) => ({
+  initial: { opacity: 0, y: 8 },
+  animate: { opacity: 1, y: 0 },
+  transition: { ...SPRING.BASE, delay: 0.1 + i * 0.05 },
 })
 
-// ─── ヒーローカード：Pattern A ───────────────────────────────────────────
-function PatternAHero() {
+// ─── Pattern A ───────────────────────────────────────────────────────────
+function PatternAHero({ accent }: { accent: string }) {
   return (
-    <motion.div
-      className="flex flex-col items-center text-center"
-      variants={heroVariants}
-      initial="hidden"
-      animate="visible"
-      exit="exit"
-    >
+    <div className="flex flex-col items-center text-center">
       <div className="text-xs font-semibold mb-2" style={{ color: D.heroMuted }}>
         今のペースで資産が尽きる時期
       </div>
       <div className="text-[44px] font-extrabold leading-none mb-2" style={{ color: D.heroText }}>
         {assetRunwayDate}
       </div>
-      <div className="text-sm font-semibold" style={{ color: PATTERN_META.A.accent }}>
+      <div className="text-sm font-semibold" style={{ color: accent }}>
         残り約 <SpringNumber value={Math.round(assetRunwayDays / 30)} /> ヶ月
       </div>
       <div className="mt-5 grid grid-cols-2 gap-3 w-full max-w-xs">
         {[
-          { label: '総資産', value: yen(MOCK.totalAssets) },
+          { label: '総資産',    value: yen(MOCK.totalAssets) },
           { label: '純日次支出', value: yen(Math.round(MOCK.netDailyExpense)) },
         ].map((item, i) => (
           <motion.div
             key={item.label}
             className="rounded-2xl p-3 text-center"
-            style={{
-              background: 'rgba(255,255,255,0.09)',
-              border: '1px solid rgba(255,255,255,0.14)',
-            }}
-            variants={itemVariants(0.12 + i * 0.06)}
-            initial="hidden"
-            animate="visible"
+            style={{ background: 'rgba(255,255,255,0.09)', border: '1px solid rgba(255,255,255,0.14)' }}
+            {...staggerItem(i)}
           >
             <div className="text-[10px] mb-1" style={{ color: D.heroMuted }}>{item.label}</div>
             <div className="text-sm font-extrabold tabular-nums" style={{ color: D.heroText }}>{item.value}</div>
           </motion.div>
         ))}
       </div>
-    </motion.div>
+    </div>
   )
 }
 
-// ─── ヒーローカード：Pattern B ───────────────────────────────────────────
-function PatternBHero() {
+// ─── Pattern B ───────────────────────────────────────────────────────────
+function PatternBHero({ accent }: { accent: string }) {
   const isPositive = savingsDiff >= 0
   return (
-    <motion.div
-      className="flex flex-col items-center text-center"
-      variants={heroVariants}
-      initial="hidden"
-      animate="visible"
-      exit="exit"
-    >
+    <div className="flex flex-col items-center text-center">
       <div className="text-xs font-semibold mb-2" style={{ color: D.heroMuted }}>今月の貯蓄</div>
       <div className="text-[52px] font-extrabold leading-none tabular-nums mb-3" style={{ color: D.heroText }}>
         ¥<SpringNumber value={thisMonthSavings} />
@@ -222,8 +220,8 @@ function PatternBHero() {
       <div
         className="flex items-center gap-1.5 px-3 py-1 rounded-full text-sm font-bold"
         style={{
-          background: isPositive ? 'rgba(52,211,153,0.15)' : 'rgba(244,63,94,0.15)',
-          color: isPositive ? D.accentGreen : '#f87171',
+          background: isPositive ? 'rgba(53,181,162,0.16)' : 'rgba(244,63,94,0.16)',
+          color: isPositive ? accent : '#f87171',
         }}
       >
         {isPositive ? <TrendingUp size={14} /> : <TrendingDown size={14} />}
@@ -231,110 +229,79 @@ function PatternBHero() {
       </div>
       <div className="mt-5 grid grid-cols-2 gap-2.5 w-full max-w-xs">
         {[
-          { label: '月収', value: yen(MOCK.thisMonthIncome), accent: D.accentGreen },
-          { label: '今月支出', value: yen(MOCK.thisMonthExpense), accent: '#f87171' },
-          { label: '貯蓄率', value: `${savingsRate}%`, accent: PATTERN_META.B.accent },
-          { label: '先月の貯蓄', value: yen(lastMonthSavings), accent: D.heroMuted },
+          { label: '月収',      value: yen(MOCK.thisMonthIncome),  color: accent },
+          { label: '今月支出',  value: yen(MOCK.thisMonthExpense), color: '#f87171' },
+          { label: '貯蓄率',    value: `${savingsRate}%`,          color: accent },
+          { label: '先月の貯蓄', value: yen(lastMonthSavings),     color: D.heroMuted },
         ].map((item, i) => (
           <motion.div
             key={item.label}
             className="rounded-2xl p-3 text-center"
-            style={{
-              background: 'rgba(255,255,255,0.09)',
-              border: '1px solid rgba(255,255,255,0.14)',
-            }}
-            variants={itemVariants(0.12 + i * 0.05)}
-            initial="hidden"
-            animate="visible"
+            style={{ background: 'rgba(255,255,255,0.09)', border: '1px solid rgba(255,255,255,0.14)' }}
+            {...staggerItem(i)}
           >
             <div className="text-[10px] mb-1" style={{ color: D.heroMuted }}>{item.label}</div>
-            <div className="text-sm font-extrabold tabular-nums" style={{ color: item.accent }}>
-              {item.value}
-            </div>
+            <div className="text-sm font-extrabold tabular-nums" style={{ color: item.color }}>{item.value}</div>
           </motion.div>
         ))}
       </div>
-    </motion.div>
+    </div>
   )
 }
 
-// ─── ヒーローカード：Pattern C ───────────────────────────────────────────
-function PatternCHero() {
+// ─── Pattern C ───────────────────────────────────────────────────────────
+function PatternCHero({ accent }: { accent: string }) {
   const annualTarget = 1500000
-  const progressPct = Math.min(100, Math.round((annualSavingsPace / annualTarget) * 100))
+  const progressPct  = Math.min(100, Math.round((annualSavingsPace / annualTarget) * 100))
   return (
-    <motion.div
-      className="flex flex-col items-center text-center"
-      variants={heroVariants}
-      initial="hidden"
-      animate="visible"
-      exit="exit"
-    >
+    <div className="flex flex-col items-center text-center">
       <div className="text-xs font-semibold mb-2" style={{ color: D.heroMuted }}>このペースで年間</div>
       <div className="text-[44px] font-extrabold leading-none tabular-nums mb-1" style={{ color: D.heroText }}>
         ¥<SpringNumber value={annualSavingsPace} />
       </div>
       <div className="text-sm mb-5" style={{ color: D.heroMuted }}>貯蓄できます</div>
-
-      {/* 目標進捗バー */}
       <div className="w-full max-w-xs">
         <div className="flex justify-between text-xs mb-2">
           <span style={{ color: D.heroMuted }}>年間目標 {yen(annualTarget)}</span>
-          <span className="font-bold" style={{ color: PATTERN_META.C.accent }}>{progressPct}%</span>
+          <span className="font-bold" style={{ color: accent }}>{progressPct}%</span>
         </div>
-        <ProgressBar pct={progressPct} color={PATTERN_META.C.accent} height={8} />
+        <ProgressBar pct={progressPct} color={accent} height={8} />
       </div>
-
       <div className="mt-4 grid grid-cols-3 gap-2 w-full max-w-xs">
         {[
           { label: '今月の貯蓄', value: yen(thisMonthSavings) },
-          { label: '貯蓄率', value: `${savingsRate}%` },
+          { label: '貯蓄率',    value: `${savingsRate}%` },
           { label: '目標達成率', value: `${progressPct}%` },
         ].map((item, i) => (
           <motion.div
             key={item.label}
             className="rounded-2xl p-2.5 text-center"
-            style={{
-              background: 'rgba(255,255,255,0.09)',
-              border: '1px solid rgba(255,255,255,0.14)',
-            }}
-            variants={itemVariants(0.2 + i * 0.06)}
-            initial="hidden"
-            animate="visible"
+            style={{ background: 'rgba(255,255,255,0.09)', border: '1px solid rgba(255,255,255,0.14)' }}
+            {...staggerItem(i)}
           >
             <div className="text-[9px] mb-0.5" style={{ color: D.heroMuted }}>{item.label}</div>
             <div className="text-xs font-extrabold tabular-nums" style={{ color: D.heroText }}>{item.value}</div>
           </motion.div>
         ))}
       </div>
-    </motion.div>
+    </div>
   )
 }
 
-// ─── ヒーローカード：Pattern D ───────────────────────────────────────────
+// ─── Pattern D ───────────────────────────────────────────────────────────
 type ScoreTone = 'good' | 'ok' | 'bad'
-
-function scoreTone(s: number): ScoreTone {
-  return s >= 70 ? 'good' : s >= 40 ? 'ok' : 'bad'
-}
+function scoreTone(s: number): ScoreTone { return s >= 70 ? 'good' : s >= 40 ? 'ok' : 'bad' }
 function toneColor(t: ScoreTone) {
-  return t === 'good' ? D.accentGreen : t === 'ok' ? '#fbbf24' : '#f87171'
+  return t === 'good' ? D.income : t === 'ok' ? '#f59e0b' : D.danger
 }
 const TONE_LABELS: Record<ScoreTone, string> = { good: '良好', ok: '普通', bad: '要注意' }
 
 function PatternDHero() {
-  const tone = scoreTone(TOTAL_SCORE)
-  const color = toneColor(tone)
+  const tone   = scoreTone(TOTAL_SCORE)
+  const color  = toneColor(tone)
   const ToneIcon = tone === 'good' ? Shield : tone === 'ok' ? Target : AlertTriangle
-
   return (
-    <motion.div
-      className="flex flex-col items-center text-center"
-      variants={heroVariants}
-      initial="hidden"
-      animate="visible"
-      exit="exit"
-    >
+    <div className="flex flex-col items-center text-center">
       <div className="text-xs font-semibold mb-2" style={{ color: D.heroMuted }}>財政健全スコア</div>
       <div className="flex items-end gap-2 mb-2">
         <div className="text-[64px] font-extrabold leading-none tabular-nums" style={{ color }}>
@@ -349,46 +316,32 @@ function PatternDHero() {
         <ToneIcon size={14} />
         {TONE_LABELS[tone]}
       </div>
-
-      {/* スコア内訳バー */}
       <div className="w-full max-w-xs space-y-3">
         {SCORE_FACTORS.map((f, i) => {
           const t = scoreTone(f.score)
           const c = toneColor(t)
           return (
-            <motion.div
-              key={f.label}
-              variants={itemVariants(0.12 + i * 0.07)}
-              initial="hidden"
-              animate="visible"
-            >
+            <motion.div key={f.label} {...staggerItem(i)}>
               <div className="flex justify-between text-xs mb-1.5">
                 <span style={{ color: D.heroMuted }}>{f.label}</span>
                 <span className="font-bold tabular-nums" style={{ color: c }}>{f.score}</span>
               </div>
-              <ProgressBar pct={f.score} color={c} height={5} delay={0.18 + i * 0.07} />
+              <ProgressBar pct={f.score} color={c} height={5} delay={0.15 + i * 0.07} />
             </motion.div>
           )
         })}
       </div>
-    </motion.div>
+    </div>
   )
 }
 
 // ─── Meta アコーディオン ──────────────────────────────────────────────────
 function MetaAccordion({
-  pros,
-  cons,
-  data,
-  warning,
+  pros, cons, data, warning,
 }: {
-  pros: string[]
-  cons: string[]
-  data: string[]
-  warning?: string
+  pros: string[]; cons: string[]; data: string[]; warning?: string
 }) {
   const [open, setOpen] = useState(false)
-
   return (
     <div>
       <motion.button
@@ -410,31 +363,18 @@ function MetaAccordion({
             transition={SPRING.QUICK}
             className="overflow-hidden"
           >
-            <div
-              className="pb-4 pt-3 space-y-3 border-t"
-              style={{ borderColor: D.border }}
-            >
+            <div className="pb-4 pt-3 space-y-3 border-t" style={{ borderColor: D.border }}>
               {warning && (
                 <div
                   className="flex items-start gap-2 rounded-xl px-3 py-2.5 text-xs"
-                  style={{
-                    background: '#fff8f0',
-                    border: `1px solid ${D.brand}30`,
-                    color: D.text + 'cc',
-                  }}
+                  style={{ background: '#fff8f0', border: `1px solid ${D.brand}30`, color: D.text + 'cc' }}
                 >
-                  <AlertTriangle
-                    size={12}
-                    style={{ color: D.brand, flexShrink: 0, marginTop: 1 }}
-                  />
+                  <AlertTriangle size={12} style={{ color: D.brand, flexShrink: 0, marginTop: 1 }} />
                   {warning}
                 </div>
               )}
               <div>
-                <div
-                  className="mb-1.5 text-[10px] font-bold uppercase tracking-wider"
-                  style={{ color: D.muted }}
-                >
+                <div className="mb-1.5 text-[10px] font-bold uppercase tracking-wider" style={{ color: D.muted }}>
                   得られる情報
                 </div>
                 <ul className="space-y-1">
@@ -449,17 +389,13 @@ function MetaAccordion({
                 <div>
                   <div className="mb-1 text-[10px] font-bold" style={{ color: D.income }}>メリット</div>
                   <ul className="space-y-0.5">
-                    {pros.map((p, i) => (
-                      <li key={i} className="text-xs" style={{ color: D.text + 'bb' }}>✓ {p}</li>
-                    ))}
+                    {pros.map((p, i) => <li key={i} className="text-xs" style={{ color: D.text + 'bb' }}>✓ {p}</li>)}
                   </ul>
                 </div>
                 <div>
                   <div className="mb-1 text-[10px] font-bold" style={{ color: D.danger }}>デメリット</div>
                   <ul className="space-y-0.5">
-                    {cons.map((c, i) => (
-                      <li key={i} className="text-xs" style={{ color: D.text + 'bb' }}>✗ {c}</li>
-                    ))}
+                    {cons.map((c, i) => <li key={i} className="text-xs" style={{ color: D.text + 'bb' }}>✗ {c}</li>)}
                   </ul>
                 </div>
               </div>
@@ -471,17 +407,9 @@ function MetaAccordion({
   )
 }
 
-// ─── パターンメタデータ ────────────────────────────────────────────────────
-const PATTERN_DETAILS: Record<
-  PatternId,
-  { pros: string[]; cons: string[]; data: string[]; warning?: string }
-> = {
+const PATTERN_DETAILS: Record<PatternId, { pros: string[]; cons: string[]; data: string[]; warning?: string }> = {
   A: {
-    data: [
-      '今の純支出ペースが続いた場合の資産枯渇時期',
-      '総資産 ÷ (平均日次支出 − 月収÷30) で算出',
-      '資産が「減っているか」の長期サイン',
-    ],
+    data: ['今の純支出ペースが続いた場合の資産枯渇時期', '総資産 ÷ (平均日次支出 − 月収÷30) で算出', '資産が「減っているか」の長期サイン'],
     pros: ['長期的な危機感を持てる', '資産と支出の関係が可視化される'],
     cons: ['定収入があると ∞ になりやすい', '「尽きる」という表現がネガティブ', '月収変動で大きくブレる'],
     warning: '定収入がある人は純日次支出がほぼ 0 になり「∞」表示になりやすい。その場合この指標は無意味。',
@@ -494,55 +422,53 @@ const PATTERN_DETAILS: Record<
   C: {
     data: ['今月のペースで年換算した貯蓄額', '年間目標との達成率', '貯蓄率（手取りに対する比率）'],
     pros: ['前向きな目標感が生まれる', '「年間○○万貯める」という計画に使える'],
-    cons: [
-      '1 ヶ月データで年換算するのは精度が低い',
-      '目標設定が必要（オンボーディング負荷）',
-      'ボーナス月などで大きくブレる',
-    ],
-    warning:
-      '今月の貯蓄が少ない月に見ると不安になりやすい。直近 3〜6 ヶ月平均の方が安定する。',
+    cons: ['1 ヶ月データで年換算するのは精度が低い', '目標設定が必要（オンボーディング負荷）', 'ボーナス月などで大きくブレる'],
+    warning: '今月の貯蓄が少ない月に見ると不安になりやすい。直近 3〜6 ヶ月平均の方が安定する。',
   },
   D: {
-    data: [
-      '複数の財政指標を統合した総合スコア（0〜100）',
-      '内訳: 予算遵守率・貯蓄率・支出トレンドの加重平均',
-      '各指標の個別スコアと改善ポイント',
-    ],
+    data: ['複数の財政指標を統合した総合スコア（0〜100）', '内訳: 予算遵守率・貯蓄率・支出トレンドの加重平均', '各指標の個別スコアと改善ポイント'],
     pros: ['単一の数値でわかりやすい', '改善すべき要因が内訳で確認できる', 'ゲーム感覚でモチベーション維持'],
     cons: ['スコアの根拠が不透明に感じられる', '重みの設定が恣意的', '実装コストが高い'],
     warning: 'スコアの算出ロジックを開示しないとブラックボックス感が強い。「なぜ 55 点か」を説明できる設計が必要。',
   },
 }
 
-const HERO_COMPONENTS: Record<PatternId, () => React.JSX.Element> = {
-  A: PatternAHero,
-  B: PatternBHero,
-  C: PatternCHero,
-  D: PatternDHero,
-}
-
 // ─── メインページ ────────────────────────────────────────────────────────
 export function AssetOutlookABPrototype() {
-  const [active, setActive] = useState<PatternId>('B')
-  const accent = PATTERN_META[active].accent
-  const HeroContent = HERO_COMPONENTS[active]
+  const [active, setActive]     = useState<PatternId>('B')
+  const [direction, setDirection] = useState(0) // 正 = 次へ（左スワイプ）、負 = 前へ
+
+  const activeIdx = PATTERNS.indexOf(active)
+  const accent    = PATTERN_META[active].accent
+
+  function goToIdx(nextIdx: number) {
+    if (nextIdx < 0 || nextIdx >= PATTERNS.length) return
+    setDirection(nextIdx > activeIdx ? 1 : -1)
+    setActive(PATTERNS[nextIdx])
+  }
+
+  function handleDragEnd(_: MouseEvent | TouchEvent | PointerEvent, info: PanInfo) {
+    const threshold = 40
+    if (info.offset.x < -threshold) goToIdx(activeIdx + 1)
+    else if (info.offset.x > threshold) goToIdx(activeIdx - 1)
+  }
+
+  // パターンコンポーネントのマッピング
+  const heroMap: Record<PatternId, React.ReactNode> = {
+    A: <PatternAHero accent={accent} />,
+    B: <PatternBHero accent={accent} />,
+    C: <PatternCHero accent={accent} />,
+    D: <PatternDHero />,
+  }
 
   return (
     <div className="min-h-screen pb-16" style={{ background: D.bg }}>
       {/* ヘッダー */}
       <div
         className="sticky top-0 z-10 flex h-12 items-center gap-3 border-b px-4"
-        style={{
-          background: `${D.bg}ee`,
-          backdropFilter: 'blur(12px)',
-          borderColor: 'rgba(28,20,16,0.10)',
-        }}
+        style={{ background: `${D.bg}ee`, backdropFilter: 'blur(12px)', borderColor: 'rgba(28,20,16,0.10)' }}
       >
-        <Link
-          to="/"
-          className="flex items-center gap-1 text-xs font-semibold"
-          style={{ color: D.brand }}
-        >
+        <Link to="/" className="flex items-center gap-1 text-xs font-semibold" style={{ color: D.brand }}>
           <ChevronLeft size={14} />ギャラリー
         </Link>
         <span className="text-sm font-extrabold" style={{ color: D.text }}>
@@ -555,10 +481,7 @@ export function AssetOutlookABPrototype() {
         {/* ヒーローカード */}
         <motion.div
           className="relative rounded-3xl overflow-hidden mb-4"
-          style={{
-            background: D.heroBg,
-            boxShadow: '0 8px 40px rgba(30,26,58,0.35)',
-          }}
+          style={{ background: D.heroBg, boxShadow: '0 8px 40px rgba(26,12,4,0.40)' }}
           initial={{ opacity: 0, y: 24, filter: 'blur(10px)' }}
           animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
           transition={SPRING.SMOOTH}
@@ -567,73 +490,83 @@ export function AssetOutlookABPrototype() {
           <motion.div
             className="absolute rounded-full pointer-events-none"
             style={{
-              width: 240,
-              height: 240,
+              width: 220,
+              height: 220,
               top: -80,
-              right: -80,
-              background: `radial-gradient(circle, ${accent}28 0%, transparent 70%)`,
+              right: -70,
+              background: `radial-gradient(circle, ${accent}22 0%, transparent 70%)`,
             }}
             animate={{ opacity: [0.7, 1, 0.7] }}
             transition={{ duration: 4, repeat: Infinity, ease: 'easeInOut' }}
           />
 
-          {/* タブスイッチャー */}
-          <div className="flex gap-1 p-3 pb-0">
-            {(['A', 'B', 'C', 'D'] as PatternId[]).map((id) => (
-              <motion.button
-                key={id}
-                className="relative flex-1 py-1.5 text-xs font-bold rounded-xl"
-                style={{ color: active === id ? D.heroText : D.heroMuted }}
-                onClick={() => setActive(id)}
-                whileTap={{ scale: 0.92 }}
-                transition={SPRING.SNAP}
-              >
-                {active === id && (
-                  <motion.div
-                    layoutId="tab-hero-bg"
-                    className="absolute inset-0 rounded-xl"
-                    style={{ background: 'rgba(255,255,255,0.16)' }}
-                    transition={SPRING.QUICK}
-                  />
-                )}
-                <span className="relative z-10">{id}</span>
-              </motion.button>
-            ))}
-          </div>
-
-          {/* パターン名 */}
-          <div className="px-5 pt-3 pb-1">
+          {/* パターン名 + スワイプヒント */}
+          <div className="px-5 pt-4 pb-1 flex items-center justify-between">
             <AnimatePresence mode="wait">
               <motion.div
                 key={`name-${active}`}
-                className="text-[10px] font-bold uppercase tracking-wider"
+                className="text-[11px] font-bold uppercase tracking-wider"
                 style={{ color: accent }}
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
+                initial={{ opacity: 0, x: direction > 0 ? 12 : -12 }}
+                animate={{ opacity: 1, x: 0 }}
                 exit={{ opacity: 0 }}
-                transition={{ duration: 0.15 }}
+                transition={{ duration: 0.16 }}
               >
                 Pattern {active} — {PATTERN_META[active].name}
               </motion.div>
             </AnimatePresence>
+            <div className="text-[10px]" style={{ color: 'rgba(255,255,255,0.28)' }}>
+              ← スワイプ →
+            </div>
           </div>
 
-          {/* ヒーローコンテンツ */}
-          <div className="px-5 pt-3 pb-7">
-            <AnimatePresence mode="wait">
-              <HeroContent key={active} />
+          {/* スワイプ領域 */}
+          <motion.div
+            drag="x"
+            dragConstraints={{ left: 0, right: 0 }}
+            dragElastic={0.06}
+            onDragEnd={handleDragEnd}
+            className="px-5 pt-3 pb-5 select-none"
+            style={{ touchAction: 'pan-y', cursor: 'grab' }}
+            whileDrag={{ cursor: 'grabbing' }}
+          >
+            <AnimatePresence mode="wait" custom={direction}>
+              <motion.div
+                key={active}
+                custom={direction}
+                variants={slideVariants}
+                initial="enter"
+                animate="center"
+                exit="exit"
+              >
+                {heroMap[active]}
+              </motion.div>
             </AnimatePresence>
+          </motion.div>
+
+          {/* ドットインジケーター */}
+          <div className="flex justify-center gap-2 pb-4">
+            {PATTERNS.map((id, i) => (
+              <motion.button
+                key={id}
+                onClick={() => goToIdx(i)}
+                style={{
+                  height: 6,
+                  borderRadius: 9999,
+                  background: active === id ? accent : 'rgba(255,255,255,0.28)',
+                }}
+                animate={{ width: active === id ? 20 : 6 }}
+                transition={SPRING.QUICK}
+                layout
+              />
+            ))}
           </div>
         </motion.div>
 
         {/* 詳細カード */}
         <motion.div
           className="rounded-2xl border px-4"
-          style={{
-            background: D.card,
-            borderColor: D.border,
-            boxShadow: D.shadow,
-          }}
+          style={{ background: D.card, borderColor: D.border, boxShadow: D.shadow }}
           initial={{ opacity: 0, y: 12 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ ...SPRING.SMOOTH, delay: 0.08 }}
@@ -667,36 +600,25 @@ export function AssetOutlookABPrototype() {
               <thead>
                 <tr style={{ borderBottom: `1px solid ${D.border}` }}>
                   {['', 'A: ランウェイ', 'B: 貯蓄額', 'C: 年間ペース', 'D: スコア'].map((h) => (
-                    <th
-                      key={h}
-                      className="py-2 px-3 text-left font-bold whitespace-nowrap"
-                      style={{ color: D.muted }}
-                    >
-                      {h}
-                    </th>
+                    <th key={h} className="py-2 px-3 text-left font-bold whitespace-nowrap" style={{ color: D.muted }}>{h}</th>
                   ))}
                 </tr>
               </thead>
               <tbody>
                 {[
-                  { label: '対象', vals: ['資産取り崩し中', '定収入・貯蓄', '年間目標あり', '総合管理'] },
-                  { label: '直感的さ', vals: ['△', '◎', '○', '○'] },
+                  { label: '対象',      vals: ['資産取り崩し中', '定収入・貯蓄', '年間目標あり', '総合管理'] },
+                  { label: '直感的さ',  vals: ['△', '◎', '○', '○'] },
                   { label: '実装コスト', vals: ['中', '低', '低〜中', '高'] },
                 ].map((row) => (
                   <tr key={row.label} style={{ borderBottom: `1px solid ${D.border}` }}>
-                    <td
-                      className="py-2 px-3 font-semibold whitespace-nowrap"
-                      style={{ color: D.muted }}
-                    >
-                      {row.label}
-                    </td>
+                    <td className="py-2 px-3 font-semibold whitespace-nowrap" style={{ color: D.muted }}>{row.label}</td>
                     {row.vals.map((v, i) => (
                       <td
                         key={i}
                         className="py-2 px-3 whitespace-nowrap"
                         style={{
                           color: D.text,
-                          fontWeight: (['A', 'B', 'C', 'D'] as PatternId[])[i] === active ? 700 : 400,
+                          fontWeight: (PATTERNS[i]) === active ? 700 : 400,
                         }}
                       >
                         {v}
@@ -711,18 +633,10 @@ export function AssetOutlookABPrototype() {
 
         {/* ナビ */}
         <div className="mt-6 flex items-center justify-between text-xs" style={{ color: D.muted }}>
-          <Link
-            to="/category-ab"
-            style={{ color: D.brand }}
-            className="font-semibold hover:underline"
-          >
+          <Link to="/category-ab" style={{ color: D.brand }} className="font-semibold hover:underline">
             ← カテゴリ TOP A/B
           </Link>
-          <Link
-            to="/home-v4"
-            style={{ color: D.brand }}
-            className="font-semibold hover:underline"
-          >
+          <Link to="/home-v4" style={{ color: D.brand }} className="font-semibold hover:underline">
             V4 ダッシュボードへ →
           </Link>
         </div>

--- a/apps/sandbox/src/pages/HomeV4Prototype.tsx
+++ b/apps/sandbox/src/pages/HomeV4Prototype.tsx
@@ -258,7 +258,7 @@ function ProgressBar({
 function Numpad({ onKey }: { onKey: (k: string) => void }) {
     const keys = ["1","2","3","4","5","6","7","8","9","000","0","⌫"];
     return (
-        <div className="grid grid-cols-3 gap-2">
+        <div className="grid grid-cols-3 gap-1.5">
             {keys.map((k) => (
                 <motion.button
                     key={k}
@@ -266,7 +266,7 @@ function Numpad({ onKey }: { onKey: (k: string) => void }) {
                     onClick={() => onKey(k)}
                     whileTap={{ scale: 0.84 }}
                     transition={SPRING.snap}
-                    className="flex h-14 items-center justify-center text-[18px] font-semibold tap-highlight select-none"
+                    className="flex h-10 items-center justify-center text-[16px] font-semibold tap-highlight select-none"
                     style={{
                         borderRadius: R.inner,
                         background:   k === "⌫" ? "#fff0ea" : C.card,
@@ -1084,8 +1084,9 @@ export function HomeV4Prototype() {
                                 <input
                                     value={noteText}
                                     onChange={(e) => setNoteText(e.target.value)}
-                                    className="flex h-10 w-full px-3 text-sm outline-none transition-colors"
+                                    className="flex h-10 w-full px-3 outline-none transition-colors"
                                     style={{
+                                        fontSize:     '16px', // iOS Safari ズーム抑制（16px 未満でズーム発生）
                                         border:       `1.5px solid ${noteText ? C.brand : C.border}`,
                                         borderRadius: R.input,
                                         background:   noteText ? C.brandLight : C.bg,

--- a/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
+++ b/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
@@ -122,8 +122,8 @@ function NumberRow({
                 if (e.key === 'Enter') (e.target as HTMLInputElement).blur()
                 if (e.key === 'Escape') setEditing(false)
               }}
-              className="w-32 text-sm font-bold outline-none border-b-2 bg-transparent tabular-nums"
-              style={{ color: D.text, borderColor: D.brand }}
+              className="w-32 font-bold outline-none border-b-2 bg-transparent tabular-nums"
+              style={{ fontSize: '16px', color: D.text, borderColor: D.brand }}
               step={step}
               min={0}
             />


### PR DESCRIPTION
## Summary

- **#288 AssetOutlookAB スワイプ化・ブランドカラー統一**: タブボタンを廃止してドットインジケーターに変更。framer-motion `drag="x"` + `onDragEnd` でスワイプ切り替え実装。方向対応のスライドアニメーション（`AnimatePresence custom={direction}`）。ヒーローカードをブランドウォームダークブラウン（#1a0c04 〜 #2c1608）に変更し、アクセントをオレンジ / ティールに統一
- **#289 テンキー縮小・iOS zoom 抑制**: Numpad キーを `h-14`(56px) → `h-10`(40px) に縮小。登録ボタンが初期表示で見えるように。メモ入力・PersonalSettings の数値入力に `fontSize: 16px` を設定し iOS Safari の自動ズームを抑制

## Changed Files

| ファイル | 変更内容 |
|---------|---------|
| `AssetOutlookABPrototype.tsx` | スワイプ + ドット + ブランドカラー |
| `HomeV4Prototype.tsx` | テンキー縮小 + iOS zoom 修正 |
| `PersonalSettingsPrototype.tsx` | iOS zoom 修正 |

## Test plan

- [ ] `/asset-outlook-ab` でスワイプ左右でパターンが切り替わる
- [ ] ドットインジケーターがアクティブパターンを反映する
- [ ] タブボタンが表示されていない
- [ ] `/home-v4` でドロワーを開いたとき登録ボタンが初期表示で見える
- [ ] テンキーが適切なサイズに縮小されている
- [ ] メモ入力でiOS Safariがズームしない（fontSize 16px）

Closes #288
Closes #289
Sprint: 18

🤖 Generated with [Claude Code](https://claude.com/claude-code)