### PR TITLE
feat: 初回設定完了フラグ（initialSetupCompleted）を user_settings に追加する

### DIFF
--- a/apps/api/prisma/migrations/20260515150000_add_initial_setup_completed/migration.sql
+++ b/apps/api/prisma/migrations/20260515150000_add_initial_setup_completed/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable: user_settings に初回設定完了フラグカラムを追加する
+ALTER TABLE `user_settings`
+    ADD COLUMN `initial_setup_completed` BOOLEAN NOT NULL DEFAULT false;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -104,16 +104,17 @@ model UserSecurityAnswer {
   @@map("user_security_answers")
 }
 
-// ユーザー設定（総資産・月次収入・給料日・固定費）
+// ユーザー設定（総資産・月次収入・給料日・固定費・初回設定完了フラグ）
 model UserSettings {
-  id             String   @id @db.VarChar(26)
-  userId         String   @unique @db.VarChar(255) @map("user_id")
-  totalAssets    Int      @default(0) @map("total_assets")
-  monthlyIncome  Int      @default(0) @map("monthly_income")
-  paydayDay      Int      @default(25) @map("payday_day")
-  fixedExpenses  Int      @default(0) @map("fixed_expenses")
-  createdAt      DateTime @default(now()) @db.DateTime(6) @map("created_at")
-  updatedAt      DateTime @updatedAt @db.DateTime(6) @map("updated_at")
+  id                    String   @id @db.VarChar(26)
+  userId                String   @unique @db.VarChar(255) @map("user_id")
+  totalAssets           Int      @default(0) @map("total_assets")
+  monthlyIncome         Int      @default(0) @map("monthly_income")
+  paydayDay             Int      @default(25) @map("payday_day")
+  fixedExpenses         Int      @default(0) @map("fixed_expenses")
+  initialSetupCompleted Boolean  @default(false) @map("initial_setup_completed")
+  createdAt             DateTime @default(now()) @db.DateTime(6) @map("created_at")
+  updatedAt             DateTime @updatedAt @db.DateTime(6) @map("updated_at")
 
   @@index([userId], map: "IDX_user_settings_user_id")
   @@map("user_settings")

--- a/apps/api/src/__tests__/integration/settings.integration.test.ts
+++ b/apps/api/src/__tests__/integration/settings.integration.test.ts
@@ -61,7 +61,7 @@ describeIf('Settings 統合テスト（実 DB）', () => {
     });
 
     describe('GET /api/settings', () => {
-        it('正常系: 未設定のとき totalAssets=0, monthlyIncome=0, paydayDay=25, fixedExpenses=0 を返す', async () => {
+        it('正常系: 未設定のとき totalAssets=0, monthlyIncome=0, paydayDay=25, fixedExpenses=0, initialSetupCompleted=false を返す', async () => {
             const { users } = await seedTestData({ pattern: 'minimal' });
             const agent = await loginClient(users[0].userId);
 
@@ -72,6 +72,7 @@ describeIf('Settings 統合テスト（実 DB）', () => {
                 monthlyIncome: 0,
                 paydayDay: 25,
                 fixedExpenses: 0,
+                initialSetupCompleted: false,
             });
         });
 
@@ -98,7 +99,49 @@ describeIf('Settings 統合テスト（実 DB）', () => {
                 monthlyIncome: 200000,
                 paydayDay: 25,
                 fixedExpenses: 80000,
+                initialSetupCompleted: false,
             });
+        });
+
+        it('正常系: initialSetupCompleted=true で保存・取得できる', async () => {
+            const { users } = await seedTestData({ pattern: 'minimal' });
+            const agent = await loginClient(users[0].userId);
+
+            const res = await agent.put('/api/settings', {
+                totalAssets: 0,
+                monthlyIncome: 0,
+                paydayDay: 25,
+                fixedExpenses: 0,
+                initialSetupCompleted: true,
+            });
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ initialSetupCompleted: true });
+
+            const getRes = await agent.get('/api/settings');
+            expect(getRes.body).toMatchObject({ initialSetupCompleted: true });
+        });
+
+        it('正常系: initialSetupCompleted を省略した更新で既存フラグが保持される', async () => {
+            const { users } = await seedTestData({ pattern: 'minimal' });
+            const agent = await loginClient(users[0].userId);
+
+            await agent.put('/api/settings', {
+                totalAssets: 0,
+                monthlyIncome: 0,
+                paydayDay: 25,
+                fixedExpenses: 0,
+                initialSetupCompleted: true,
+            });
+
+            await agent.put('/api/settings', {
+                totalAssets: 100000,
+                monthlyIncome: 0,
+                paydayDay: 25,
+                fixedExpenses: 0,
+            });
+
+            const getRes = await agent.get('/api/settings');
+            expect(getRes.body).toMatchObject({ initialSetupCompleted: true, totalAssets: 100000 });
         });
 
         it('正常系: 給料日1日・固定費0円で保存できる', async () => {

--- a/apps/api/src/__tests__/unit/use-cases/UpsertUserSettingsUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/UpsertUserSettingsUseCase.test.ts
@@ -11,6 +11,7 @@ const mockSettings: UserSettings = {
     monthlyIncome: 200000,
     paydayDay: 25,
     fixedExpenses: 80000,
+    initialSetupCompleted: false,
     createdAt: new Date('2026-05-08T00:00:00.000Z'),
     updatedAt: new Date('2026-05-08T00:00:00.000Z'),
 };
@@ -135,5 +136,26 @@ describe('UpsertUserSettingsUseCase', () => {
         if (!result.ok) {
             expect(result.error).toBeInstanceOf(ValidationError);
         }
+    });
+
+    it('正常系: initialSetupCompleted=true で保存できる', async () => {
+        vi.mocked(mockRepo.upsert).mockResolvedValue({ ...mockSettings, initialSetupCompleted: true });
+
+        const result = await useCase.execute({ ...validInput, initialSetupCompleted: true });
+
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.value.initialSetupCompleted).toBe(true);
+        }
+        expect(mockRepo.upsert).toHaveBeenCalledWith({ ...validInput, initialSetupCompleted: true });
+    });
+
+    it('正常系: initialSetupCompleted を省略した場合もリポジトリが呼ばれる', async () => {
+        vi.mocked(mockRepo.upsert).mockResolvedValue(mockSettings);
+
+        const result = await useCase.execute(validInput);
+
+        expect(result.ok).toBe(true);
+        expect(mockRepo.upsert).toHaveBeenCalledWith(validInput);
     });
 });

--- a/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
+++ b/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
@@ -11,6 +11,8 @@ export type UpsertUserSettingsInput = {
     paydayDay: number;
     /** 月次固定費合計（円） */
     fixedExpenses: number;
+    /** 初回設定完了フラグ（省略時は既存値を維持） */
+    initialSetupCompleted?: boolean;
 };
 
 /** 給料日の有効範囲 */

--- a/apps/api/src/domain/models/UserSettings.ts
+++ b/apps/api/src/domain/models/UserSettings.ts
@@ -1,4 +1,4 @@
-/** ユーザー設定ドメインモデル（総資産・月次収入・給料日・固定費） */
+/** ユーザー設定ドメインモデル（総資産・月次収入・給料日・固定費・初回設定完了フラグ） */
 export type UserSettings = {
     id: string;
     userId: string;
@@ -8,6 +8,8 @@ export type UserSettings = {
     paydayDay: number;
     /** 月次固定費合計（円） */
     fixedExpenses: number;
+    /** 初回設定完了フラグ */
+    initialSetupCompleted: boolean;
     createdAt: Date;
     updatedAt: Date;
 };

--- a/apps/api/src/domain/repositories/IUserSettingsRepository.ts
+++ b/apps/api/src/domain/repositories/IUserSettingsRepository.ts
@@ -1,8 +1,13 @@
 import type { UserSettings } from '../models/UserSettings';
 
+/** upsert 時の入力型: initialSetupCompleted は省略可（省略時は既存値を維持、新規作成時は false） */
+export type UpsertSettingsInput = Omit<UserSettings, 'id' | 'createdAt' | 'updatedAt' | 'initialSetupCompleted'> & {
+    initialSetupCompleted?: boolean;
+};
+
 export interface IUserSettingsRepository {
     /** ユーザーIDで設定を取得する（未設定時は null） */
     findByUserId(userId: string): Promise<UserSettings | null>;
     /** 設定を保存する（存在すれば更新、なければ作成） */
-    upsert(settings: Omit<UserSettings, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserSettings>;
+    upsert(settings: UpsertSettingsInput): Promise<UserSettings>;
 }

--- a/apps/api/src/infrastructure/persistence/PrismaUserSettingsRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaUserSettingsRepository.ts
@@ -1,7 +1,7 @@
 import type { PrismaClient } from '@prisma/client';
 import { ulid } from 'ulid';
 import type { UserSettings } from '../../domain/models/UserSettings';
-import type { IUserSettingsRepository } from '../../domain/repositories/IUserSettingsRepository';
+import type { IUserSettingsRepository, UpsertSettingsInput } from '../../domain/repositories/IUserSettingsRepository';
 
 export class PrismaUserSettingsRepository implements IUserSettingsRepository {
     constructor(private readonly prisma: PrismaClient) {}
@@ -16,12 +16,13 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
             monthlyIncome: record.monthlyIncome,
             paydayDay: record.paydayDay,
             fixedExpenses: record.fixedExpenses,
+            initialSetupCompleted: record.initialSetupCompleted,
             createdAt: record.createdAt,
             updatedAt: record.updatedAt,
         };
     }
 
-    async upsert(settings: Omit<UserSettings, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserSettings> {
+    async upsert(settings: UpsertSettingsInput): Promise<UserSettings> {
         const record = await this.prisma.userSettings.upsert({
             where: { userId: settings.userId },
             create: {
@@ -31,12 +32,16 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
                 monthlyIncome: settings.monthlyIncome,
                 paydayDay: settings.paydayDay,
                 fixedExpenses: settings.fixedExpenses,
+                initialSetupCompleted: settings.initialSetupCompleted ?? false,
             },
             update: {
                 totalAssets: settings.totalAssets,
                 monthlyIncome: settings.monthlyIncome,
                 paydayDay: settings.paydayDay,
                 fixedExpenses: settings.fixedExpenses,
+                ...(settings.initialSetupCompleted !== undefined && {
+                    initialSetupCompleted: settings.initialSetupCompleted,
+                }),
             },
         });
         return {
@@ -46,6 +51,7 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
             monthlyIncome: record.monthlyIncome,
             paydayDay: record.paydayDay,
             fixedExpenses: record.fixedExpenses,
+            initialSetupCompleted: record.initialSetupCompleted,
             createdAt: record.createdAt,
             updatedAt: record.updatedAt,
         };

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -434,6 +434,7 @@ export const UserSettingsResponseSchema = z
         monthlyIncome: z.number().int().min(0).openapi({ description: '月次固定収入（円）', example: 200000 }),
         paydayDay: z.number().int().min(1).max(31).openapi({ description: '給料日（月の何日か: 1〜31）', example: 25 }),
         fixedExpenses: z.number().int().min(0).openapi({ description: '月次固定費合計（円）', example: 80000 }),
+        initialSetupCompleted: z.boolean().openapi({ description: '初回設定完了フラグ', example: false }),
     })
     .openapi('UserSettingsResponse');
 
@@ -460,5 +461,9 @@ export const UpsertUserSettingsBodySchema = z
             .int()
             .min(0, '固定費は0以上の値を入力してください')
             .openapi({ description: '月次固定費合計（円）', example: 80000 }),
+        initialSetupCompleted: z
+            .boolean({ invalid_type_error: '初回設定完了フラグは真偽値で入力してください' })
+            .optional()
+            .openapi({ description: '初回設定完了フラグ', example: true }),
     })
     .openapi('UpsertUserSettingsBody');

--- a/apps/api/src/presentation/routes/settings.ts
+++ b/apps/api/src/presentation/routes/settings.ts
@@ -73,6 +73,7 @@ export function createSettingsRoutes({
                 monthlyIncome: settings?.monthlyIncome ?? 0,
                 paydayDay: settings?.paydayDay ?? 25,
                 fixedExpenses: settings?.fixedExpenses ?? 0,
+                initialSetupCompleted: settings?.initialSetupCompleted ?? false,
             },
             200
         );
@@ -80,13 +81,14 @@ export function createSettingsRoutes({
 
     app.openapi(upsertUserSettingsRoute, async (c) => {
         const userId = c.get('userId');
-        const { totalAssets, monthlyIncome, paydayDay, fixedExpenses } = c.req.valid('json');
+        const { totalAssets, monthlyIncome, paydayDay, fixedExpenses, initialSetupCompleted } = c.req.valid('json');
         const result = await upsertUserSettingsUseCase.execute({
             userId,
             totalAssets,
             monthlyIncome,
             paydayDay,
             fixedExpenses,
+            initialSetupCompleted,
         });
         if (!result.ok) {
             return c.json({ result: 'error' as const, message: result.error.message }, result.error.statusCode as 400);
@@ -97,6 +99,7 @@ export function createSettingsRoutes({
                 monthlyIncome: result.value.monthlyIncome,
                 paydayDay: result.value.paydayDay,
                 fixedExpenses: result.value.fixedExpenses,
+                initialSetupCompleted: result.value.initialSetupCompleted,
             },
             200
         );

--- a/apps/web/src/lib/api/settings.ts
+++ b/apps/web/src/lib/api/settings.ts
@@ -1,5 +1,5 @@
 import { serverFetch } from "./client";
-import type { UserSettingsResponse } from "@budget/api-client";
+import type { UserSettingsResponse, UpsertUserSettingsBody } from "@budget/api-client";
 
 // 後方互換エイリアス（既存コードが参照中）
 export type UserSettings = UserSettingsResponse;
@@ -8,7 +8,7 @@ export async function getSettings(): Promise<UserSettingsResponse> {
   return serverFetch<UserSettingsResponse>("/api/settings");
 }
 
-export async function putSettings(data: UserSettingsResponse): Promise<UserSettingsResponse> {
+export async function putSettings(data: UpsertUserSettingsBody): Promise<UserSettingsResponse> {
   return serverFetch<UserSettingsResponse>("/api/settings", {
     method: "PUT",
     body: JSON.stringify(data),

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -60,6 +60,7 @@ Table user_settings {
   monthlyIncome Int [not null, default: 0]
   paydayDay Int [not null, default: 25]
   fixedExpenses Int [not null, default: 0]
+  initialSetupCompleted Boolean [not null, default: false]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]
 }

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -1889,6 +1889,11 @@ export interface components {
              * @example 80000
              */
             fixedExpenses: number;
+            /**
+             * @description 初回設定完了フラグ
+             * @example false
+             */
+            initialSetupCompleted: boolean;
         };
         UpsertUserSettingsBody: {
             /**
@@ -1911,6 +1916,11 @@ export interface components {
              * @example 80000
              */
             fixedExpenses: number;
+            /**
+             * @description 初回設定完了フラグ
+             * @example true
+             */
+            initialSetupCompleted?: boolean;
         };
         XDayResponse: {
             /** @example 2031-09-14T00:00:00.000Z */

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -670,11 +670,16 @@ components:
           minimum: 0
           description: 月次固定費合計（円）
           example: 80000
+        initialSetupCompleted:
+          type: boolean
+          description: 初回設定完了フラグ
+          example: false
       required:
         - totalAssets
         - monthlyIncome
         - paydayDay
         - fixedExpenses
+        - initialSetupCompleted
     UpsertUserSettingsBody:
       type: object
       properties:
@@ -699,6 +704,10 @@ components:
           minimum: 0
           description: 月次固定費合計（円）
           example: 80000
+        initialSetupCompleted:
+          type: boolean
+          description: 初回設定完了フラグ
+          example: true
       required:
         - totalAssets
         - monthlyIncome


### PR DESCRIPTION
## 概要

`user_settings` テーブルに `initial_setup_completed` フラグを追加し、初回設定完了状態を DB で永続化できるようにする。
これにより別ブラウザ・別端末に移行しても設定状態が引き継げるようになる。

## 変更内容

- **Prisma schema**: `UserSettings` に `initialSetupCompleted Boolean @default(false)` を追加
- **migration**: `20260515150000_add_initial_setup_completed` — ALTER TABLE で `initial_setup_completed` カラムを追加
- **ドメインモデル** (`UserSettings.ts`): `initialSetupCompleted: boolean` フィールドを追加
- **リポジトリインターフェース** (`IUserSettingsRepository`): `UpsertSettingsInput` 型を導入し `initialSetupCompleted` をオプション化
- **Prisma リポジトリ**: upsert 時に `initialSetupCompleted` を省略した場合は既存値を維持（新規作成時は `false`）
- **OpenAPI schema**: `UserSettingsResponse` に必須フィールド、`UpsertUserSettingsBody` にオプションフィールドとして追加
- **API routes**: GET/PUT `/api/settings` で `initialSetupCompleted` を返却・受け付け
- **api-client** `schema.d.ts`: 手動更新
- **web** `lib/api/settings.ts`: `putSettings` の引数を `UpsertUserSettingsBody` に修正（後方互換性維持）

## 影響範囲

- 既存の PUT `/api/settings` 呼び出しは `initialSetupCompleted` を省略しても動作する（後方互換）
- GET `/api/settings` のレスポンスに `initialSetupCompleted` が追加されるため、既存クライアントが余分フィールドを無視する前提

## テスト内容

- **unit test** `UpsertUserSettingsUseCase.test.ts`: `initialSetupCompleted=true` での保存・省略時の動作を 2 件追加
- **integration test** `settings.integration.test.ts`: 保存・取得・省略時保持の 3 件追加（DB 統合）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし — BE のみ）

## スクリーンショット

該当なし（バックエンドのみの変更）

Closes #336
Sprint: 25

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2)_