### PR TITLE
fix: セキュリティ CVE 対応確認 と biome-ignore 不要抑制コメントの削除

### DIFF
--- a/apps/api/scripts/seed.ts
+++ b/apps/api/scripts/seed.ts
@@ -21,7 +21,6 @@ if (process.env.NODE_ENV !== 'production') {
     require('dotenv').config({ path: path.resolve(__dirname, '../../../.env') });
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: bcrypt は CommonJS モジュールのため require を使用
 const bcrypt = require('bcrypt') as {
     hash: (data: string, rounds: number) => Promise<string>;
 };

--- a/apps/api/src/infrastructure/persistence/PrismaSecurityAnswerRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaSecurityAnswerRepository.ts
@@ -2,7 +2,6 @@ import type { PrismaClient } from '@prisma/client';
 import { ulid } from 'ulid';
 import type { ISecurityAnswerRepository } from '../../domain/repositories/ISecurityAnswerRepository';
 
-// biome-ignore lint/suspicious/noExplicitAny: bcrypt は CommonJS モジュールのため require を使用
 const bcrypt = require('bcrypt') as {
     hash: (data: string, rounds: number) => Promise<string>;
     compare: (data: string, encrypted: string) => Promise<boolean>;

--- a/apps/api/src/infrastructure/persistence/PrismaUserRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaUserRepository.ts
@@ -3,7 +3,6 @@ import type { UpdateUserInput } from '@budget/common';
 import { User } from '../../domain/models/User';
 import type { IUserRepository } from '../../domain/repositories/IUserRepository';
 
-// biome-ignore lint/suspicious/noExplicitAny: bcrypt は CommonJS モジュールのため require を使用
 const bcrypt = require('bcrypt') as {
     hash: (data: string, rounds: number) => Promise<string>;
     compare: (data: string, encrypted: string) => Promise<boolean>;

--- a/apps/api/src/infrastructure/security/BcryptPasswordHasher.ts
+++ b/apps/api/src/infrastructure/security/BcryptPasswordHasher.ts
@@ -1,6 +1,5 @@
 import type { IPasswordHasher } from '../../domain/services/IPasswordHasher';
 
-// biome-ignore lint/suspicious/noExplicitAny: bcrypt は CommonJS モジュールのため require を使用
 const bcrypt = require('bcrypt') as {
     hash: (data: string, rounds: number) => Promise<string>;
     compare: (data: string, encrypted: string) => Promise<boolean>;


### PR DESCRIPTION
## 背景

セキュリティ Issue #349〜#354（next < 16.2.6 の CVE）は PR #357 で既に対応済み（Next.js 16.2.6 にアップデート）。
本ブランチでは対応済みを確認し、verify-flow.sh による新規ツール動作検証と、ツール追加に伴い発生した不要な lint 抑制コメントのクリーンアップを実施。

## 変更内容

### 不要な `biome-ignore` 抑制コメントの削除

`scripts/**/*.ts` オーバーライドで `noExplicitAny: "off"` が設定されたため、`scripts/seed.ts` の抑制は冗長になった。
また `src/` 配下の bcrypt `require` キャストは `any` ではなく具体型へのキャストであり、抑制自体が不要だった。

削除対象ファイル（4件）:
- `apps/api/scripts/seed.ts`
- `apps/api/src/infrastructure/persistence/PrismaSecurityAnswerRepository.ts`
- `apps/api/src/infrastructure/persistence/PrismaUserRepository.ts`
- `apps/api/src/infrastructure/security/BcryptPasswordHasher.ts`

### セキュリティ CVE 確認（コード変更なし）

- Issue #349〜#354 は next < 16.2.6 の CVE で、PR #357 で対応済み
- 全 Issue を手動クローズ済み
- `bash .github/hooks/verify-flow.sh` で全6ステップ通過を確認

## 検証

- `pnpm run lint`: OK（Biome 警告 0 件）
- `pnpm test:unit`: 255 tests passed
- `pnpm test:integration`: 40 tests passed
- `bash .github/hooks/verify-flow.sh`: 全チェック通過

Closes #349
Closes #350
Closes #351
Closes #352
Closes #353
Closes #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)