### PR TITLE
feat: Sandbox ナビゲーション改善・カテゴリ選択 A/B/C・リロードバグ修正

### DIFF
--- a/.github/velocity-log.json
+++ b/.github/velocity-log.json
@@ -15,8 +15,8 @@
       "chore"
     ],
     "pbi_type_rules": "fix:/bug: prefix → fix / type:tech-debt label → tech-debt / type:chore or design label → chore / otherwise → feature",
-    "initial_velocity_estimate": 6,
-    "note": "initial_velocity_estimate は仮設定値（1作業日 ≈ 6pt）。実績を蓄積しながら調整する。",
+    "initial_velocity_estimate": 9,
+    "note": "Sprint #13-18 実績分析により 6pt → 9pt に改定（2026-05-15）。直近3スプリント平均 5.3pt・ピーク 8pt（Sprint #17）。AI 実装サイクルは推定の 1/10 以下で完了しており、M×3 + S×1 程度が 1 スプリントの適切な上限。上限超過時はユーザーに確認して分割する。",
     "next_sprint_number": 20
   },
   "sprints": [

--- a/apps/sandbox/src/components/SandboxNav.tsx
+++ b/apps/sandbox/src/components/SandboxNav.tsx
@@ -1,0 +1,164 @@
+/**
+ * SandboxNav — Sandbox 全ページ共通フローティングナビ
+ *
+ * プロトタイプページの左下に固定表示される薄型ナビバー。
+ * - ギャラリーへ戻る
+ * - 前後プロトタイプへ移動
+ * プロトタイプ本体のレイアウトを妨げないよう最小化可能。
+ */
+
+import { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { LayoutGrid, ChevronLeft, ChevronRight, ChevronDown, ChevronUp } from 'lucide-react'
+
+// Gallery.tsx の prototypes 配列と同期させる（SSOT ではないが Sandbox 内限定）
+const PAGES: { path: string; label: string }[] = [
+  { path: '/bottom-nav',              label: 'ボトムナビゲーション' },
+  { path: '/quick-entry',             label: 'クイック入力フォーム' },
+  { path: '/nav-layout',              label: 'ナビゲーション統合レイアウト' },
+  { path: '/account-section',         label: 'アカウントセクション' },
+  { path: '/onboarding',              label: 'オンボーディングウィザード' },
+  { path: '/calendar-page',           label: 'カレンダーページ刷新' },
+  { path: '/daily-budget-card',       label: '今日使えるお金カード' },
+  { path: '/daily-budget-card-palette', label: 'カラーパレット比較' },
+  { path: '/home-v3',                 label: 'ホーム V3' },
+  { path: '/home-v4',                 label: 'ホーム V4' },
+  { path: '/category-ab',             label: '支出カテゴリ TOP A/B' },
+  { path: '/category-input-ab',       label: 'カテゴリ選択 A/B/C' },
+  { path: '/asset-outlook-ab',        label: '長期指標 A/B' },
+  { path: '/recent-records-ab',       label: '最近の記録 A/B' },
+  { path: '/personal-settings',       label: '個人設定画面' },
+]
+
+export function SandboxNav() {
+  const { pathname } = useLocation()
+  const [open, setOpen] = useState(false)
+
+  // ギャラリー自体では表示しない
+  if (pathname === '/') return null
+
+  const currentIdx = PAGES.findIndex((p) => p.path === pathname)
+  const current = PAGES[currentIdx]
+  const prev = currentIdx > 0 ? PAGES[currentIdx - 1] : null
+  const next = currentIdx < PAGES.length - 1 ? PAGES[currentIdx + 1] : null
+
+  return (
+    <div
+      className="fixed bottom-4 left-3 z-50 flex flex-col items-start gap-1"
+      style={{ pointerEvents: 'none' }}
+    >
+      {/* ページ一覧ドロップアップ */}
+      {open && (
+        <div
+          className="mb-1 rounded-xl border py-1 shadow-lg"
+          style={{
+            background: 'rgba(255,253,245,0.97)',
+            backdropFilter: 'blur(12px)',
+            border: '1px solid rgba(28,20,16,0.10)',
+            boxShadow: '0 8px 24px rgba(28,20,16,0.14)',
+            pointerEvents: 'auto',
+            maxHeight: '60vh',
+            overflowY: 'auto',
+            minWidth: 200,
+          }}
+        >
+          {PAGES.map((p) => (
+            <Link
+              key={p.path}
+              to={p.path}
+              onClick={() => setOpen(false)}
+              className="flex items-center gap-2 px-3 py-2 text-xs font-semibold transition-colors hover:bg-[#fff6ee]"
+              style={{
+                color: p.path === pathname ? '#f18840' : 'rgba(28,20,16,0.7)',
+              }}
+            >
+              {p.path === pathname && (
+                <span
+                  className="h-1.5 w-1.5 rounded-full shrink-0"
+                  style={{ background: '#f18840' }}
+                />
+              )}
+              {p.path !== pathname && <span className="h-1.5 w-1.5 rounded-full shrink-0" />}
+              {p.label}
+            </Link>
+          ))}
+        </div>
+      )}
+
+      {/* コントロールバー */}
+      <div
+        className="flex items-center gap-1 rounded-full px-2 py-1.5"
+        style={{
+          background: 'rgba(28,20,16,0.72)',
+          backdropFilter: 'blur(10px)',
+          boxShadow: '0 2px 8px rgba(28,20,16,0.25)',
+          pointerEvents: 'auto',
+        }}
+      >
+        {/* ギャラリーへ */}
+        <Link
+          to="/"
+          title="ギャラリーへ戻る"
+          className="flex h-6 w-6 items-center justify-center rounded-full transition-colors hover:bg-white/20"
+        >
+          <LayoutGrid size={13} className="text-white" />
+        </Link>
+
+        <span
+          className="mx-0.5 text-white/20 text-xs select-none"
+          aria-hidden="true"
+        >|</span>
+
+        {/* 前へ */}
+        {prev ? (
+          <Link
+            to={prev.path}
+            title={prev.label}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-colors hover:bg-white/20"
+          >
+            <ChevronLeft size={13} className="text-white" />
+          </Link>
+        ) : (
+          <span className="flex h-6 w-6 items-center justify-center opacity-20">
+            <ChevronLeft size={13} className="text-white" />
+          </span>
+        )}
+
+        {/* 現在ページ名 + ドロップアップトグル */}
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="flex items-center gap-1 rounded-full px-2 transition-colors hover:bg-white/20"
+          style={{ maxWidth: 120 }}
+        >
+          <span
+            className="truncate text-[11px] font-bold text-white"
+            style={{ maxWidth: 90 }}
+          >
+            {current?.label ?? pathname}
+          </span>
+          {open ? (
+            <ChevronDown size={11} className="shrink-0 text-white/70" />
+          ) : (
+            <ChevronUp size={11} className="shrink-0 text-white/70" />
+          )}
+        </button>
+
+        {/* 次へ */}
+        {next ? (
+          <Link
+            to={next.path}
+            title={next.label}
+            className="flex h-6 w-6 items-center justify-center rounded-full transition-colors hover:bg-white/20"
+          >
+            <ChevronRight size={13} className="text-white" />
+          </Link>
+        ) : (
+          <span className="flex h-6 w-6 items-center justify-center opacity-20">
+            <ChevronRight size={13} className="text-white" />
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import { Gallery } from './pages/Gallery'
+import { SandboxNav } from './components/SandboxNav'
 import { BottomNavPrototype } from './pages/BottomNavPrototype'
 import { QuickEntryPrototype } from './pages/QuickEntryPrototype'
 import { NavLayoutPrototype } from './pages/NavLayoutPrototype'
@@ -17,10 +18,13 @@ import { CategoryTopABPrototype } from './pages/CategoryTopABPrototype'
 import { AssetOutlookABPrototype } from './pages/AssetOutlookABPrototype'
 import { RecentRecordsABPrototype } from './pages/RecentRecordsABPrototype'
 import { PersonalSettingsPrototype } from './pages/PersonalSettingsPrototype'
+import { NotificationsPrototype } from './pages/NotificationsPrototype'
+import { CategoryInputABPrototype } from './pages/CategoryInputABPrototype'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
+      <SandboxNav />
       <Routes>
         <Route path="/" element={<Gallery />} />
         <Route path="/bottom-nav" element={<BottomNavPrototype />} />
@@ -37,6 +41,8 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/asset-outlook-ab" element={<AssetOutlookABPrototype />} />
         <Route path="/recent-records-ab" element={<RecentRecordsABPrototype />} />
         <Route path="/personal-settings" element={<PersonalSettingsPrototype />} />
+        <Route path="/notifications" element={<NotificationsPrototype />} />
+        <Route path="/category-input-ab" element={<CategoryInputABPrototype />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/apps/sandbox/src/pages/CategoryInputABPrototype.tsx
+++ b/apps/sandbox/src/pages/CategoryInputABPrototype.tsx
@@ -1,0 +1,356 @@
+/**
+ * CategoryInputABPrototype — カテゴリ選択UI A/B/C デザインパターン比較
+ *
+ * HomeV4 ドロワーのカテゴリ選択を3パターンで比較。
+ * - Pattern A: 現行グリッド改（4列、選択時アクティブ強調）
+ * - Pattern B: リスト型（縦スクロール、アイコン+ラベル+説明）
+ * - Pattern C: スクロールチップ（横スクロール式ピル型）
+ */
+
+import { useState } from 'react'
+import { motion, AnimatePresence } from 'framer-motion'
+import {
+  ShoppingBasket, ShoppingBag, Car, Zap, Smile, HeartPulse, Tag, Check,
+} from 'lucide-react'
+
+// ─── デザイントークン ────────────────────────────────────────────────────────
+
+const C = {
+  bg:         '#f5f3ef',
+  card:       '#ffffff',
+  text:       '#1c1410',
+  muted:      'rgba(28,20,16,0.45)',
+  border:     'rgba(28,20,16,0.08)',
+  brand:      '#f18840',
+  brandLight: '#fff6ee',
+  brandDeep:  '#e8622a',
+} as const
+
+const SPRING = {
+  snap:  { type: 'spring', stiffness: 600, damping: 35 } as const,
+  quick: { type: 'spring', stiffness: 400, damping: 30 } as const,
+  base:  { type: 'spring', stiffness: 300, damping: 28 } as const,
+} as const
+
+// ─── カテゴリ定義 ─────────────────────────────────────────────────────────────
+
+type Category = {
+  id: string
+  label: string
+  icon: React.ElementType
+  color: string
+  bgLight: string
+  desc: string
+}
+
+const CATEGORIES: Category[] = [
+  { id: 'food',       label: '食費',   icon: ShoppingBasket, color: '#f18840', bgLight: '#fff6ee', desc: 'スーパー・外食・カフェ' },
+  { id: 'daily',      label: '日用品', icon: ShoppingBag,    color: '#a855f7', bgLight: '#faf5ff', desc: '洗剤・消耗品など' },
+  { id: 'transport',  label: '交通費', icon: Car,            color: '#3b82f6', bgLight: '#eff6ff', desc: '電車・バス・タクシー' },
+  { id: 'utilities',  label: '光熱費', icon: Zap,            color: '#eab308', bgLight: '#fefce8', desc: '電気・ガス・水道' },
+  { id: 'fun',        label: '娯楽費', icon: Smile,          color: '#ec4899', bgLight: '#fdf2f8', desc: '映画・趣味など' },
+  { id: 'medical',    label: '医療費', icon: HeartPulse,     color: '#ef4444', bgLight: '#fef2f2', desc: '病院・薬局など' },
+  { id: 'other',      label: 'その他', icon: Tag,            color: '#6b7280', bgLight: '#f9fafb', desc: '分類なし' },
+]
+
+// ─── Pattern A — 4列グリッド ─────────────────────────────────────────────────
+
+function PatternA({ selected, onSelect }: { selected: string; onSelect: (id: string) => void }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-bold" style={{ color: C.muted }}>カテゴリ</p>
+      <div className="grid grid-cols-4 gap-2">
+        {CATEGORIES.map((cat) => {
+          const Icon = cat.icon
+          const active = selected === cat.id
+          return (
+            <motion.button
+              key={cat.id}
+              type="button"
+              onClick={() => onSelect(cat.id)}
+              whileTap={{ scale: 0.88 }}
+              transition={SPRING.snap}
+              className="flex flex-col items-center gap-1 rounded-xl py-2.5 px-1 text-[11px] font-semibold relative"
+              style={{
+                background: active ? cat.bgLight : C.card,
+                border: `1.5px solid ${active ? cat.color : C.border}`,
+                color: active ? cat.color : C.muted,
+              }}
+            >
+              {active && (
+                <motion.span
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  transition={SPRING.quick}
+                  className="absolute -top-1.5 -right-1.5 h-4 w-4 flex items-center justify-center rounded-full"
+                  style={{ background: cat.color }}
+                >
+                  <Check size={9} className="text-white" strokeWidth={3} />
+                </motion.span>
+              )}
+              <Icon size={18} style={{ color: active ? cat.color : C.muted }} />
+              {cat.label}
+            </motion.button>
+          )
+        })}
+      </div>
+      <div className="mt-3 rounded-xl border p-3 text-xs" style={{ background: '#f9fafb', borderColor: C.border }}>
+        <p className="font-bold mb-0.5" style={{ color: C.text }}>Pattern A メリット</p>
+        <p style={{ color: C.muted }}>一覧性が高く視認しやすい。アクティブ状態をボーダー+バッジで明示。7カテゴリが全て見える。</p>
+        <p className="font-bold mt-1.5 mb-0.5" style={{ color: C.text }}>デメリット</p>
+        <p style={{ color: C.muted }}>カテゴリが増えると折り返しが多くなる。4列目が1つだけになると不均衡に見える。</p>
+      </div>
+    </div>
+  )
+}
+
+// ─── Pattern B — 縦リスト型 ─────────────────────────────────────────────────
+
+function PatternB({ selected, onSelect }: { selected: string; onSelect: (id: string) => void }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-bold" style={{ color: C.muted }}>カテゴリ</p>
+      <div className="flex flex-col gap-1.5">
+        {CATEGORIES.map((cat) => {
+          const Icon = cat.icon
+          const active = selected === cat.id
+          return (
+            <motion.button
+              key={cat.id}
+              type="button"
+              onClick={() => onSelect(cat.id)}
+              whileTap={{ scale: 0.98 }}
+              transition={SPRING.snap}
+              className="flex items-center gap-3 rounded-xl px-3 py-2.5 text-left"
+              style={{
+                background: active ? cat.bgLight : C.card,
+                border: `1.5px solid ${active ? cat.color : C.border}`,
+              }}
+            >
+              <div
+                className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+                style={{ background: cat.bgLight }}
+              >
+                <Icon size={17} style={{ color: cat.color }} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <p className="text-[13px] font-bold leading-none" style={{ color: active ? cat.color : C.text }}>
+                  {cat.label}
+                </p>
+                <p className="mt-0.5 text-[11px]" style={{ color: C.muted }}>
+                  {cat.desc}
+                </p>
+              </div>
+              {active && (
+                <motion.div
+                  initial={{ scale: 0 }}
+                  animate={{ scale: 1 }}
+                  transition={SPRING.quick}
+                  className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full"
+                  style={{ background: cat.color }}
+                >
+                  <Check size={11} className="text-white" strokeWidth={3} />
+                </motion.div>
+              )}
+            </motion.button>
+          )
+        })}
+      </div>
+      <div className="mt-3 rounded-xl border p-3 text-xs" style={{ background: '#f9fafb', borderColor: C.border }}>
+        <p className="font-bold mb-0.5" style={{ color: C.text }}>Pattern B メリット</p>
+        <p style={{ color: C.muted }}>説明テキストで用途が明確。タップ領域が広くミスタップしにくい。スクリーンリーダーにも対応しやすい。</p>
+        <p className="font-bold mt-1.5 mb-0.5" style={{ color: C.text }}>デメリット</p>
+        <p style={{ color: C.muted }}>縦に長くなりドロワーのスクロールが必要。カテゴリを一目で比較しにくい。</p>
+      </div>
+    </div>
+  )
+}
+
+// ─── Pattern C — 横スクロールチップ ─────────────────────────────────────────
+
+function PatternC({ selected, onSelect }: { selected: string; onSelect: (id: string) => void }) {
+  return (
+    <div>
+      <p className="mb-1.5 text-xs font-bold" style={{ color: C.muted }}>カテゴリ</p>
+      <div
+        className="flex gap-2 overflow-x-auto pb-2"
+        style={{ scrollbarWidth: 'none', WebkitOverflowScrolling: 'touch' }}
+      >
+        {CATEGORIES.map((cat) => {
+          const Icon = cat.icon
+          const active = selected === cat.id
+          return (
+            <motion.button
+              key={cat.id}
+              type="button"
+              onClick={() => onSelect(cat.id)}
+              whileTap={{ scale: 0.90 }}
+              transition={SPRING.snap}
+              className="flex shrink-0 items-center gap-1.5 rounded-full px-3 py-2 text-[12px] font-bold"
+              style={{
+                background: active ? cat.color : C.card,
+                border: `1.5px solid ${active ? cat.color : C.border}`,
+                color: active ? '#ffffff' : C.muted,
+              }}
+            >
+              <Icon size={13} />
+              {cat.label}
+            </motion.button>
+          )
+        })}
+      </div>
+
+      {/* 選択中カテゴリの詳細表示 */}
+      <AnimatePresence mode="wait">
+        {selected && (() => {
+          const cat = CATEGORIES.find((c) => c.id === selected)
+          if (!cat) return null
+          const Icon = cat.icon
+          return (
+            <motion.div
+              key={selected}
+              initial={{ opacity: 0, y: 6 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -6 }}
+              transition={SPRING.base}
+              className="flex items-center gap-2 rounded-xl p-3 mt-1"
+              style={{ background: cat.bgLight, border: `1px solid rgba(0,0,0,0.06)` }}
+            >
+              <div
+                className="flex h-8 w-8 items-center justify-center rounded-xl"
+                style={{ background: cat.color }}
+              >
+                <Icon size={15} className="text-white" />
+              </div>
+              <div>
+                <p className="text-[13px] font-bold" style={{ color: cat.color }}>{cat.label}</p>
+                <p className="text-[11px]" style={{ color: C.muted }}>{cat.desc}</p>
+              </div>
+            </motion.div>
+          )
+        })()}
+      </AnimatePresence>
+
+      <div className="mt-3 rounded-xl border p-3 text-xs" style={{ background: '#f9fafb', borderColor: C.border }}>
+        <p className="font-bold mb-0.5" style={{ color: C.text }}>Pattern C メリット</p>
+        <p style={{ color: C.muted }}>縦スペースを節約。ドロワー全体がコンパクトになり金額入力との距離が縮まる。横スクロールは直感的。</p>
+        <p className="font-bold mt-1.5 mb-0.5" style={{ color: C.text }}>デメリット</p>
+        <p style={{ color: C.muted }}>右端のカテゴリが見切れる。カテゴリが多いと全体が見えないため発見しにくい。</p>
+      </div>
+    </div>
+  )
+}
+
+// ─── パターン選択タブ ────────────────────────────────────────────────────────
+
+type PatternId = 'A' | 'B' | 'C'
+
+// ─── メイン ──────────────────────────────────────────────────────────────────
+
+export function CategoryInputABPrototype() {
+  const [pattern, setPattern] = useState<PatternId>('A')
+  const [selectedA, setSelectedA] = useState('food')
+  const [selectedB, setSelectedB] = useState('food')
+  const [selectedC, setSelectedC] = useState('food')
+
+  const PATTERNS: { id: PatternId; label: string }[] = [
+    { id: 'A', label: 'A: グリッド' },
+    { id: 'B', label: 'B: リスト' },
+    { id: 'C', label: 'C: チップ' },
+  ]
+
+  return (
+    <div className="min-h-screen pb-10" style={{ background: C.bg }}>
+      {/* ヘッダー */}
+      <header
+        className="sticky top-0 z-10 px-4 py-3 border-b"
+        style={{
+          background: 'rgba(245,243,239,0.92)',
+          backdropFilter: 'blur(12px)',
+          borderColor: C.border,
+        }}
+      >
+        <h1 className="text-base font-extrabold" style={{ color: C.text }}>
+          カテゴリ選択 A/B/C 比較
+        </h1>
+        <p className="text-xs mt-0.5" style={{ color: C.muted }}>
+          HomeV4 ドロワー内のカテゴリ選択UI — 3パターン
+        </p>
+      </header>
+
+      {/* パターン切り替えタブ */}
+      <div className="sticky top-[56px] z-10 flex gap-1 px-4 py-2 border-b" style={{ background: C.bg, borderColor: C.border }}>
+        {PATTERNS.map((p) => (
+          <motion.button
+            key={p.id}
+            type="button"
+            onClick={() => setPattern(p.id)}
+            whileTap={{ scale: 0.95 }}
+            transition={SPRING.snap}
+            className="flex-1 rounded-xl py-2 text-[13px] font-bold"
+            style={{
+              background: pattern === p.id ? C.brand : C.card,
+              color: pattern === p.id ? '#fff' : C.muted,
+              border: `1.5px solid ${pattern === p.id ? C.brand : C.border}`,
+            }}
+          >
+            {p.label}
+          </motion.button>
+        ))}
+      </div>
+
+      {/* ドロワーイメージ */}
+      <div className="mx-auto max-w-sm px-4 pt-4">
+        {/* 金額入力モック */}
+        <div
+          className="rounded-2xl border p-4 mb-4"
+          style={{ background: C.card, borderColor: C.border }}
+        >
+          <p className="text-xs font-bold mb-1" style={{ color: C.muted }}>支出金額</p>
+          <p className="text-3xl font-extrabold tabular-nums" style={{ color: C.brand }}>¥1,280</p>
+          <p className="text-xs mt-0.5" style={{ color: C.muted }}>記録後の残り: ¥5,123</p>
+        </div>
+
+        {/* カテゴリ選択パターン */}
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={pattern}
+            initial={{ opacity: 0, x: 20 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -20 }}
+            transition={SPRING.base}
+          >
+            {pattern === 'A' && <PatternA selected={selectedA} onSelect={setSelectedA} />}
+            {pattern === 'B' && <PatternB selected={selectedB} onSelect={setSelectedB} />}
+            {pattern === 'C' && <PatternC selected={selectedC} onSelect={setSelectedC} />}
+          </motion.div>
+        </AnimatePresence>
+
+        {/* メモ入力モック */}
+        <div className="mt-4">
+          <input
+            type="text"
+            placeholder="メモ（店名・用途など、任意）"
+            readOnly
+            className="w-full rounded-xl border px-3 py-2.5 text-sm outline-none"
+            style={{
+              fontSize: '16px',
+              background: C.card,
+              borderColor: C.border,
+              color: C.text,
+            }}
+          />
+        </div>
+
+        {/* 登録ボタンモック */}
+        <button
+          type="button"
+          className="mt-4 w-full rounded-2xl py-3.5 text-sm font-extrabold text-white"
+          style={{ background: `linear-gradient(135deg, ${C.brand}, ${C.brandDeep})` }}
+        >
+          記録する
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle, CalendarDays, Wallet, Palette, LayoutDashboard, LayoutGrid, PieChart, TrendingUp, List, Settings } from 'lucide-react'
+import { Smartphone, PenLine, ArrowRight, Layout, User, PlayCircle, CalendarDays, Wallet, Palette, LayoutDashboard, LayoutGrid, PieChart, TrendingUp, List, Settings, Bell, SquareMenu } from 'lucide-react'
 
 type PrototypeCard = {
   path: string
@@ -122,6 +122,22 @@ const prototypes: PrototypeCard[] = [
     icon: Settings,
     issue: '#283',
     status: 'ready',
+  },
+  {
+    path: '/notifications',
+    title: '通知一覧画面',
+    description: '予算超過アラート・給料日リマインダー・連続記録バッジなどの通知センタープロトタイプ。',
+    icon: Bell,
+    issue: '#295',
+    status: 'wip',
+  },
+  {
+    path: '/category-input-ab',
+    title: 'カテゴリ選択 A/B/C 比較',
+    description: 'グリッド / リスト / スクロールチップ の3パターン比較。メリット・デメリット付き。',
+    icon: SquareMenu,
+    issue: '#294',
+    status: 'wip',
   },
 ]
 

--- a/apps/sandbox/src/pages/HomeV4Prototype.tsx
+++ b/apps/sandbox/src/pages/HomeV4Prototype.tsx
@@ -28,6 +28,9 @@ import {
     useTransform,
     useReducedMotion,
 } from "framer-motion";
+
+// motion() でラップした Link — framer-motion アニメーション + React Router ナビを両立
+const MotionLink = motion(Link);
 import { Drawer } from "vaul";
 import {
     Home, Calendar, BarChart2, Settings,
@@ -398,14 +401,14 @@ export function HomeV4Prototype() {
 
                 <nav className="hidden flex-1 items-center justify-center gap-0.5 md:flex">
                     {[
-                        { label: "ホーム",     icon: Home,     active: true  },
-                        { label: "カレンダー", icon: Calendar,  active: false },
-                        { label: "レポート",   icon: BarChart2, active: false },
-                        { label: "設定",       icon: Settings,  active: false },
+                        { label: "ホーム",     icon: Home,     to: "/home-v4",           active: true  },
+                        { label: "カレンダー", icon: Calendar,  to: "/calendar-page",     active: false },
+                        { label: "レポート",   icon: BarChart2, to: "/asset-outlook-ab",  active: false },
+                        { label: "設定",       icon: Settings,  to: "/personal-settings", active: false },
                     ].map((item) => (
-                        <motion.button
+                        <MotionLink
                             key={item.label}
-                            type="button"
+                            to={item.to}
                             whileTap={{ scale: 0.95 }}
                             transition={SPRING.snap}
                             className="flex items-center gap-1.5 px-3 py-2 text-[13px] font-semibold tap-highlight"
@@ -413,17 +416,18 @@ export function HomeV4Prototype() {
                                 borderRadius: "10px",
                                 background: item.active ? C.brandLight : "transparent",
                                 color:      item.active ? C.brand : "rgba(28,20,16,0.50)",
+                                textDecoration: "none",
                             }}
                         >
                             <item.icon size={14} aria-hidden />
                             {item.label}
-                        </motion.button>
+                        </MotionLink>
                     ))}
                 </nav>
 
                 <div className="ml-auto flex shrink-0 items-center gap-2">
-                    <motion.button
-                        type="button"
+                    <MotionLink
+                        to="/notifications"
                         whileTap={{ scale: 0.82 }}
                         transition={SPRING.snap}
                         className="relative flex h-8 w-8 items-center justify-center tap-highlight"
@@ -443,19 +447,22 @@ export function HomeV4Prototype() {
                                 />
                             )}
                         </AnimatePresence>
-                    </motion.button>
-                    <motion.div
+                    </MotionLink>
+                    <MotionLink
+                        to="/personal-settings"
                         whileTap={{ scale: 0.90 }}
                         transition={SPRING.snap}
-                        className="flex h-8 w-8 cursor-pointer items-center justify-center text-[12px] font-extrabold text-white tap-highlight"
+                        className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white tap-highlight"
                         style={{
                             background:   `linear-gradient(135deg, ${C.brand}, ${C.brandDeep})`,
                             borderRadius: R.badge,
                             boxShadow:    "0 2px 8px rgba(241,136,64,0.30)",
+                            textDecoration: "none",
                         }}
+                        aria-label="設定"
                     >
                         {MOCK.userId}
-                    </motion.div>
+                    </MotionLink>
                 </div>
             </motion.header>
 
@@ -658,15 +665,15 @@ export function HomeV4Prototype() {
                         >
                             <div className="flex items-center justify-between border-b px-4 py-3" style={{ borderColor: C.border }}>
                                 <span className="text-sm font-bold" style={{ color: C.text }}>最近の記録</span>
-                                <motion.button
-                                    type="button"
+                                <MotionLink
+                                    to="/recent-records-ab"
                                     whileTap={{ scale: 0.92 }}
                                     transition={SPRING.snap}
                                     className="flex items-center gap-0.5 text-[12px] font-semibold tap-highlight"
-                                    style={{ color: C.brand }}
+                                    style={{ color: C.brand, textDecoration: "none" }}
                                 >
                                     すべて見る <ChevronRight size={12} />
-                                </motion.button>
+                                </MotionLink>
                             </div>
 
                             <div>

--- a/apps/sandbox/src/pages/NotificationsPrototype.tsx
+++ b/apps/sandbox/src/pages/NotificationsPrototype.tsx
@@ -1,0 +1,194 @@
+/**
+ * NotificationsPrototype — 通知一覧画面のプロトタイプ
+ *
+ * 今後実装予定の通知機能の画面イメージ。
+ * - 予算超過アラート
+ * - 給料日リマインダー
+ * - 連続記録達成バッジ
+ */
+
+import { Bell, AlertTriangle, Wallet, Flame, CheckCircle2 } from 'lucide-react'
+
+type Notification = {
+  id: string
+  type: 'alert' | 'info' | 'achievement'
+  title: string
+  body: string
+  time: string
+  read: boolean
+}
+
+const MOCK_NOTIFICATIONS: Notification[] = [
+  {
+    id: '1',
+    type: 'alert',
+    title: '今月の予算を超過しています',
+    body: '食費が予算 ¥30,000 に対して ¥34,200 になりました。',
+    time: '今日 07:00',
+    read: false,
+  },
+  {
+    id: '2',
+    type: 'info',
+    title: '給料日まであと3日',
+    body: '1日予算 ¥2,100 で乗り切りましょう。残高 ¥6,403。',
+    time: '今日 06:30',
+    read: false,
+  },
+  {
+    id: '3',
+    type: 'achievement',
+    title: '🔥 7日連続記録達成！',
+    body: '素晴らしい習慣です。このまま続けましょう。',
+    time: '昨日 23:00',
+    read: true,
+  },
+  {
+    id: '4',
+    type: 'info',
+    title: '月次レポートが作成されました',
+    body: '4月の家計サマリーを確認できます。',
+    time: '5/1 09:00',
+    read: true,
+  },
+  {
+    id: '5',
+    type: 'alert',
+    title: '光熱費の記録が3日ありません',
+    body: '忘れている支出がないか確認してみましょう。',
+    time: '4/28 18:00',
+    read: true,
+  },
+]
+
+const typeConfig = {
+  alert: {
+    icon: AlertTriangle,
+    bg: '#fff1f2',
+    border: 'rgba(244,63,94,0.20)',
+    iconColor: '#f43f5e',
+  },
+  info: {
+    icon: Wallet,
+    bg: '#fff6ee',
+    border: 'rgba(241,136,64,0.20)',
+    iconColor: '#f18840',
+  },
+  achievement: {
+    icon: Flame,
+    bg: '#faf5ff',
+    border: 'rgba(168,85,247,0.20)',
+    iconColor: '#a855f7',
+  },
+}
+
+export function NotificationsPrototype() {
+  const unread = MOCK_NOTIFICATIONS.filter((n) => !n.read).length
+
+  return (
+    <div
+      className="min-h-screen"
+      style={{ background: '#f5f3ef', fontFamily: 'var(--font-outfit, sans-serif)' }}
+    >
+      {/* ヘッダー */}
+      <header
+        className="sticky top-0 z-10 flex items-center justify-between px-4 py-3 border-b"
+        style={{
+          background: 'rgba(245,243,239,0.90)',
+          backdropFilter: 'blur(12px)',
+          borderColor: 'rgba(28,20,16,0.08)',
+        }}
+      >
+        <div className="flex items-center gap-2">
+          <Bell size={18} style={{ color: '#1c1410' }} />
+          <h1 className="text-base font-extrabold" style={{ color: '#1c1410' }}>
+            通知
+          </h1>
+          {unread > 0 && (
+            <span
+              className="flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-[11px] font-extrabold text-white"
+              style={{ background: '#f43f5e' }}
+            >
+              {unread}
+            </span>
+          )}
+        </div>
+        {unread > 0 && (
+          <button
+            type="button"
+            className="text-xs font-semibold"
+            style={{ color: '#f18840' }}
+          >
+            すべて既読にする
+          </button>
+        )}
+      </header>
+
+      {/* 通知リスト */}
+      <div className="mx-auto max-w-lg px-4 py-3 flex flex-col gap-2">
+        {MOCK_NOTIFICATIONS.map((n) => {
+          const cfg = typeConfig[n.type]
+          const Icon = cfg.icon
+          return (
+            <div
+              key={n.id}
+              className="flex items-start gap-3 rounded-2xl border p-4 transition-colors"
+              style={{
+                background: n.read ? '#ffffff' : cfg.bg,
+                borderColor: n.read ? 'rgba(28,20,16,0.08)' : cfg.border,
+                opacity: n.read ? 0.72 : 1,
+              }}
+            >
+              {/* アイコン */}
+              <div
+                className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl"
+                style={{ background: cfg.bg, border: `1px solid ${cfg.border}` }}
+              >
+                <Icon size={15} style={{ color: cfg.iconColor }} />
+              </div>
+
+              {/* テキスト */}
+              <div className="flex-1 min-w-0">
+                <div className="flex items-start justify-between gap-2">
+                  <p
+                    className="text-sm font-bold leading-snug"
+                    style={{ color: '#1c1410' }}
+                  >
+                    {n.title}
+                  </p>
+                  {!n.read && (
+                    <span
+                      className="mt-1 h-2 w-2 shrink-0 rounded-full"
+                      style={{ background: '#f18840' }}
+                    />
+                  )}
+                </div>
+                <p
+                  className="mt-0.5 text-xs leading-relaxed"
+                  style={{ color: 'rgba(28,20,16,0.55)' }}
+                >
+                  {n.body}
+                </p>
+                <p
+                  className="mt-1.5 text-[11px] font-semibold"
+                  style={{ color: 'rgba(28,20,16,0.35)' }}
+                >
+                  {n.time}
+                </p>
+              </div>
+            </div>
+          )
+        })}
+
+        {MOCK_NOTIFICATIONS.length === 0 && (
+          <div className="flex flex-col items-center py-16 gap-3">
+            <CheckCircle2 size={40} style={{ color: 'rgba(28,20,16,0.18)' }} />
+            <p className="text-sm font-semibold" style={{ color: 'rgba(28,20,16,0.40)' }}>
+              通知はありません
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -13,7 +13,7 @@ type Props = {
  */
 export function AppShell({ userName, children }: Props) {
   return (
-    <div className="flex flex-col min-h-screen md:flex-row bg-[#fffdf5]">
+    <div className="flex flex-col min-h-dvh md:flex-row bg-[#fffdf5]">
       {/* PC: サイドバー / モバイル: ミニヘッダー */}
       <Header userName={userName} />
 


### PR DESCRIPTION
## 概要

Sprint #19 の全 PBI を一括実装。

## 変更内容

### #294 カテゴリ選択 A/B/C デザインパターン
- `CategoryInputABPrototype.tsx` 新規作成
  - Pattern A: 4列グリッド（選択時アクティブバッジ+ボーダー強調）
  - Pattern B: 縦リスト（アイコン+ラベル+説明テキスト）
  - Pattern C: 横スクロールチップ（選択中カテゴリ詳細カード付き）
- Gallery にエントリ追加

### #295 HomeV4 ナビ導線有効化
- `MotionLink = motion(Link)` でトップナビをルーティング化
  - ホーム→/home-v4 / カレンダー→/calendar-page / レポート→/asset-outlook-ab / 設定→/personal-settings
- 通知ベル→/notifications、アバター→/personal-settings に接続
- 「すべて見る」→/recent-records-ab に接続
- `NotificationsPrototype.tsx` 新規作成（予算超過・給料日・達成バッジなどのモック通知センター）

### #296 モバイルリロードバグ修正
- `AppShell`: `min-h-screen` → `min-h-dvh` に変更
- 原因: `100vh` はモバイルブラウザのツールバー込み高さを返すため画面下コンテンツが切れる
- 修正: `100dvh`（dynamic viewport height）で実際の表示領域に追従

### #297 スプリントキャパシティ改定
- `velocity-log.json`: `initial_velocity_estimate` 6 → 9 に改定
- 直近3スプリント平均 5.3pt・ピーク 8pt の実績に基づく

### #298 Sandbox 共通ナビゲーション
- `SandboxNav.tsx` 新規作成（全プロトタイプページ共通フローティングナビ）
  - 左下固定の小型ピル型コントロールバー
  - ギャラリーへ戻る / 前後ページナビゲーション
  - ページ名タップで全ページドロップアップ表示

## テスト

- `pnpm test:unit` 全件パス（168 tests）
- `pnpm test:integration` 全件パス（38 tests）
- lint / type-check グリーン

Closes #294
Closes #295
Closes #296
Closes #297
Closes #298
Sprint: 19