### PR TITLE
feat: サンドボックスUIのデザイントークン共通化とレイアウト統一

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,7 @@
 #
 # ブランチ保護設定（GitHub Settings > Branches > main）:
 #   Require status checks to pass before merging に以下を登録すること:
+#   - Rebase Check
 #   - Test Plan Check
 #   - Issue Link Check
 #   - Lint & Type Check
@@ -36,6 +37,39 @@ permissions:
   pull-requests: read
 
 jobs:
+  # ─── リベースチェック ──────────────────────────────────────────────────────
+  # PR ブランチが origin/main の最新から切られていない（遅れている）場合に失敗する。
+  # マージ前に必ず最新 main へのリベースを強制するガードレール。
+  rebase-check:
+    name: Rebase Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # merge-base の計算に全履歴が必要
+
+      - name: Check branch is rebased on latest main
+        run: |
+          git fetch origin main --quiet
+
+          MERGE_BASE=$(git merge-base HEAD origin/main)
+          MAIN_HEAD=$(git rev-parse origin/main)
+
+          echo "origin/main HEAD : ${MAIN_HEAD}"
+          echo "merge-base       : ${MERGE_BASE}"
+
+          if [ "${MERGE_BASE}" != "${MAIN_HEAD}" ]; then
+            echo ""
+            echo "❌ ブランチが origin/main の最新から遅れています。"
+            echo ""
+            echo "   以下を実行してリベースし、force push してください:"
+            echo "   git fetch origin main && git rebase origin/main"
+            echo "   git push --force-with-lease"
+            exit 1
+          fi
+
+          echo "✅ origin/main の最新からリベース済みです。"
+
   # ─── テストプランチェック ──────────────────────────────────────────────────
   # PR body の "Test plan" セクション内に未チェック項目（- [ ]）が残っている場合に失敗する。
   # 全チェックボックスを確認済みにしてからマージすることを強制するガードレール。

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,6 +14,7 @@
 #
 # ブランチ保護設定（GitHub Settings > Branches > main）:
 #   Require status checks to pass before merging に以下を登録すること:
+#   - Test Plan Check
 #   - Issue Link Check
 #   - Lint & Type Check
 #   - Next.js Build
@@ -35,6 +36,41 @@ permissions:
   pull-requests: read
 
 jobs:
+  # ─── テストプランチェック ──────────────────────────────────────────────────
+  # PR body の "Test plan" セクション内に未チェック項目（- [ ]）が残っている場合に失敗する。
+  # 全チェックボックスを確認済みにしてからマージすることを強制するガードレール。
+  test-plan-check:
+    name: Test Plan Check
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check all test plan items are checked
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # "Test plan" セクション以降を抽出（大文字小文字を問わない）
+          TEST_PLAN_SECTION=$(echo "${PR_BODY}" | grep -A 9999 -i '## test plan' || true)
+
+          if [ -z "${TEST_PLAN_SECTION}" ]; then
+            echo "⚠️  PR の本文に '## Test plan' セクションが見つかりません。"
+            echo "   テストプランを追加するか、テスト不要な場合は '## Test plan' セクションにその理由を記載してください。"
+            exit 1
+          fi
+
+          # 未チェックのチェックボックス（- [ ]）をカウント
+          UNCHECKED=$(echo "${TEST_PLAN_SECTION}" | grep -c '^\s*- \[ \]' || true)
+
+          if [ "${UNCHECKED}" -gt 0 ]; then
+            echo "❌ Test plan に未確認の項目が ${UNCHECKED} 件残っています。"
+            echo ""
+            echo "   以下の項目を確認し、チェックを付けてからマージしてください:"
+            echo "${TEST_PLAN_SECTION}" | grep '^\s*- \[ \]'
+            exit 1
+          fi
+
+          echo "✅ Test plan のすべての項目が確認済みです。"
+
   # ─── Issue リンクチェック ───────────────────────────────────────────────────
   # PR body に "Closes #NNN" / "Fixes #NNN" / "Resolves #NNN" が含まれない場合に失敗する。
   # 古い Issue を放置しないための最低限の強制ガードレール。

--- a/apps/sandbox/src/components/SandboxCard.tsx
+++ b/apps/sandbox/src/components/SandboxCard.tsx
@@ -1,0 +1,37 @@
+/**
+ * SandboxCard — サンドボックス共通カードコンポーネント
+ */
+
+import type { CSSProperties, ReactNode } from 'react'
+import { D } from './designTokens'
+
+export { D } from './designTokens'
+
+const CARD_RADIUS = 'rounded-md'
+
+export function SandboxCard({
+  children,
+  className = '',
+  noclip = false,
+  style,
+}: {
+  children: ReactNode
+  className?: string
+  /** overflow:hidden を無効化する（ドロップダウン等が枠外に出る場合） */
+  noclip?: boolean
+  style?: CSSProperties
+}) {
+  return (
+    <div
+      className={`${CARD_RADIUS} border ${noclip ? '' : 'overflow-hidden'} ${className}`}
+      style={{
+        background:  D.card,
+        borderColor: D.border,
+        boxShadow:   D.shadow,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/sandbox/src/components/SandboxLayout.tsx
+++ b/apps/sandbox/src/components/SandboxLayout.tsx
@@ -1,0 +1,209 @@
+/**
+ * SandboxLayout — サンドボックス共通レイアウト
+ *
+ * 以下を一元管理する:
+ * - PC 左サイドバー（ロゴ + ナビ + ベル + アバター）
+ * - SP モバイルトップバー（ベル + アバター）
+ * - SP ボトムナビ（standard: 4項目グリッド / fab: 中央FABあり）
+ */
+
+import { Link } from 'react-router-dom'
+import { Home, Receipt, BarChart2, Settings, Bell, Plus } from 'lucide-react'
+import { D } from './SandboxCard'
+import type { ReactNode } from 'react'
+
+// ── ナビゲーション定義 ─────────────────────────────────────────────────────
+export type SandboxPage = 'home' | 'meisai' | 'report' | 'settings'
+
+const NAV_ITEMS = [
+  { label: 'ホーム',   icon: Home,     to: '/home',              page: 'home'     },
+  { label: '明細',     icon: Receipt,  to: '/meisai',            page: 'meisai'   },
+  { label: 'レポート', icon: BarChart2, to: '/report',            page: 'report'   },
+  { label: '設定',     icon: Settings, to: '/personal-settings', page: 'settings' },
+] as const satisfies { label: string; icon: React.ElementType; to: string; page: SandboxPage }[]
+
+// ── コンポーネント ─────────────────────────────────────────────────────────
+export function SandboxLayout({
+  children,
+  currentPage,
+  bottomNavVariant = 'standard',
+  onFabClick,
+}: {
+  children: ReactNode
+  currentPage: SandboxPage
+  /** standard: 4項目グリッド / fab: 中央FABあり */
+  bottomNavVariant?: 'standard' | 'fab'
+  /** fab variant のみ: FABタップ時のコールバック（未指定時は /home へ遷移） */
+  onFabClick?: () => void
+}) {
+  return (
+    <>
+      {/* ── PC サイドバー ─────────────────────────────────────────────────── */}
+      <aside
+        className="hidden lg:flex lg:flex-col fixed inset-y-0 left-0 z-30 w-52 border-r"
+        style={{ background: D.card, borderColor: D.border }}
+      >
+        {/* ロゴ */}
+        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b px-4" style={{ borderColor: D.border }}>
+          <img src="/logo192.png" alt="家計かんり" className="h-8 w-8 shrink-0" style={{ borderRadius: '10px' }} />
+          <span className="text-[15px] font-extrabold tracking-tight" style={{ color: D.text }}>家計かんり</span>
+        </div>
+
+        {/* ナビ */}
+        <nav className="flex-1 overflow-y-auto p-3 space-y-0.5" aria-label="メインメニュー">
+          {NAV_ITEMS.map((item) => {
+            const active = item.page === currentPage
+            return (
+              <Link key={item.label} to={item.to}
+                aria-current={active ? 'page' : undefined}
+                className="flex w-full items-center gap-3 px-3 py-2.5 text-[13px] font-semibold"
+                style={{
+                  borderRadius:   '10px',
+                  background:     active ? D.brandLight : 'transparent',
+                  color:          active ? D.brand : 'rgba(28,20,16,0.50)',
+                  textDecoration: 'none',
+                }}
+              >
+                <item.icon size={17} aria-hidden />
+                {item.label}
+              </Link>
+            )
+          })}
+        </nav>
+
+        {/* ベル + アバター */}
+        <div className="shrink-0 border-t px-3 py-2.5 flex items-center justify-between" style={{ borderColor: D.border }}>
+          <button type="button" className="flex h-8 w-8 items-center justify-center"
+            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
+            <Bell size={17} />
+          </button>
+          <Link to="/my-page"
+            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
+            style={{
+              background:     `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
+              borderRadius:   '9999px',
+              boxShadow:      '0 2px 8px rgba(241,136,64,0.30)',
+              textDecoration: 'none',
+            }}
+            aria-label="マイページ"
+          >Y</Link>
+        </div>
+      </aside>
+
+      {/* ── コンテンツエリア ───────────────────────────────────────────────── */}
+      <div className="min-h-screen pb-24 lg:pb-8 lg:pl-52" style={{ background: D.bg }}>
+
+        {/* SP: ベル + アバター */}
+        <div className="lg:hidden flex items-center justify-end gap-2 px-4 pt-3 pb-1">
+          <button type="button" className="flex h-8 w-8 items-center justify-center"
+            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
+            <Bell size={17} />
+          </button>
+          <Link to="/my-page"
+            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
+            style={{
+              background:     `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
+              borderRadius:   '9999px',
+              boxShadow:      '0 2px 8px rgba(241,136,64,0.30)',
+              textDecoration: 'none',
+            }}
+            aria-label="マイページ"
+          >Y</Link>
+        </div>
+
+        {/* ページ固有コンテンツ */}
+        {children}
+
+        {/* ── SP ボトムナビ ──────────────────────────────────────────────── */}
+        <nav
+          className="fixed bottom-0 left-0 right-0 z-30 lg:hidden"
+          style={{
+            background:    'rgba(255,253,245,0.92)',
+            backdropFilter: 'blur(16px)',
+            borderTop:     `1px solid ${D.border}`,
+            paddingBottom: 'env(safe-area-inset-bottom, 0px)',
+          }}
+          aria-label="メインメニュー"
+        >
+          {bottomNavVariant === 'fab' ? (
+            /* FAB variant */
+            <div className="flex items-center h-14">
+              {[NAV_ITEMS[0], NAV_ITEMS[1]].map((item) => {
+                const active = item.page === currentPage
+                return (
+                  <Link key={item.label} to={item.to}
+                    aria-current={active ? 'page' : undefined}
+                    className="flex flex-1 flex-col items-center justify-center gap-0.5 h-full"
+                    style={{ color: active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}
+                  >
+                    <item.icon size={20} strokeWidth={active ? 2.4 : 2} aria-hidden />
+                    <span className="text-[10px] font-bold leading-none">{item.label}</span>
+                  </Link>
+                )
+              })}
+
+              {/* 中央 FAB */}
+              <div className="flex flex-1 items-end justify-center pb-3">
+                {onFabClick ? (
+                  <button type="button" onClick={onFabClick} aria-label="記録する"
+                    className="flex items-center justify-center rounded-full text-white"
+                    style={{
+                      width: 56, height: 56,
+                      background: `linear-gradient(135deg, ${D.brand} 0%, ${D.brandDeep} 100%)`,
+                      boxShadow: '0 4px 20px rgba(241,136,64,0.45), 0 1px 4px rgba(241,136,64,0.20)',
+                    }}
+                  >
+                    <Plus size={24} />
+                  </button>
+                ) : (
+                  <Link to="/home" aria-label="記録する"
+                    className="flex items-center justify-center rounded-full text-white"
+                    style={{
+                      width: 56, height: 56,
+                      background: `linear-gradient(135deg, ${D.brand} 0%, ${D.brandDeep} 100%)`,
+                      boxShadow: '0 4px 20px rgba(241,136,64,0.45), 0 1px 4px rgba(241,136,64,0.20)',
+                      textDecoration: 'none',
+                    }}
+                  >
+                    <Plus size={24} />
+                  </Link>
+                )}
+              </div>
+
+              {[NAV_ITEMS[2], NAV_ITEMS[3]].map((item) => {
+                const active = item.page === currentPage
+                return (
+                  <Link key={item.label} to={item.to}
+                    aria-current={active ? 'page' : undefined}
+                    className="flex flex-1 flex-col items-center justify-center gap-0.5 h-full"
+                    style={{ color: active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}
+                  >
+                    <item.icon size={20} strokeWidth={active ? 2.4 : 2} aria-hidden />
+                    <span className="text-[10px] font-bold leading-none">{item.label}</span>
+                  </Link>
+                )
+              })}
+            </div>
+          ) : (
+            /* standard variant */
+            <div className="grid grid-cols-4 h-14">
+              {NAV_ITEMS.map((item) => {
+                const active = item.page === currentPage
+                return (
+                  <Link key={item.label} to={item.to}
+                    aria-current={active ? 'page' : undefined}
+                    className="flex flex-col items-center justify-center gap-0.5"
+                    style={{ color: active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}
+                  >
+                    <item.icon size={20} strokeWidth={active ? 2.4 : 2} aria-hidden />
+                    <span className="text-[10px] font-bold leading-none">{item.label}</span>
+                  </Link>
+                )
+              })}
+            </div>
+          )}
+        </nav>
+      </div>
+    </>
+  )
+}

--- a/apps/sandbox/src/components/designTokens.ts
+++ b/apps/sandbox/src/components/designTokens.ts
@@ -1,0 +1,20 @@
+/**
+ * サンドボックス共通デザイントークン
+ *
+ * 色・シャドウ等を変えたい場合はこのファイルだけ修正すればよい。
+ */
+export const D = {
+  bg:          '#fffdf5',
+  card:        '#ffffff',
+  text:        '#1c1410',
+  muted:       'rgba(28,20,16,0.45)',
+  border:      'rgba(28,20,16,0.08)',
+  shadow:      '0 2px 12px rgba(28,20,16,0.08), 0 0 0 1px rgba(28,20,16,0.06)',
+  brand:       '#f18840',
+  brandDeep:   '#e8622a',
+  brandLight:  '#fff6ee',
+  income:      '#35b5a2',
+  danger:      '#f43f5e',
+  caution:     '#f59e0b',
+  surface:     '#f5f3ef',
+} as const

--- a/apps/sandbox/src/pages/HomePrototype.tsx
+++ b/apps/sandbox/src/pages/HomePrototype.tsx
@@ -238,7 +238,7 @@ function StreakTooltip({ content, children }: { content: ReactNode; children: Re
                     <TooltipPrimitive.Content
                         sideOffset={6}
                         side="top"
-                        className="z-[100] rounded-xl px-3 py-2 shadow-xl"
+                        className="z-[100] rounded-md px-3 py-2 shadow-xl"
                         style={{
                             background: "#1c1410",
                             border: "1px solid rgba(255,255,255,0.08)",
@@ -530,7 +530,7 @@ function AmountPanel({ balanceType, amountStr, onClear, previewRemaining, titleN
 
     return (
         <motion.div
-            className="relative overflow-hidden rounded-2xl px-5 py-4"
+            className="relative overflow-hidden rounded-md px-5 py-4"
             style={{
                 background: balanceType === 0
                     ? `linear-gradient(135deg, ${C.brandLight}, #ffe8d6)`
@@ -795,7 +795,7 @@ function QuickEntryContent(p: QECProps) {
                     {/* 右: カテゴリ + メモ + 記録ボタン */}
                     <div className="flex flex-col gap-3">
                         <div
-                            className="rounded-xl p-3"
+                            className="rounded-md p-3"
                             style={{ border: `1px solid ${C.border}`, background: C.bg }}
                         >
                             <CategoryGrid
@@ -1447,7 +1447,7 @@ export function HomePrototype() {
                             initial={{ scale: 0.6, opacity: 0 }}
                             animate={{ scale: 1,   opacity: 1 }}
                             transition={{ ...SPRING.smooth, delay: 0.1 }}
-                            className="flex h-16 w-16 items-center justify-center rounded-2xl"
+                            className="flex h-16 w-16 items-center justify-center rounded-md"
                             style={{ background: C.brandLight, boxShadow: "0 4px 20px rgba(241,136,64,0.16)" }}
                         >
                             <Sparkles size={28} style={{ color: C.brand }} />
@@ -1464,7 +1464,7 @@ export function HomePrototype() {
                             initial={{ opacity: 0, y: 10 }}
                             animate={{ opacity: 1, y: 0 }}
                             transition={{ ...SPRING.base, delay: 0.2 }}
-                            className="w-full max-w-xs rounded-2xl border-2 p-6 text-center"
+                            className="w-full max-w-xs rounded-md border-2 p-6 text-center"
                             style={{ background: ps.bg, borderColor: ps.border }}
                         >
                             <p className="text-xs font-semibold mb-1" style={{ color: C.muted }}>
@@ -1556,7 +1556,7 @@ export function HomePrototype() {
                                                 <span className="tabular-nums font-semibold">{formatYen(todayTotalExpense)} / {formatYen(MOCK.dailyBudget)}</span>
                                             </div>
                                             <ProgressBar pct={Math.min(100, Math.round(todaySpendPct * 100))} delay={0.1} gradient={todaySpendPct <= 0.8 ? "linear-gradient(90deg, #34d399, #35b5a2)" : todaySpendPct <= 1.0 ? "linear-gradient(90deg, #f9a8d4, #e879a3)" : "linear-gradient(90deg, #fb7185, #f43f5e)"} />
-                                            <div className="mt-3 flex items-center gap-2 rounded-xl px-3 py-2.5" style={{ background: savingsInsight.bg }}>
+                                            <div className="mt-3 flex items-center gap-2 rounded-md px-3 py-2.5" style={{ background: savingsInsight.bg }}>
                                                 <savingsInsight.Icon size={13} style={{ color: savingsInsight.color, flexShrink: 0 }} />
                                                 <span className="text-[11px] font-semibold leading-tight" style={{ color: savingsInsight.color }}>{savingsInsight.message}</span>
                                             </div>
@@ -1680,12 +1680,12 @@ export function HomePrototype() {
                                                     </div>
                                                 </div>
                                                 <div className="grid grid-cols-2 gap-2">
-                                                    <div className="flex flex-col gap-0.5 rounded-xl px-3 py-2.5" style={{ background: momSaved ? C.incomeLight : "rgba(244,63,94,0.06)" }}>
+                                                    <div className="flex flex-col gap-0.5 rounded-md px-3 py-2.5" style={{ background: momSaved ? C.incomeLight : "rgba(244,63,94,0.06)" }}>
                                                         <span className="text-[9px] font-semibold" style={{ color: C.muted }}>先月比 支出</span>
                                                         <span className="text-[18px] font-extrabold tabular-nums" style={{ color: momSaved ? C.income : "#f43f5e", letterSpacing: "-0.02em" }}>{momPct > 0 ? "+" : ""}{momPct}%</span>
                                                         <span className="text-[9px]" style={{ color: C.muted }}>{momSaved ? `月換算で${formatYen(Math.round((lastMonthDailyAvg - thisMonthDailyAvg) * 30))}節約` : "先月より支出増"}</span>
                                                     </div>
-                                                    <div className="flex flex-col gap-0.5 rounded-xl px-3 py-2.5" style={{ background: C.incomeLight }}>
+                                                    <div className="flex flex-col gap-0.5 rounded-md px-3 py-2.5" style={{ background: C.incomeLight }}>
                                                         <span className="text-[9px] font-semibold" style={{ color: C.muted }}>今月の貯蓄率</span>
                                                         <span className="text-[18px] font-extrabold tabular-nums" style={{ color: C.income, letterSpacing: "-0.02em" }}>{sRate}%</span>
                                                         <span className="text-[9px]" style={{ color: C.muted }}>収入の{sRate}%を貯蓄ペース</span>
@@ -1748,7 +1748,7 @@ export function HomePrototype() {
                                 <span className="tabular-nums font-semibold">{formatYen(todayTotalExpense)} / {formatYen(MOCK.dailyBudget)}</span>
                             </div>
                             <ProgressBar pct={Math.min(100, Math.round(todaySpendPct * 100))} delay={0.3} gradient={todaySpendPct <= 0.8 ? "linear-gradient(90deg, #34d399, #35b5a2)" : todaySpendPct <= 1.0 ? "linear-gradient(90deg, #f9a8d4, #e879a3)" : "linear-gradient(90deg, #fb7185, #f43f5e)"} />
-                            <div className="mt-3 flex items-center gap-2 rounded-xl px-3 py-2.5" style={{ background: savingsInsight.bg }}>
+                            <div className="mt-3 flex items-center gap-2 rounded-md px-3 py-2.5" style={{ background: savingsInsight.bg }}>
                                 <savingsInsight.Icon size={13} style={{ color: savingsInsight.color, flexShrink: 0 }} />
                                 <span className="text-[11px] font-semibold leading-tight" style={{ color: savingsInsight.color }}>{savingsInsight.message}</span>
                             </div>
@@ -1852,12 +1852,12 @@ export function HomePrototype() {
                                         </div>
                                     </div>
                                     <div className="grid grid-cols-2 gap-2">
-                                        <div className="flex flex-col gap-0.5 rounded-xl px-3 py-2.5" style={{ background: momSaved ? C.incomeLight : "rgba(244,63,94,0.06)" }}>
+                                        <div className="flex flex-col gap-0.5 rounded-md px-3 py-2.5" style={{ background: momSaved ? C.incomeLight : "rgba(244,63,94,0.06)" }}>
                                             <span className="text-[9px] font-semibold" style={{ color: C.muted }}>先月比 支出</span>
                                             <span className="text-[18px] font-extrabold tabular-nums" style={{ color: momSaved ? C.income : "#f43f5e", letterSpacing: "-0.02em" }}>{momPct > 0 ? "+" : ""}{momPct}%</span>
                                             <span className="text-[9px]" style={{ color: C.muted }}>{momSaved ? `月換算で${formatYen(Math.round((lastMonthDailyAvg - thisMonthDailyAvg) * 30))}節約` : "先月より支出増"}</span>
                                         </div>
-                                        <div className="flex flex-col gap-0.5 rounded-xl px-3 py-2.5" style={{ background: C.incomeLight }}>
+                                        <div className="flex flex-col gap-0.5 rounded-md px-3 py-2.5" style={{ background: C.incomeLight }}>
                                             <span className="text-[9px] font-semibold" style={{ color: C.muted }}>今月の貯蓄率</span>
                                             <span className="text-[18px] font-extrabold tabular-nums" style={{ color: C.income, letterSpacing: "-0.02em" }}>{sRate}%</span>
                                             <span className="text-[9px]" style={{ color: C.muted }}>収入の{sRate}%を貯蓄ペース</span>
@@ -2055,7 +2055,7 @@ export function HomePrototype() {
             {/* ─── PC モーダル（lg 以上、Drawer の代替） ──────────────────────
              *  本実装 apps/web/src/components/ui/dialog.tsx のスタイルを踏襲:
              *  - fixed left-1/2 top-1/2 / -translate-x/y-1/2
-             *  - rounded-2xl, border-2 border-[#1c1410]/10, bg-white, shadow-lg
+             *  - rounded-md, border-2 border-[#1c1410]/10, bg-white, shadow-lg
              *  - black/50 オーバーレイ + backdropFilter blur
              */}
             <AnimatePresence>
@@ -2106,7 +2106,7 @@ export function HomePrototype() {
                                     onClick={handleModalCloseRequest}
                                     whileTap={{ scale: 0.82 }}
                                     transition={SPRING.snap}
-                                    className="flex h-7 w-7 items-center justify-center rounded-lg opacity-60 transition-opacity hover:opacity-100"
+                                    className="flex h-7 w-7 items-center justify-center rounded-md opacity-60 transition-opacity hover:opacity-100"
                                     style={{ color: C.text }}
                                     aria-label="閉じる"
                                 >

--- a/apps/sandbox/src/pages/MeisaiPrototype.tsx
+++ b/apps/sandbox/src/pages/MeisaiPrototype.tsx
@@ -9,28 +9,11 @@
  */
 
 import { useState } from 'react'
-import { Link, useSearchParams } from 'react-router-dom'
+import { useSearchParams } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
-import {
-  Home, Receipt, BarChart2, Settings,
-  Bell, Plus, Search, LayoutList, CalendarDays,
-} from 'lucide-react'
-
-// ── Design tokens ──────────────────────────────────────────────────────────────
-const D = {
-  bg:         '#fffdf5',
-  card:       '#ffffff',
-  text:       '#1c1410',
-  muted:      'rgba(28,20,16,0.45)',
-  border:     'rgba(28,20,16,0.08)',
-  shadow:     '0 2px 12px rgba(28,20,16,0.08), 0 0 0 1px rgba(28,20,16,0.06)',
-  brand:      '#f18840',
-  brandDeep:  '#e8622a',
-  brandLight: '#fff6ee',
-  income:     '#35b5a2',
-  danger:     '#f43f5e',
-  surface:    '#f5f3ef',
-} as const
+import { Search, LayoutList, CalendarDays } from 'lucide-react'
+import { D } from '../components/SandboxCard'
+import { SandboxLayout } from '../components/SandboxLayout'
 
 const SPRING = {
   SNAP:   { type: 'spring', stiffness: 600, damping: 35 },
@@ -38,14 +21,6 @@ const SPRING = {
   BASE:   { type: 'spring', stiffness: 300, damping: 28 },
   SMOOTH: { type: 'spring', stiffness: 200, damping: 26 },
 } as const
-
-// ── Nav ────────────────────────────────────────────────────────────────────────
-const NAV_ITEMS = [
-  { label: 'ホーム',   icon: Home,     to: '/home',              active: false },
-  { label: '明細',     icon: Receipt,  to: '/meisai',            active: true  },
-  { label: 'レポート', icon: BarChart2, to: '/report',            active: false },
-  { label: '設定',     icon: Settings, to: '/personal-settings', active: false },
-] as const
 
 // ── Mock data ──────────────────────────────────────────────────────────────────
 type Tx = { id: number; date: string; label: string; category: string; amount: number; color: string }
@@ -212,76 +187,14 @@ export function MeisaiPrototype() {
   }
 
   return (
-    <>
-      {/* ── PC サイドバー ──────────────────────────────────────────────────── */}
-      <aside
-        className="hidden lg:flex lg:flex-col fixed inset-y-0 left-0 z-30 w-52 border-r"
-        style={{ background: D.card, borderColor: D.border }}
-      >
-        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b px-4" style={{ borderColor: D.border }}>
-          <img src="/logo192.png" alt="家計かんり" className="h-8 w-8 shrink-0" style={{ borderRadius: '10px' }} />
-          <span className="text-[15px] font-extrabold tracking-tight" style={{ color: D.text }}>家計かんり</span>
-        </div>
-        <nav className="flex-1 overflow-y-auto p-3 space-y-0.5" aria-label="メインメニュー">
-          {NAV_ITEMS.map((item) => (
-            <Link key={item.label} to={item.to}
-              aria-current={item.active ? 'page' : undefined}
-              className="flex w-full items-center gap-3 px-3 py-2.5 text-[13px] font-semibold"
-              style={{
-                borderRadius:   '10px',
-                background:     item.active ? D.brandLight : 'transparent',
-                color:          item.active ? D.brand : 'rgba(28,20,16,0.50)',
-                textDecoration: 'none',
-              }}
-            >
-              <item.icon size={17} aria-hidden />
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-        <div className="shrink-0 border-t px-3 py-2.5 flex items-center justify-between" style={{ borderColor: D.border }}>
-          <button type="button" className="flex h-8 w-8 items-center justify-center"
-            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
-            <Bell size={17} />
-          </button>
-          <Link to="/my-page"
-            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
-            style={{
-              background: `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
-              borderRadius: '9999px',
-              boxShadow: '0 2px 8px rgba(241,136,64,0.30)',
-              textDecoration: 'none',
-            }}
-            aria-label="マイページ">Y</Link>
-        </div>
-      </aside>
-
-      <div className="min-h-screen pb-24 lg:pb-8 lg:pl-52" style={{ background: D.bg }}>
-
-        {/* ── SP: ベル + アバター ─────────────────────────────────────────── */}
-        <div className="lg:hidden flex items-center justify-end gap-2 px-4 pt-3 pb-1">
-          <button type="button" className="flex h-8 w-8 items-center justify-center"
-            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
-            <Bell size={17} />
-          </button>
-          <Link to="/my-page"
-            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
-            style={{
-              background: `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
-              borderRadius: '9999px',
-              boxShadow: '0 2px 8px rgba(241,136,64,0.30)',
-              textDecoration: 'none',
-            }}
-            aria-label="マイページ">Y</Link>
-        </div>
+    <SandboxLayout currentPage="meisai" bottomNavVariant="fab">
 
         {/* ── スティッキーコントロール ──────────────────────────────────────── */}
         <div
-          className="sticky top-0 z-10 border-b"
+          className="sticky top-0 z-10"
           style={{
             background:     'rgba(255,253,245,0.96)',
             backdropFilter: 'blur(10px)',
-            borderColor:    D.border,
           }}
         >
           {/* 行1: 期間フィルタ + リスト/カレンダー切替 */}
@@ -307,7 +220,7 @@ export function MeisaiPrototype() {
           </div>
           {/* リスト / カレンダー切替トグル */}
           <div
-            className="flex items-center gap-0.5 rounded-xl p-0.5 shrink-0"
+            className="flex items-center gap-0.5 rounded-md p-0.5 shrink-0"
             style={{ background: D.surface }}
           >
             {([
@@ -316,7 +229,7 @@ export function MeisaiPrototype() {
             ]).map(({ v, Icon }) => (
               <motion.button key={v} type="button"
                 onClick={() => setView(v)}
-                className="flex h-7 w-7 items-center justify-center rounded-lg"
+                className="flex h-7 w-7 items-center justify-center rounded-md"
                 style={{
                   background: view === v ? D.card       : 'transparent',
                   color:      view === v ? D.brand      : D.muted,
@@ -335,7 +248,7 @@ export function MeisaiPrototype() {
           {/* 行2: 検索バー */}
           <div className="px-4 pb-2 md:px-6">
             <div
-              className="flex items-center gap-2 rounded-xl px-3 py-2"
+              className="flex items-center gap-2 rounded-md px-3 py-2"
               style={{ background: D.surface, border: `1px solid ${D.border}` }}
             >
               <Search size={13} style={{ color: D.muted, flexShrink: 0 }} />
@@ -373,7 +286,7 @@ export function MeisaiPrototype() {
                   initial={{ opacity: 0, y: 8 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ ...SPRING.BASE, delay: gi * 0.03 }}
-                  className="rounded-2xl overflow-hidden"
+                  className="rounded-md overflow-hidden"
                   style={{ background: D.card, border: `1px solid ${D.border}`, boxShadow: D.shadow }}
                 >
                   {/* グループヘッダー */}
@@ -437,7 +350,7 @@ export function MeisaiPrototype() {
             >
               {/* カレンダーカード */}
               <div
-                className="rounded-2xl overflow-hidden"
+                className="rounded-md overflow-hidden"
                 style={{ background: D.card, border: `1px solid ${D.border}`, boxShadow: D.shadow }}
               >
                 {/* ヘッダー: ナビ + 月/週トグル */}
@@ -451,7 +364,7 @@ export function MeisaiPrototype() {
                       if (calView === 'month') return
                       setWeekIdx(i => Math.max(0, i - 1))
                     }}
-                    className="flex h-7 w-7 items-center justify-center rounded-lg text-[13px] font-bold"
+                    className="flex h-7 w-7 items-center justify-center rounded-md text-[13px] font-bold"
                     style={{
                       background: D.surface,
                       color: (calView === 'week' && weekIdx > 0) ? D.text : D.muted,
@@ -476,7 +389,7 @@ export function MeisaiPrototype() {
                         if (calView === 'month') return
                         setWeekIdx(i => Math.min(CALENDAR_WEEKS.length - 1, i + 1))
                       }}
-                      className="flex h-7 w-7 items-center justify-center rounded-lg text-[13px] font-bold"
+                      className="flex h-7 w-7 items-center justify-center rounded-md text-[13px] font-bold"
                       style={{
                         background: D.surface,
                         color: (calView === 'week' && weekIdx < CALENDAR_WEEKS.length - 1) ? D.text : D.muted,
@@ -489,7 +402,7 @@ export function MeisaiPrototype() {
 
                     {/* 月 / 週 トグル */}
                     <div
-                      className="flex items-center rounded-lg overflow-hidden"
+                      className="flex items-center rounded-md overflow-hidden"
                       style={{ background: D.surface, padding: '2px' }}
                     >
                       {(['month', 'week'] as const).map(cv => (
@@ -537,7 +450,7 @@ export function MeisaiPrototype() {
                           return (
                             <button key={day} type="button"
                               onClick={() => setSelectedDay(day === selectedDay ? null : day)}
-                              className="flex flex-col items-center justify-center gap-0.5 rounded-xl py-1.5"
+                              className="flex flex-col items-center justify-center gap-0.5 rounded-md py-1.5"
                               style={{
                                 background: isSelected ? D.brand : 'transparent',
                                 color:      isSelected ? '#fff'  : D.text,
@@ -605,7 +518,7 @@ export function MeisaiPrototype() {
                           if (day === null) {
                             return (
                               <div key={`null-${colIdx}`}
-                                className="flex flex-col items-center gap-0.5 rounded-xl py-2"
+                                className="flex flex-col items-center gap-0.5 rounded-md py-2"
                                 style={{ background: D.surface, opacity: 0.3 }}
                               >
                                 <span className="text-[9px] font-bold" style={{ color: D.muted }}>
@@ -621,7 +534,7 @@ export function MeisaiPrototype() {
                           return (
                             <motion.button key={day} type="button"
                               onClick={() => setSelectedDay(day === selectedDay ? null : day)}
-                              className="flex flex-col items-center gap-0.5 rounded-xl py-2"
+                              className="flex flex-col items-center gap-0.5 rounded-md py-2"
                               style={{
                                 background: isSelected ? D.brand : D.surface,
                                 outline:    isToday && !isSelected ? `2px solid ${D.brand}` : 'none',
@@ -670,7 +583,7 @@ export function MeisaiPrototype() {
                     animate={{ opacity: 1 }}
                     exit={{    opacity: 0 }}
                     transition={{ duration: 0.12 }}
-                    className="rounded-2xl overflow-hidden"
+                    className="rounded-md overflow-hidden"
                     style={{ background: D.card, border: `1px solid ${D.border}`, boxShadow: D.shadow }}
                   >
                     <div
@@ -729,63 +642,6 @@ export function MeisaiPrototype() {
         </AnimatePresence>
         </main>
 
-        {/* ── SP モバイルボトムナビ（中央FABパターン） ──────────────────────── */}
-        <nav
-          className="fixed bottom-0 left-0 right-0 z-30 lg:hidden"
-        style={{
-          background:     'rgba(255,253,245,0.92)',
-          backdropFilter: 'blur(16px)',
-          borderTop:      `1px solid ${D.border}`,
-          paddingBottom:  'env(safe-area-inset-bottom, 0px)',
-        }}
-        aria-label="メインメニュー"
-      >
-        <div className="flex items-center h-14">
-          {/* 左2項目 */}
-          {[NAV_ITEMS[0], NAV_ITEMS[1]].map((item) => (
-            <Link key={item.label} to={item.to}
-              aria-current={item.active ? 'page' : undefined}
-              className="flex flex-1 flex-col items-center justify-center gap-0.5 h-full"
-              style={{ color: item.active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}
-            >
-              <item.icon size={20} strokeWidth={item.active ? 2.4 : 2} aria-hidden />
-              <span className="text-[10px] font-bold leading-none">{item.label}</span>
-            </Link>
-          ))}
-
-          {/* 中央 FAB — /home へリンク（記録はホームに集約） */}
-          <div className="flex flex-1 items-end justify-center pb-3">
-            <Link
-              to="/home"
-              aria-label="記録する"
-              className="flex items-center justify-center rounded-full text-white"
-              style={{
-                width:      56,
-                height:     56,
-                background: `linear-gradient(135deg, ${D.brand} 0%, ${D.brandDeep} 100%)`,
-                boxShadow:  '0 4px 20px rgba(241,136,64,0.45), 0 1px 4px rgba(241,136,64,0.20)',
-                textDecoration: 'none',
-              }}
-            >
-              <Plus size={24} />
-            </Link>
-          </div>
-
-          {/* 右2項目 */}
-          {[NAV_ITEMS[2], NAV_ITEMS[3]].map((item) => (
-            <Link key={item.label} to={item.to}
-              aria-current={item.active ? 'page' : undefined}
-              className="flex flex-1 flex-col items-center justify-center gap-0.5 h-full"
-              style={{ color: item.active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}
-            >
-              <item.icon size={20} strokeWidth={item.active ? 2.4 : 2} aria-hidden />
-              <span className="text-[10px] font-bold leading-none">{item.label}</span>
-            </Link>
-          ))}
-          </div>
-        </nav>
-
-      </div>
-    </>
+    </SandboxLayout>
   )
 }

--- a/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
+++ b/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
@@ -12,10 +12,11 @@ import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
-  Check, TrendingUp, Home, Zap, Car, ShoppingBag,
-  Wallet, Heart, Bell, Calendar, BarChart2, Settings, PiggyBank,
-  ChevronLeft, ChevronRight, ChevronDown, Receipt, BookOpen,
+  Check, TrendingUp, Zap, Car, ShoppingBag,
+  Wallet, Heart, Calendar, Settings, PiggyBank,
+  ChevronLeft, ChevronRight, ChevronDown, BookOpen,
 } from 'lucide-react'
+import { SandboxLayout } from '../components/SandboxLayout'
 
 // ─── Spring ──────────────────────────────────────────────────────────────────
 const SPRING = {
@@ -25,22 +26,7 @@ const SPRING = {
   SMOOTH: { type: 'spring', stiffness: 200, damping: 26 },
 } as const
 
-// ─── Design Tokens ───────────────────────────────────────────────────────────
-const D = {
-  bg:          '#fffdf5',
-  card:        '#ffffff',
-  text:        '#1c1410',
-  muted:       'rgba(28,20,16,0.45)',
-  border:      'rgba(28,20,16,0.08)',
-  shadow:      '0 2px 12px rgba(28,20,16,0.08), 0 0 0 1px rgba(28,20,16,0.06)',
-  brand:       '#f18840',
-  brandDeep:   '#e8622a',
-  brandLight:  '#fff6ee',
-  income:      '#35b5a2',
-  danger:      '#f43f5e',
-  caution:     '#f59e0b',
-  surface:     '#f5f3ef',
-} as const
+import { D } from '../components/SandboxCard'
 
 // ─── State ───────────────────────────────────────────────────────────────────
 const INITIAL_STATE = {
@@ -89,7 +75,7 @@ function AmountField({
       {/* − ボタン */}
       <motion.button
         type="button"
-        className="h-9 w-9 shrink-0 rounded-xl flex items-center justify-center text-base font-bold select-none"
+        className="h-9 w-9 shrink-0 rounded-md flex items-center justify-center text-base font-bold select-none"
         style={{ background: D.surface, color: D.muted }}
         onMouseDown={(e) => e.preventDefault()} // blur を抑止して先にクリックを処理
         onClick={() => onChange(Math.max(0, value - step))}
@@ -102,7 +88,7 @@ function AmountField({
 
       {/* 入力フィールド */}
       <div
-        className="flex flex-1 items-center gap-1.5 rounded-xl border px-3 py-2 transition-colors"
+        className="flex flex-1 items-center gap-1.5 rounded-md border px-3 py-2 transition-colors"
         style={{
           borderColor: focused ? D.brand : D.border,
           background:  focused ? D.brandLight : D.surface,
@@ -131,7 +117,7 @@ function AmountField({
       {/* + ボタン */}
       <motion.button
         type="button"
-        className="h-9 w-9 shrink-0 rounded-xl flex items-center justify-center text-base font-bold select-none"
+        className="h-9 w-9 shrink-0 rounded-md flex items-center justify-center text-base font-bold select-none"
         style={{ background: D.surface, color: D.muted }}
         onMouseDown={(e) => e.preventDefault()}
         onClick={() => onChange(value + step)}
@@ -214,7 +200,7 @@ function SalaryDayPicker({ value, onChange }: { value: number; onChange: (v: num
     <div className="flex flex-col gap-2">
       {/* 行1: ラベル + よくある日チップ（メイン選択） */}
       <div className="flex items-center gap-3">
-        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg"
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
           style={{ background: D.surface }}>
           <Calendar size={14} style={{ color: D.brand }} />
         </div>
@@ -222,7 +208,7 @@ function SalaryDayPicker({ value, onChange }: { value: number; onChange: (v: num
         <div className="flex-1 flex items-center justify-end gap-1.5 overflow-x-auto">
           {COMMON_DAYS.map(d => (
             <motion.button key={d} type="button"
-              className="h-9 w-9 rounded-xl text-sm font-bold shrink-0"
+              className="h-9 w-9 rounded-md text-sm font-bold shrink-0"
               style={{
                 background: value === d ? D.brand   : D.surface,
                 color:      value === d ? '#ffffff' : D.text,
@@ -259,7 +245,7 @@ function SalaryDayPicker({ value, onChange }: { value: number; onChange: (v: num
 
           <button ref={triggerRef} type="button"
             onClick={handleToggle}
-            className="flex items-center gap-1 rounded-xl px-2.5 py-1.5 font-bold text-sm tabular-nums"
+            className="flex items-center gap-1 rounded-md px-2.5 py-1.5 font-bold text-sm tabular-nums"
             style={{
               background: open ? D.brandLight : D.surface,
               border:     `1.5px solid ${open ? D.brand : 'transparent'}`,
@@ -328,7 +314,7 @@ function SalaryDayPicker({ value, onChange }: { value: number; onChange: (v: num
                         onClick={() => { onChange(d); setOpen(false) }}
                         role="option"
                         aria-selected={d === value}
-                        className="h-8 w-8 rounded-lg text-[12px] font-bold flex items-center justify-center transition-colors"
+                        className="h-8 w-8 rounded-md text-[12px] font-bold flex items-center justify-center transition-colors"
                         style={{
                           background: d === value
                             ? D.brand
@@ -374,7 +360,7 @@ function SectionCard({ title, children, delay = 0, noClip = false }: {
           {title}
         </span>
       </div>
-      <div className="rounded-2xl border"
+      <div className="rounded-md border"
         style={{
           background: D.card, borderColor: D.border, boxShadow: D.shadow,
           overflow: noClip ? 'visible' : 'hidden',
@@ -405,14 +391,6 @@ function Toast({ visible }: { visible: boolean }) {
     </AnimatePresence>
   )
 }
-
-// ─── Nav ─────────────────────────────────────────────────────────────────────
-const NAV_ITEMS = [
-  { label: 'ホーム',   icon: Home,     to: '/home',              active: false },
-  { label: '明細',     icon: Receipt,  to: '/meisai',            active: false },
-  { label: 'レポート', icon: BarChart2, to: '/report',            active: false },
-  { label: '設定',     icon: Settings, to: '/personal-settings', active: true  },
-] as const
 
 // ─── Main ────────────────────────────────────────────────────────────────────
 export function PersonalSettingsPrototype() {
@@ -453,51 +431,7 @@ export function PersonalSettingsPrototype() {
   }
 
   return (
-    <>
-      {/* ── PC サイドバー ──────────────────────────────────────────────────── */}
-      <aside
-        className="hidden lg:flex lg:flex-col fixed inset-y-0 left-0 z-30 w-52 border-r"
-        style={{ background: D.card, borderColor: D.border }}
-      >
-        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b px-4" style={{ borderColor: D.border }}>
-          <img src="/logo192.png" alt="家計かんり" className="h-8 w-8 shrink-0" style={{ borderRadius: '10px' }} />
-          <span className="text-[15px] font-extrabold tracking-tight" style={{ color: D.text }}>家計かんり</span>
-        </div>
-        <nav className="flex-1 overflow-y-auto p-3 space-y-0.5" aria-label="メインメニュー">
-          {NAV_ITEMS.map((item) => (
-            <Link key={item.label} to={item.to}
-              aria-current={item.active ? 'page' : undefined}
-              className="flex w-full items-center gap-3 px-3 py-2.5 text-[13px] font-semibold"
-              style={{
-                borderRadius:   '10px',
-                background:     item.active ? D.brandLight : 'transparent',
-                color:          item.active ? D.brand : 'rgba(28,20,16,0.50)',
-                textDecoration: 'none',
-              }}
-            >
-              <item.icon size={17} aria-hidden />
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-        <div className="shrink-0 border-t px-3 py-2.5 flex items-center justify-between" style={{ borderColor: D.border }}>
-          <button type="button" className="flex h-8 w-8 items-center justify-center"
-            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
-            <Bell size={17} />
-          </button>
-          <Link to="/my-page"
-            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
-            style={{
-              background: `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
-              borderRadius: '9999px',
-              boxShadow: '0 2px 8px rgba(241,136,64,0.30)',
-              textDecoration: 'none',
-            }}
-            aria-label="マイページ">Y</Link>
-        </div>
-      </aside>
-
-      <div className="min-h-screen pb-24 lg:pb-8 lg:pl-52" style={{ background: D.bg }}>
+    <SandboxLayout currentPage="settings">
 
 
         {/* ── Mini Preview Bar (mobile sticky) ────────────────────────────── */}
@@ -545,53 +479,52 @@ export function PersonalSettingsPrototype() {
       </div>
 
         {/* ── Main ─────────────────────────────────────────────────────────── */}
-        <main className="px-4 py-4 md:px-6 md:py-5">
-        <div className={`grid grid-cols-1 gap-4 lg:items-start lg:gap-5 ${activeMenu === 'settings' ? 'lg:grid-cols-[160px_minmax(0,1fr)_300px]' : 'lg:grid-cols-[160px_minmax(0,1fr)]'}`}>
+        <main className="px-4 pt-4 pb-4 md:px-6 md:pt-3 md:pb-5">
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-[320px_minmax(0,1fr)] lg:items-start lg:gap-5">
 
-          {/* ── PC Left Menu Sidebar ─────────────────────────────────────────── */}
-          <nav
-            className="hidden lg:block lg:col-start-1 lg:row-start-1 lg:sticky lg:top-[5.5rem]"
-            aria-label="設定メニュー"
-          >
-            <div className="rounded-2xl border overflow-hidden" style={{ background: D.card, borderColor: D.border, boxShadow: D.shadow }}>
-              <div className="px-4 pt-3 pb-2 text-[10px] font-bold tracking-widest uppercase" style={{ color: D.muted }}>
-                メニュー
+          {/* ── PC 左カラム: メニュー + プレビュー ──────────────────────────── */}
+          <div className="hidden lg:flex lg:flex-col lg:gap-4 lg:col-start-1 lg:row-start-1 lg:sticky lg:top-4">
+
+            {/* メニュー */}
+            <nav aria-label="設定メニュー">
+              <div className="rounded-md border overflow-hidden" style={{ background: D.card, borderColor: D.border, boxShadow: D.shadow }}>
+                {([
+                  { key: 'settings', label: '設定',   icon: Settings  },
+                  { key: 'guide',    label: 'ガイド', icon: BookOpen  },
+                ] as const).map((item) => {
+                  const active = activeMenu === item.key
+                  return (
+                    <button
+                      key={item.key}
+                      type="button"
+                      onClick={() => setActiveMenu(item.key)}
+                      className="flex w-full items-center gap-3 px-4 py-3.5 text-[13px] font-semibold text-left transition-colors hover:bg-black/[0.03]"
+                      style={{
+                        background: active ? D.brandLight : 'transparent',
+                        color:      active ? D.brandDeep : 'rgba(28,20,16,0.60)',
+                        borderLeft: active ? `3px solid ${D.brand}` : '3px solid transparent',
+                      }}
+                      aria-current={active ? 'page' : undefined}
+                    >
+                      <item.icon size={16} strokeWidth={active ? 2.3 : 2} />
+                      {item.label}
+                    </button>
+                  )
+                })}
+                <div className="h-2" />
               </div>
-              {([
-                { key: 'settings', label: '設定',   icon: Settings  },
-                { key: 'guide',    label: 'ガイド', icon: BookOpen  },
-              ] as const).map((item) => {
-                const active = activeMenu === item.key
-                return (
-                  <button
-                    key={item.key}
-                    type="button"
-                    onClick={() => setActiveMenu(item.key)}
-                    className="flex w-full items-center gap-3 px-4 py-3.5 text-[13px] font-semibold text-left transition-colors hover:bg-black/[0.03]"
-                    style={{
-                      background: active ? D.brandLight : 'transparent',
-                      color:      active ? D.brandDeep : 'rgba(28,20,16,0.60)',
-                      borderLeft: active ? `3px solid ${D.brand}` : '3px solid transparent',
-                    }}
-                    aria-current={active ? 'page' : undefined}
-                  >
-                    <item.icon size={16} strokeWidth={active ? 2.3 : 2} />
-                    {item.label}
-                  </button>
-                )
-              })}
-              <div className="h-2" />
-            </div>
-          </nav>
+            </nav>
 
-          {/* Preview Card — PC only, right column, sticky（設定タブのみ表示） */}
-          <motion.div
-            className={`lg:col-start-3 lg:row-start-1 lg:sticky lg:top-[5.5rem] ${activeMenu === 'settings' ? 'hidden lg:block' : 'hidden'}`}
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ ...SPRING.SMOOTH, delay: 0.04 }}
-          >
-            <div className="relative rounded-3xl overflow-hidden p-5"
+            {/* プレビューカード（設定タブのみ） */}
+            <AnimatePresence>
+            {activeMenu === 'settings' && (
+              <motion.div
+                initial={{ opacity: 0, y: 12 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{    opacity: 0, y: 8  }}
+                transition={{ ...SPRING.SMOOTH, delay: 0.04 }}
+              >
+            <div className="relative rounded-md overflow-hidden p-5"
               style={{ background: D.card, border: `1px solid ${D.border}`, boxShadow: D.shadow }}>
               <motion.div className="absolute rounded-full pointer-events-none"
                 style={{ width: 200, height: 200, top: -80, right: -70,
@@ -601,15 +534,6 @@ export function PersonalSettingsPrototype() {
               />
               <div className="relative">
                 {/* プレビューバッジ */}
-                <div className="flex items-center justify-between mb-1">
-                  <div className="text-[11px] font-semibold" style={{ color: D.muted }}>1日に使えるお金</div>
-                  <div
-                    className="flex items-center gap-1 rounded-full px-2 py-0.5 text-[9px] font-bold"
-                    style={{ background: D.surface, color: 'rgba(28,20,16,0.35)', letterSpacing: '0.04em' }}
-                  >
-                    プレビュー
-                  </div>
-                </div>
                 <motion.div key={dailyBudget}
                   className="text-[52px] font-extrabold leading-none tabular-nums"
                   style={{ color: budgetColor, letterSpacing: '-0.02em' }}
@@ -639,7 +563,7 @@ export function PersonalSettingsPrototype() {
                 </div>
 
                 {/* 内訳（読み取り専用） */}
-                <div className="rounded-xl p-3 mb-4 space-y-1.5 text-[11px]"
+                <div className="rounded-md p-3 mb-4 space-y-1.5 text-[11px]"
                   style={{ background: D.surface, cursor: 'default', userSelect: 'none' }}>
                   {[
                     { label: '月収',     value: state.monthlyIncome, color: D.text,   bold: false, hide: false },
@@ -675,7 +599,7 @@ export function PersonalSettingsPrototype() {
                         : '未設定',
                     },
                   ].map((chip, i) => (
-                    <motion.div key={chip.label} className="rounded-lg p-2"
+                    <motion.div key={chip.label} className="rounded-md p-2"
                       style={{ background: '#f0ede8' }}
                       initial={{ opacity: 0, y: 8 }} animate={{ opacity: 1, y: 0 }}
                       transition={{ ...SPRING.BASE, delay: 0.1 + i * 0.04 }}>
@@ -686,14 +610,18 @@ export function PersonalSettingsPrototype() {
                 </div>
               </div>
             </div>
-          </motion.div>
+            </motion.div>
+            )}
+            </AnimatePresence>
+
+          </div>{/* /左カラム */}
 
           {/* ── Content column ──────────────────────────────────────────────── */}
           <div className="space-y-4 lg:col-start-2 lg:row-start-1">
 
             {/* SP top menu tabs */}
             <div
-              className="flex rounded-xl p-1 gap-1 lg:hidden"
+              className="flex rounded-md p-1 gap-1 lg:hidden"
               style={{ background: D.surface }}
               role="tablist"
               aria-label="設定メニュー"
@@ -710,7 +638,7 @@ export function PersonalSettingsPrototype() {
                     role="tab"
                     aria-selected={active}
                     onClick={() => setActiveMenu(item.key)}
-                    className="flex flex-1 items-center justify-center gap-1.5 rounded-lg py-2 text-[12px] font-bold transition-colors"
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-md py-2 text-[12px] font-bold transition-colors"
                     style={{
                       background: active ? D.card : 'transparent',
                       color:      active ? D.brand : 'rgba(28,20,16,0.45)',
@@ -740,7 +668,7 @@ export function PersonalSettingsPrototype() {
                       className="flex items-center gap-3 px-4 py-3.5 transition-colors hover:bg-[#fff6ee]"
                       style={{ textDecoration: 'none' }}
                     >
-                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
                         style={{ background: D.brandLight }}>
                         <BookOpen size={16} style={{ color: D.brand }} />
                       </div>
@@ -753,7 +681,7 @@ export function PersonalSettingsPrototype() {
 
                     {/* 管理設定ガイド（近日公開） */}
                     <div className="flex items-center gap-3 px-4 py-3.5 opacity-50 cursor-not-allowed select-none border-t" style={{ borderColor: D.border }}>
-                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl"
+                      <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
                         style={{ background: D.surface }}>
                         <Settings size={16} style={{ color: D.muted }} />
                       </div>
@@ -776,7 +704,7 @@ export function PersonalSettingsPrototype() {
               <>
 
             {/* ── SP: アカウント（マイページ代替） ───────────────────────────── */}
-            <div className="lg:hidden rounded-2xl border overflow-hidden" style={{ background: D.card, borderColor: D.border, boxShadow: D.shadow }}>
+            <div className="lg:hidden rounded-md border overflow-hidden" style={{ background: D.card, borderColor: D.border, boxShadow: D.shadow }}>
               <div className="flex items-center gap-3 px-4 py-4">
                 <div
                   className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full text-[15px] font-extrabold text-white"
@@ -868,12 +796,12 @@ export function PersonalSettingsPrototype() {
               <SectionCard title="貯蓄目標" delay={0.16}>
                 <div className="px-4 pt-3.5 pb-6 space-y-3">
                   <div className="flex items-center gap-2 mb-0.5">
-                    <div className="flex h-7 w-7 items-center justify-center rounded-lg"
+                    <div className="flex h-7 w-7 items-center justify-center rounded-md"
                       style={{ background: D.surface }}>
                       <PiggyBank size={14} style={{ color: D.brand }} />
                     </div>
                     <div
-                      className="inline-flex rounded-xl p-0.5 gap-0.5"
+                      className="inline-flex rounded-md p-0.5 gap-0.5"
                       style={{ background: D.surface }}
                       role="tablist"
                       aria-label="貯蓄目標の期間"
@@ -884,7 +812,7 @@ export function PersonalSettingsPrototype() {
                           <motion.button key={mode}
                             role="tab" aria-selected={active} type="button"
                             onClick={() => switchSavingsMode(mode)}
-                            className="px-3 py-1 rounded-lg text-xs font-bold"
+                            className="px-3 py-1 rounded-md text-xs font-bold"
                             style={{
                               background: active ? D.card    : 'transparent',
                               color:      active ? D.brand   : D.muted,
@@ -936,7 +864,7 @@ export function PersonalSettingsPrototype() {
 
             {/* 保存 */}
             <motion.button type="button"
-              className="w-full py-4 rounded-2xl text-sm font-extrabold text-white"
+              className="w-full py-4 rounded-md text-sm font-extrabold text-white"
               style={{ background: D.brand, boxShadow: `0 4px 20px ${D.brand}40` }}
               whileTap={{ scale: 0.97 }}
               onClick={handleSave}
@@ -953,30 +881,7 @@ export function PersonalSettingsPrototype() {
         </div>
         </main>
 
-        {/* ── SP モバイルボトムナビ ──────────────────────────────────────────── */}
-        <nav className="fixed bottom-0 left-0 right-0 z-30 lg:hidden"
-          style={{
-            background: 'rgba(255,253,245,0.92)', backdropFilter: 'blur(16px)',
-            borderTop: `1px solid ${D.border}`,
-            paddingBottom: 'env(safe-area-inset-bottom, 0px)',
-          }}
-          aria-label="メインメニュー"
-        >
-          <div className="grid grid-cols-4 h-14">
-            {NAV_ITEMS.map((item) => (
-              <Link key={item.label} to={item.to}
-                aria-current={item.active ? 'page' : undefined}
-                className="flex flex-col items-center justify-center gap-0.5"
-                style={{ color: item.active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}>
-                <item.icon size={20} strokeWidth={item.active ? 2.4 : 2} aria-hidden />
-                <span className="text-[10px] font-bold leading-none">{item.label}</span>
-              </Link>
-            ))}
-          </div>
-        </nav>
-
         <Toast visible={saved} />
-      </div>
-    </>
+    </SandboxLayout>
   )
 }

--- a/apps/sandbox/src/pages/ReportPrototype.tsx
+++ b/apps/sandbox/src/pages/ReportPrototype.tsx
@@ -7,27 +7,10 @@
 import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
-import {
-  Home, Receipt, BarChart2, Settings,
-  Bell, ArrowRight,
-} from 'lucide-react'
+import { ArrowRight } from 'lucide-react'
 import { EXPENSE_CATEGORY_TOKENS as ET } from '../tokens/categoryTokens'
-
-// ── Design tokens ──────────────────────────────────────────────────────────────
-const D = {
-  bg:         '#fffdf5',
-  card:       '#ffffff',
-  text:       '#1c1410',
-  muted:      'rgba(28,20,16,0.45)',
-  border:     'rgba(28,20,16,0.08)',
-  shadow:     '0 2px 12px rgba(28,20,16,0.08), 0 0 0 1px rgba(28,20,16,0.06)',
-  brand:      '#f18840',
-  brandDeep:  '#e8622a',
-  brandLight: '#fff6ee',
-  income:     '#35b5a2',
-  danger:     '#f43f5e',
-  surface:    '#f5f3ef',
-} as const
+import { D } from '../components/SandboxCard'
+import { SandboxLayout } from '../components/SandboxLayout'
 
 const SPRING = {
   SNAP:   { type: 'spring', stiffness: 600, damping: 35 },
@@ -35,14 +18,6 @@ const SPRING = {
   BASE:   { type: 'spring', stiffness: 300, damping: 28 },
   SMOOTH: { type: 'spring', stiffness: 200, damping: 26 },
 } as const
-
-// ── Nav ────────────────────────────────────────────────────────────────────────
-const NAV_ITEMS = [
-  { label: 'ホーム',   icon: Home,     to: '/home',              active: false },
-  { label: '明細',     icon: Receipt,  to: '/meisai',            active: false },
-  { label: 'レポート', icon: BarChart2, to: '/report',            active: true  },
-  { label: '設定',     icon: Settings, to: '/personal-settings', active: false },
-] as const
 
 // ── Mock data ──────────────────────────────────────────────────────────────────
 type Period = 'week' | 'month' | 'lastMonth'
@@ -106,81 +81,18 @@ export function ReportPrototype() {
     : null
 
   return (
-    <>
-      {/* ── PC サイドバー ──────────────────────────────────────────────────── */}
-      <aside
-        className="hidden lg:flex lg:flex-col fixed inset-y-0 left-0 z-30 w-52 border-r"
-        style={{ background: D.card, borderColor: D.border }}
-      >
-        <div className="flex h-14 shrink-0 items-center gap-2.5 border-b px-4" style={{ borderColor: D.border }}>
-          <img src="/logo192.png" alt="家計かんり" className="h-8 w-8 shrink-0" style={{ borderRadius: '10px' }} />
-          <span className="text-[15px] font-extrabold tracking-tight" style={{ color: D.text }}>家計かんり</span>
-        </div>
-        <nav className="flex-1 overflow-y-auto p-3 space-y-0.5" aria-label="メインメニュー">
-          {NAV_ITEMS.map((item) => (
-            <Link key={item.label} to={item.to}
-              aria-current={item.active ? 'page' : undefined}
-              className="flex w-full items-center gap-3 px-3 py-2.5 text-[13px] font-semibold"
-              style={{
-                borderRadius:   '10px',
-                background:     item.active ? D.brandLight : 'transparent',
-                color:          item.active ? D.brand : 'rgba(28,20,16,0.50)',
-                textDecoration: 'none',
-              }}
-            >
-              <item.icon size={17} aria-hidden />
-              {item.label}
-            </Link>
-          ))}
-        </nav>
-        <div className="shrink-0 border-t px-3 py-2.5 flex items-center justify-between" style={{ borderColor: D.border }}>
-          <button type="button" className="flex h-8 w-8 items-center justify-center"
-            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
-            <Bell size={17} />
-          </button>
-          <Link to="/my-page"
-            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
-            style={{
-              background: `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
-              borderRadius: '9999px',
-              boxShadow: '0 2px 8px rgba(241,136,64,0.30)',
-              textDecoration: 'none',
-            }}
-            aria-label="マイページ">Y</Link>
-        </div>
-      </aside>
-
-      <div className="min-h-screen pb-24 lg:pb-8 lg:pl-52" style={{ background: D.bg }}>
-
-        {/* ── SP: ベル + アバター ─────────────────────────────────────────── */}
-        <div className="lg:hidden flex items-center justify-end gap-2 px-4 pt-3 pb-1">
-          <button type="button" className="flex h-8 w-8 items-center justify-center"
-            style={{ color: 'rgba(28,20,16,0.45)', borderRadius: '8px' }} aria-label="通知">
-            <Bell size={17} />
-          </button>
-          <Link to="/my-page"
-            className="flex h-8 w-8 items-center justify-center text-[12px] font-extrabold text-white"
-            style={{
-              background: `linear-gradient(135deg, ${D.brand}, ${D.brandDeep})`,
-              borderRadius: '9999px',
-              boxShadow: '0 2px 8px rgba(241,136,64,0.30)',
-              textDecoration: 'none',
-            }}
-            aria-label="マイページ">Y</Link>
-        </div>
+    <SandboxLayout currentPage="report">
 
         {/* ── スティッキー期間タブ ─────────────────────────────────────────── */}
         <div
-          className="sticky top-0 z-10 border-b"
+          className="sticky top-0 z-10"
           style={{
             background:     'rgba(255,253,245,0.96)',
             backdropFilter: 'blur(10px)',
-            borderColor:    D.border,
           }}
         >
           <div className="flex items-center gap-2 px-4 py-2 md:px-6">
-            <span className="text-[14px] font-extrabold shrink-0" style={{ color: D.text }}>レポート</span>
-            <div className="flex gap-1 ml-2">
+            <div className="flex gap-1">
               {PERIOD_ORDER.map(p => {
                 const active = period === p
                 return (
@@ -214,7 +126,7 @@ export function ReportPrototype() {
 
             {/* ── 収支サマリーカード ────────────────────────────────────────── */}
             <div
-              className="rounded-2xl p-5"
+              className="rounded-md p-5"
               style={{ background: D.card, border: `1px solid ${D.border}`, boxShadow: D.shadow }}
             >
               {/* タイトル */}
@@ -281,7 +193,7 @@ export function ReportPrototype() {
 
             {/* ── カテゴリ別支出カード ─────────────────────────────────────── */}
             <div
-              className="rounded-2xl p-4"
+              className="rounded-md p-4"
               style={{ background: D.card, border: `1px solid ${D.border}`, boxShadow: D.shadow }}
             >
               <div className="flex items-center justify-between mb-4">
@@ -348,7 +260,7 @@ export function ReportPrototype() {
 
             {/* ── フッター: 明細へのリンク ─────────────────────────────────── */}
             <Link to="/meisai"
-              className="flex items-center justify-center gap-2 rounded-2xl py-3.5 text-[13px] font-bold"
+              className="flex items-center justify-center gap-2 rounded-md py-3.5 text-[13px] font-bold"
               style={{
                 background:     D.brandLight,
                 border:         `1.5px solid rgba(241,136,64,0.24)`,
@@ -364,32 +276,6 @@ export function ReportPrototype() {
         </AnimatePresence>
         </main>
 
-        {/* ── SP モバイルボトムナビ ──────────────────────────────────────────── */}
-        <nav
-          className="fixed bottom-0 left-0 right-0 z-30 lg:hidden"
-          style={{
-            background:     'rgba(255,253,245,0.92)',
-            backdropFilter: 'blur(16px)',
-            borderTop:      `1px solid ${D.border}`,
-            paddingBottom:  'env(safe-area-inset-bottom, 0px)',
-          }}
-          aria-label="メインメニュー"
-        >
-          <div className="grid grid-cols-4 h-14">
-            {NAV_ITEMS.map((item) => (
-              <Link key={item.label} to={item.to}
-                aria-current={item.active ? 'page' : undefined}
-                className="flex flex-col items-center justify-center gap-0.5"
-                style={{ color: item.active ? D.brand : 'rgba(28,20,16,0.40)', textDecoration: 'none' }}
-              >
-                <item.icon size={20} strokeWidth={item.active ? 2.4 : 2} aria-hidden />
-                <span className="text-[10px] font-bold leading-none">{item.label}</span>
-              </Link>
-            ))}
-          </div>
-        </nav>
-
-      </div>
-    </>
+    </SandboxLayout>
   )
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -79,6 +79,29 @@ pre-commit:
 pre-push:
   parallel: false
   commands:
+    # origin/main の最新からリベースされているか確認する。
+    # main への直接 push はスキップ。feature ブランチは必ず rebase してから push すること。
+    rebase-check:
+      run: |
+        CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+        if [ "${CURRENT_BRANCH}" = "main" ]; then
+          exit 0
+        fi
+
+        git fetch origin main --quiet 2>/dev/null || true
+        MERGE_BASE=$(git merge-base HEAD origin/main)
+        MAIN_HEAD=$(git rev-parse origin/main)
+
+        if [ "${MERGE_BASE}" != "${MAIN_HEAD}" ]; then
+          echo "❌ ブランチが origin/main の最新から遅れています。"
+          echo ""
+          echo "   以下を実行してリベースしてから再度 push してください:"
+          echo "   git fetch origin main && git rebase origin/main"
+          exit 1
+        fi
+        echo "✅ origin/main の最新からリベース済みです。"
+      fail_text: "push 前に origin/main へのリベースが必要です。git fetch origin main && git rebase origin/main を実行してください。"
+
     integration-test:
       run: |
         # テスト用 DB コンテナが起動済みか確認（コンテナ名で厳密に判定）


### PR DESCRIPTION
## 🔗 関連 Issue

Closes #363

## Summary

- `designTokens.ts` を追加し、デザイントークン（`D` オブジェクト）を SSOT 化
- `SandboxCard` / `SandboxLayout` を共通コンポーネントとして抽出（ナビゲーション重複コードを削除）
- Report・明細ページのスティッキーヘッダーからボーダーとタイトルを削除
- 設定ページのプレビューカードをメニュー下に移動（ガイドタブ時は非表示）
- 全サンドボックスページの角丸を `rounded-md` に統一

## Test plan

- [x] localhost:5173 でホーム・明細・レポート・設定の各ページが正常に表示される
- [x] 設定ページで「設定」タブ選択時のみプレビューカードが表示される
- [x] 設定ページで「ガイド」タブ選択時はプレビューカードが非表示になる
- [x] SP（スマートフォン）ビューで底部ナビが正しく表示される
- [x] 明細ページで FAB（+ボタン）が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)