### PR TITLE
feat(web): レポートページの明細から支出を直接編集できるようにする

### DIFF
--- a/apps/web/src/app/report/page.tsx
+++ b/apps/web/src/app/report/page.tsx
@@ -1,13 +1,12 @@
 import { Suspense } from "react";
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
-import { X } from "lucide-react";
 import { getBudgets } from "@/lib/api/budget";
-import { deleteBudgetAction } from "@/lib/actions/budget";
-import { getCategoryById, OUTGO_CATEGORIES } from "@budget/common";
+import { OUTGO_CATEGORIES } from "@budget/common";
 import { PeriodSelector } from "@/components/report/PeriodSelector";
 import { MonthlyComparisonCard } from "@/components/report/MonthlyComparisonCard";
 import { CategoryDonutChart } from "@/components/report/CategoryDonutChart";
+import { ReportDetailItem } from "@/components/report/ReportDetailItem";
 import { AppShell } from "@/components/layout/AppShell";
 import { calcMonthlyComparison } from "@budget/common";
 import type { BudgetResponse } from "@budget/api-client";
@@ -186,51 +185,9 @@ async function ReportSection({ period }: { period: Period }) {
                   className="divide-y divide-[#e8c8b0] rounded-2xl border border-[#1c1410]/12 bg-white overflow-hidden"
                   style={{ boxShadow: "var(--shadow-card)" }}
                 >
-                  {items.map((item) => {
-                    const category = getCategoryById(item.balanceType, item.categoryId);
-                    const deleteAction = deleteBudgetAction.bind(null, item.id);
-                    const isIncome = item.balanceType === 1;
-                    return (
-                      <li
-                        key={item.id}
-                        className="flex items-center justify-between gap-3 px-4 py-3"
-                      >
-                        <div className="flex items-center gap-2">
-                          {category && (
-                            <span
-                              className="h-3 w-3 flex-shrink-0 rounded-full border border-[#1c1410]/10"
-                              style={{ backgroundColor: category.color }}
-                            />
-                          )}
-                          <div className="flex flex-col">
-                            <span className="text-sm font-bold text-[#1c1410]">
-                              {category?.name ?? "未分類"}
-                            </span>
-                            {item.content && (
-                              <span className="text-xs font-medium text-[#1c1410]/40">{item.content}</span>
-                            )}
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-3">
-                          <span
-                            className="text-sm font-extrabold tabular-nums"
-                            style={{ color: isIncome ? "var(--color-income)" : "var(--color-expense)" }}
-                          >
-                            {isIncome ? "+" : "-"}¥{item.amount.toLocaleString()}
-                          </span>
-                          <form action={deleteAction}>
-                            <button
-                              type="submit"
-                              aria-label="削除"
-                              className="flex h-7 w-7 items-center justify-center rounded-full border border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f87171] hover:bg-[#fee2e2] hover:text-[#f87171]"
-                            >
-                              <X size={12} />
-                            </button>
-                          </form>
-                        </div>
-                      </li>
-                    );
-                  })}
+                  {items.map((item) => (
+                    <ReportDetailItem key={item.id} item={item} />
+                  ))}
                 </ul>
               </section>
             );

--- a/apps/web/src/components/report/ReportDetailItem.tsx
+++ b/apps/web/src/components/report/ReportDetailItem.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { X, Pencil } from "lucide-react";
+import { deleteBudgetAction } from "@/lib/actions/budget";
+import { ExpenseEditModal } from "@/components/expense/ExpenseEditModal";
+import { getCategoryById } from "@budget/common";
+import type { BudgetResponse } from "@budget/api-client";
+import type { ExpenseResponse } from "@/lib/api/types";
+
+type Props = {
+  item: BudgetResponse;
+};
+
+function toExpenseResponse(item: BudgetResponse): ExpenseResponse {
+  return {
+    id: item.id,
+    userId: "",
+    balanceType: item.balanceType,
+    categoryId: item.categoryId,
+    amount: item.amount,
+    date: item.date,
+    content: item.content ?? null,
+    createdDate: "",
+    updatedDate: "",
+    deletedDate: null,
+  };
+}
+
+export function ReportDetailItem({ item }: Props) {
+  const [editing, setEditing] = useState(false);
+  const category = getCategoryById(item.balanceType, item.categoryId);
+  const isIncome = item.balanceType === 1;
+  const deleteAction = deleteBudgetAction.bind(null, item.id);
+
+  return (
+    <>
+      <li className="flex items-center justify-between gap-3 px-4 py-3">
+        <div className="flex items-center gap-2">
+          {category && (
+            <span
+              className="h-3 w-3 flex-shrink-0 rounded-full border border-[#1c1410]/10"
+              style={{ backgroundColor: category.color }}
+            />
+          )}
+          <div className="flex flex-col">
+            <span className="text-sm font-bold text-[#1c1410]">
+              {category?.name ?? "未分類"}
+            </span>
+            {item.content && (
+              <span className="text-xs font-medium text-[#1c1410]/40">
+                {item.content}
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <span
+            className="text-sm font-extrabold tabular-nums"
+            style={{
+              color: isIncome ? "var(--color-income)" : "var(--color-expense)",
+            }}
+          >
+            {isIncome ? "+" : "-"}¥{item.amount.toLocaleString()}
+          </span>
+          <button
+            type="button"
+            aria-label="編集"
+            onClick={() => setEditing(true)}
+            className="flex h-7 w-7 items-center justify-center rounded-full border border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f18840] hover:bg-[#fff6ee] hover:text-[#f18840]"
+          >
+            <Pencil size={12} />
+          </button>
+          <form action={deleteAction}>
+            <button
+              type="submit"
+              aria-label="削除"
+              className="flex h-7 w-7 items-center justify-center rounded-full border border-[#e8c8b0] bg-white text-[#1c1410]/40 transition-colors hover:border-[#f87171] hover:bg-[#fee2e2] hover:text-[#f87171]"
+            >
+              <X size={12} />
+            </button>
+          </form>
+        </div>
+      </li>
+      {editing && (
+        <ExpenseEditModal
+          expense={toExpenseResponse(item)}
+          onClose={() => setEditing(false)}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

- レポートページの日付別明細に編集（鉛筆）・削除（×）ボタンを追加
- `ReportDetailItem` Client Component を新規作成し、`ExpenseEditModal` を連携
- Server Component の `report/page.tsx` から Client 依存コードを分離

## Changes

- `apps/web/src/components/report/ReportDetailItem.tsx` (新規): 明細1行のClient Component。編集ボタン→ExpenseEditModal、削除ボタン→deleteBudgetAction を担当
- `apps/web/src/app/report/page.tsx`: items.map 内の `<li>` を `<ReportDetailItem>` に置き換え、不要な import を削除

## Test plan

- [ ] レポートページ → 日付別明細に鉛筆アイコンと×アイコンが表示される
- [ ] 鉛筆アイコンをクリック → 編集モーダルが開き、値が入力済みで表示される
- [ ] 編集モーダルで金額・カテゴリを変更して保存 → 一覧に反映される
- [ ] ×アイコンをクリック → レコードが削除される
- [ ] type-check: pass / unit-test: 165 passed

Closes #326
Sprint: 24

https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2)_