### PR TITLE
fix: サンドボックス設定ページのHomeアイコン未定義を修正

### DIFF
--- a/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
+++ b/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
@@ -14,7 +14,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import {
   Check, TrendingUp, Zap, Car, ShoppingBag,
   Wallet, Heart, Calendar, Settings, PiggyBank,
-  ChevronLeft, ChevronRight, ChevronDown, BookOpen,
+  ChevronLeft, ChevronRight, ChevronDown, BookOpen, Home,
 } from 'lucide-react'
 import { SandboxLayout } from '../components/SandboxLayout'
 


### PR DESCRIPTION
## 🔗 関連 Issue

Closes #364

## Summary

- PR #362 でナビ用 import 削除時に `Home` アイコンも誤って削除された
- `PersonalSettingsPrototype.tsx` の固定費「家賃」アイコンで使用していたため `ReferenceError` が発生し白画面になっていた
- lucide-react import に `Home` を追加して修正

## Test plan

- [x] localhost:5173 でサンドボックスが表示される
- [x] 設定ページ（/personal-settings）が正常に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)