### PR TITLE
feat(web): 30分無操作でセッションタイムアウト・自動ログアウトを実装する

### DIFF
--- a/apps/web/src/components/layout/AppShell.tsx
+++ b/apps/web/src/components/layout/AppShell.tsx
@@ -1,5 +1,6 @@
 import { Header } from "./Header";
 import { BottomNav } from "./BottomNav";
+import { IdleTimerWrapper } from "./IdleTimerWrapper";
 
 type Props = {
   userName?: string;
@@ -14,6 +15,7 @@ type Props = {
 export function AppShell({ userName, children }: Props) {
   return (
     <div className="flex flex-col min-h-dvh md:flex-row bg-[#fffdf5]">
+      <IdleTimerWrapper />
       {/* PC: サイドバー / モバイル: ミニヘッダー */}
       <Header userName={userName} />
 

--- a/apps/web/src/components/layout/IdleTimerWrapper.tsx
+++ b/apps/web/src/components/layout/IdleTimerWrapper.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { useIdleTimer } from "@/lib/hooks/useIdleTimer";
+import { logoutAction } from "@/lib/actions/auth";
+
+export function IdleTimerWrapper() {
+  useIdleTimer(logoutAction);
+  return null;
+}

--- a/apps/web/src/lib/hooks/useIdleTimer.ts
+++ b/apps/web/src/lib/hooks/useIdleTimer.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+
+const IDLE_MS = 30 * 60 * 1000;
+const WARN_BEFORE_MS = 60 * 1000;
+
+export function useIdleTimer(onTimeout: () => void) {
+  const onTimeoutRef = useRef(onTimeout);
+
+  // Keep ref in sync without triggering timer re-setup
+  useEffect(() => {
+    onTimeoutRef.current = onTimeout;
+  });
+
+  useEffect(() => {
+    let warnTimer: ReturnType<typeof setTimeout> | null = null;
+    let logoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let toastId: string | number | null = null;
+
+    // Plain function declaration so the toast action can reference reset without forward-ref issues
+    function reset() {
+      if (warnTimer) clearTimeout(warnTimer);
+      if (logoutTimer) clearTimeout(logoutTimer);
+      if (toastId !== null) {
+        toast.dismiss(toastId);
+        toastId = null;
+      }
+
+      warnTimer = setTimeout(() => {
+        toastId = toast.warning("セッションが間もなく切れます", {
+          description: "1分後に自動ログアウトします",
+          duration: WARN_BEFORE_MS,
+          action: { label: "続行する", onClick: reset },
+        });
+      }, IDLE_MS - WARN_BEFORE_MS);
+
+      logoutTimer = setTimeout(() => {
+        onTimeoutRef.current();
+      }, IDLE_MS);
+    }
+
+    const events = ["mousemove", "mousedown", "keydown", "touchstart", "scroll"] as const;
+    events.forEach((e) => window.addEventListener(e, reset, { passive: true }));
+    reset();
+
+    return () => {
+      events.forEach((e) => window.removeEventListener(e, reset));
+      if (warnTimer) clearTimeout(warnTimer);
+      if (logoutTimer) clearTimeout(logoutTimer);
+    };
+     
+  }, []);
+}


### PR DESCRIPTION
## Summary

- 認証済みページで30分間操作がない場合に自動ログアウトする
- タイムアウト1分前（29分時点）に Sonner トーストで警告を表示し、「続行する」ボタンでタイマーをリセットできる
- `useIdleTimer` カスタムフックを新規作成し、`AppShell` に組み込んで全認証ページに適用

## Changes

- `apps/web/src/lib/hooks/useIdleTimer.ts` (新規): マウス・キー・スクロール操作を監視して30分無操作でタイムアウト
- `apps/web/src/components/layout/IdleTimerWrapper.tsx` (新規): `useIdleTimer(logoutAction)` を呼ぶ Client Component
- `apps/web/src/components/layout/AppShell.tsx`: `<IdleTimerWrapper />` を追加

## Test plan

- [ ] ログイン後30分間操作しないと自動でログインページに遷移する
- [ ] 29分時点でトースト「セッションが間もなく切れます」が表示される
- [ ] トーストの「続行する」ボタンを押すとタイマーがリセットされる
- [ ] マウス移動・キー入力・スクロールでタイマーがリセットされる
- [ ] type-check: pass / unit-test: 165 passed (20 files)

Closes #324
Sprint: 24

https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2)_