### PR TITLE
feat: 設定ページに「家計基本設定」セクションを追加し Sprint #25 velocity-log を完成させる

### DIFF
--- a/.github/velocity-log.json
+++ b/.github/velocity-log.json
@@ -17,7 +17,7 @@
     "pbi_type_rules": "fix:/bug: prefix → fix / type:tech-debt label → tech-debt / type:chore or design label → chore / otherwise → feature",
     "initial_velocity_estimate": 9,
     "note": "Sprint #13-18 実績分析により 6pt → 9pt に改定（2026-05-15）。直近3スプリント平均 5.3pt・ピーク 8pt（Sprint #17）。AI 実装サイクルは推定の 1/10 以下で完了しており、M×3 + S×1 程度が 1 スプリントの適切な上限。上限超過時はユーザーに確認して分割する。",
-    "next_sprint_number": 26
+    "next_sprint_number": 27
   },
   "sprints": [
     {
@@ -1036,23 +1036,46 @@
     {
       "sprint_number": 25,
       "date": "2026-05-15",
-      "total_points": 0,
+      "goal": "onboarding→setup リネーム・初回設定フラグ DB 永続化・設定ページ家計基本設定を整備する",
+      "hypothesis": "設定フローの名称整理と DB 永続化により別端末でも継続利用できる基盤が整い、設定ページから家計基本情報を後から編集できるようになる",
+      "planned_points": 9,
+      "total_points": 9,
       "pbis": [
         {
           "issue": 334,
           "title": "refactor: 「onboarding」を「初回設定（/setup）」にリネームする",
-          "size": "unknown",
-          "points": null,
-          "cycle_time_hours": null,
+          "pbi_type": "tech-debt",
+          "size": "S",
+          "points": 2,
+          "cycle_time_hours": 0.2,
+          "pr": 338
+        },
+        {
+          "issue": 335,
+          "title": "refactor: 初回設定 Cookie 名を「setup_completed」に統一する",
+          "pbi_type": "tech-debt",
+          "size": "S",
+          "points": 2,
+          "cycle_time_hours": 0.1,
           "pr": 338
         },
         {
           "issue": 336,
-          "title": "feat: 初回設定完了フラグを DB で管理し、セッション間で引き継げるようにする（スキーマ・API）",
-          "size": "unknown",
-          "points": null,
-          "cycle_time_hours": null,
+          "title": "feat: 初回設定完了フラグ（initialSetupCompleted）を user_settings に追加する",
+          "pbi_type": "feature",
+          "size": "M",
+          "points": 3,
+          "cycle_time_hours": 0.3,
           "pr": 339
+        },
+        {
+          "issue": 333,
+          "title": "feat: 設定ページに「家計基本設定」セクション（給料日・月収・固定費・総資産）を追加する",
+          "pbi_type": "feature",
+          "size": "S",
+          "points": 2,
+          "cycle_time_hours": 0.5,
+          "pr": 340
         }
       ]
     }

--- a/apps/web/src/__tests__/components/HouseholdSettingsSection.test.tsx
+++ b/apps/web/src/__tests__/components/HouseholdSettingsSection.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { HouseholdSettingsSection } from '../../components/settings/HouseholdSettingsSection'
+
+vi.mock('@/lib/actions/settings', () => ({
+    upsertSettingsAction: vi.fn().mockResolvedValue({ error: null, success: true }),
+}))
+
+import { upsertSettingsAction } from '../../lib/actions/settings'
+
+const defaultProps = {
+    paydayDay: 25,
+    monthlyIncome: 300000,
+    fixedExpenses: 80000,
+    totalAssets: 1000000,
+}
+
+describe('HouseholdSettingsSection', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+        vi.mocked(upsertSettingsAction).mockResolvedValue({ error: null, success: true })
+    })
+
+    it('見出し「家計基本設定」が表示されること', () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        expect(screen.getByRole('heading', { name: '家計基本設定' })).toBeInTheDocument()
+    })
+
+    it('初期値として渡したpaydayDayが給料日フィールドに表示されること', () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        const input = screen.getByRole('spinbutton', { name: '給料日' })
+        expect(input).toHaveValue(25)
+    })
+
+    it('初期値として渡したmonthlyIncomeが月収フィールドに表示されること', () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        const input = screen.getByRole('spinbutton', { name: '月収' })
+        expect(input).toHaveValue(300000)
+    })
+
+    it('初期値として渡したfixedExpensesが固定費フィールドに表示されること', () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        const input = screen.getByRole('spinbutton', { name: '固定費' })
+        expect(input).toHaveValue(80000)
+    })
+
+    it('初期値として渡したtotalAssetsが現在の総資産フィールドに表示されること', () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        const input = screen.getByRole('spinbutton', { name: '現在の総資産' })
+        expect(input).toHaveValue(1000000)
+    })
+
+    it('保存ボタンが存在すること', () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
+    })
+
+    it('保存ボタン押下: upsertSettingsAction が呼ばれること', async () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+        await waitFor(() => {
+            expect(upsertSettingsAction).toHaveBeenCalled()
+        })
+    })
+
+    it('保存成功後: 「保存しました」メッセージが表示されること', async () => {
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('status')).toHaveTextContent('保存しました')
+        })
+    })
+
+    it('エラー時: エラーメッセージが表示されること', async () => {
+        vi.mocked(upsertSettingsAction).mockResolvedValue({ error: '保存に失敗しました', success: false })
+
+        render(<HouseholdSettingsSection {...defaultProps} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '保存' }))
+
+        await waitFor(() => {
+            expect(screen.getByRole('alert')).toHaveTextContent('保存に失敗しました')
+        })
+    })
+})

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
 import { DataExportSection } from "@/components/settings/DataExportSection";
 import { AccountSection } from "@/components/settings/AccountSection";
+import { HouseholdSettingsSection } from "@/components/settings/HouseholdSettingsSection";
 import { AppShell } from "@/components/layout/AppShell";
+import { getSettings } from "@/lib/api/settings";
 import { cookies } from "next/headers";
 
 export const metadata: Metadata = { title: "設定 | 家計管理" };
@@ -10,12 +12,25 @@ export default async function SettingsPage() {
     const cookieStore = await cookies();
     const userId = cookieStore.get("user_id")?.value ?? "Guest";
 
+    const settings = await getSettings().catch(() => ({
+        paydayDay: 25,
+        monthlyIncome: 0,
+        fixedExpenses: 0,
+        totalAssets: 0,
+    }));
+
     return (
         <AppShell userName={userId}>
             <main className="mx-auto w-full max-w-xl flex-1 px-4 py-8">
                 <h1 className="mb-6 text-2xl font-extrabold text-[#1c1410]">設定</h1>
                 <div className="space-y-4">
                     <AccountSection userName={userId} />
+                    <HouseholdSettingsSection
+                        paydayDay={settings.paydayDay}
+                        monthlyIncome={settings.monthlyIncome}
+                        fixedExpenses={settings.fixedExpenses}
+                        totalAssets={settings.totalAssets}
+                    />
                     <DataExportSection />
                 </div>
             </main>

--- a/apps/web/src/components/settings/HouseholdSettingsSection.tsx
+++ b/apps/web/src/components/settings/HouseholdSettingsSection.tsx
@@ -1,0 +1,100 @@
+'use client'
+
+import { useActionState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { upsertSettingsAction } from '@/lib/actions/settings'
+
+type Props = {
+    paydayDay: number
+    monthlyIncome: number
+    fixedExpenses: number
+    totalAssets: number
+}
+
+export function HouseholdSettingsSection({ paydayDay, monthlyIncome, fixedExpenses, totalAssets }: Props) {
+    const [state, action, isPending] = useActionState(upsertSettingsAction, { error: null, success: false })
+
+    return (
+        <div
+            className="rounded-2xl border-2 border-[#1c1410] bg-white p-6 space-y-4"
+            style={{ boxShadow: 'var(--shadow-pop)' }}
+        >
+            <h2 className="text-base font-extrabold text-[#1c1410]">家計基本設定</h2>
+
+            {state.success && (
+                <p role="status" className="text-sm font-semibold text-green-600">
+                    保存しました
+                </p>
+            )}
+            {state.error && (
+                <p role="alert" className="text-sm font-semibold text-red-600">
+                    {state.error}
+                </p>
+            )}
+
+            <form action={action} className="space-y-4">
+                <div className="space-y-1.5">
+                    <Label htmlFor="paydayDay">給料日（1〜31日）</Label>
+                    <Input
+                        id="paydayDay"
+                        name="paydayDay"
+                        type="number"
+                        min={1}
+                        max={31}
+                        defaultValue={paydayDay}
+                        required
+                        aria-label="給料日"
+                    />
+                </div>
+
+                <div className="space-y-1.5">
+                    <Label htmlFor="monthlyIncome">月収（円）</Label>
+                    <Input
+                        id="monthlyIncome"
+                        name="monthlyIncome"
+                        type="number"
+                        min={0}
+                        defaultValue={monthlyIncome}
+                        required
+                        aria-label="月収"
+                    />
+                </div>
+
+                <div className="space-y-1.5">
+                    <Label htmlFor="fixedExpenses">固定費 月合計（円）</Label>
+                    <Input
+                        id="fixedExpenses"
+                        name="fixedExpenses"
+                        type="number"
+                        min={0}
+                        defaultValue={fixedExpenses}
+                        required
+                        aria-label="固定費"
+                    />
+                </div>
+
+                <div className="space-y-1.5">
+                    <Label htmlFor="totalAssets">現在の総資産（円）</Label>
+                    <Input
+                        id="totalAssets"
+                        name="totalAssets"
+                        type="number"
+                        min={0}
+                        defaultValue={totalAssets}
+                        required
+                        aria-label="現在の総資産"
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    disabled={isPending}
+                    className="btn-candy w-full"
+                >
+                    {isPending ? '保存中...' : '保存'}
+                </button>
+            </form>
+        </div>
+    )
+}


### PR DESCRIPTION
## 概要

- 設定ページに「家計基本設定」セクション（`HouseholdSettingsSection`）を追加する
- Sprint #25 の velocity-log を完成させる（#335・#336・#333 の size/points/cycle_time_hours を補記）

## 変更内容

### feat: 家計基本設定セクション（#333）
- `apps/web/src/components/settings/HouseholdSettingsSection.tsx` — 新規作成
  - 給料日・月収・固定費・現在の総資産の入力フォーム
  - `useActionState` + `upsertSettingsAction` で Server Action 経由で保存
  - 保存成功時「保存しました」、エラー時エラーメッセージを表示
- `apps/web/src/app/settings/page.tsx` — `HouseholdSettingsSection` を組み込み
- `apps/web/src/__tests__/components/HouseholdSettingsSection.test.tsx` — 9テストケース追加

### chore: velocity-log 補完
- Sprint #25 の全 4 PBI（#334・#335・#336・#333）に size / points / cycle_time_hours を記録
- `next_sprint_number`: 26 → 27

## テスト

- unit test 173 件全パス（HouseholdSettingsSection 9件含む）
- type-check / lint / openapi-sync / migration-sync グリーン

## 関連 Issue

Closes #333
Sprint: 25

---
_Generated by [Claude Code](https://claude.ai/code/session_014E4KWccNrE9DCXHuNZqJn2)_