### PR TITLE
chore(sandbox): 明細ページのパスを /meisai から /records に変更

### DIFF
--- a/apps/sandbox/src/components/SandboxLayout.tsx
+++ b/apps/sandbox/src/components/SandboxLayout.tsx
@@ -17,7 +17,7 @@ export type SandboxPage = 'home' | 'meisai' | 'report' | 'settings'
 
 const NAV_ITEMS = [
   { label: 'ホーム',   icon: Home,     to: '/home',              page: 'home'     },
-  { label: '明細',     icon: Receipt,  to: '/meisai',            page: 'meisai'   },
+  { label: '明細',     icon: Receipt,  to: '/records',           page: 'meisai'   },
   { label: 'レポート', icon: BarChart2, to: '/report',            page: 'report'   },
   { label: '設定',     icon: Settings, to: '/personal-settings', page: 'settings' },
 ] as const satisfies { label: string; icon: React.ElementType; to: string; page: SandboxPage }[]

--- a/apps/sandbox/src/components/SandboxNav.tsx
+++ b/apps/sandbox/src/components/SandboxNav.tsx
@@ -15,7 +15,7 @@ const PAGES: { path: string; label: string }[] = [
   { path: '/category-ab',              label: '支出カテゴリ TOP A/B' },
   { path: '/personal-settings',        label: '個人設定 — 現行' },
   { path: '/settings-wizard',          label: '個人設定 B — ウィザード' },
-  { path: '/meisai',                   label: '明細' },
+  { path: '/records',                  label: '明細' },
   { path: '/report',                   label: 'レポート' },
   { path: '/status-color-palette',     label: 'ステータスカラー' },
   { path: '/savings-forecast-palette', label: '貯蓄予測カラー' },

--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -27,7 +27,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/personal-settings"   element={<PersonalSettingsPrototype />} />
         <Route path="/settings-wizard"     element={<PersonalSettingsBPrototype />} />
         <Route path="/my-page" element={<MyPagePrototype />} />
-        <Route path="/meisai"              element={<MeisaiPrototype />} />
+        <Route path="/records"             element={<MeisaiPrototype />} />
         <Route path="/report"              element={<ReportPrototype />} />
         <Route path="/status-color-palette" element={<StatusColorPalettePrototype />} />
         <Route path="/savings-forecast-palette" element={<SavingsForecastPalettePrototype />} />

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -44,7 +44,7 @@ const prototypes: PrototypeCard[] = [
     status: 'wip',
   },
   {
-    path: '/meisai',
+    path: '/records',
     title: '明細',
     description: '全記録の閲覧・検索。リスト表示 ⇄ カレンダー表示。期間フィルタ（全期間/今月/先月/直近7日）。',
     icon: Receipt,

--- a/apps/sandbox/src/pages/HomePrototype.tsx
+++ b/apps/sandbox/src/pages/HomePrototype.tsx
@@ -401,7 +401,7 @@ function RecordItem({
 
     return (
         <MotionLink
-            to={`/meisai?date=${date}`}
+            to={`/records?date=${date}`}
             className="flex w-full items-center gap-3 px-4 py-2.5"
             style={{
                 textDecoration: "none",
@@ -1173,7 +1173,7 @@ export function HomePrototype() {
             <nav className="flex-1 overflow-y-auto p-3 space-y-0.5" aria-label="メインメニュー">
                 {[
                     { label: "ホーム",   icon: Home,      to: "/home",              active: true  },
-                    { label: "明細",     icon: Receipt,   to: "/meisai",            active: false },
+                    { label: "明細",     icon: Receipt,   to: "/records",            active: false },
                     { label: "レポート", icon: BarChart2,  to: "/report",            active: false },
                     { label: "設定",     icon: Settings,   to: "/personal-settings", active: false },
                 ].map((item) => (
@@ -1883,7 +1883,7 @@ export function HomePrototype() {
                             <div className="flex items-center justify-between border-b px-4 py-3" style={{ borderColor: C.border }}>
                                 <span className="text-sm font-bold" style={{ color: C.text }}>最近の記録</span>
                                 <MotionLink
-                                    to="/meisai?period=all"
+                                    to="/records?period=all"
                                     whileTap={{ scale: 0.92 }}
                                     transition={SPRING.snap}
                                     className="flex items-center gap-0.5 text-[12px] font-semibold tap-highlight"
@@ -1951,7 +1951,7 @@ export function HomePrototype() {
                     {/* 左2項目 */}
                     {[
                         { label: "ホーム", icon: Home,    to: "/home",   active: true  },
-                        { label: "明細",   icon: Receipt, to: "/meisai", active: false },
+                        { label: "明細",   icon: Receipt, to: "/records", active: false },
                     ].map((item) => (
                         <Link key={item.label} to={item.to}
                             aria-current={item.active ? "page" : undefined}

--- a/apps/sandbox/src/pages/ReportPrototype.tsx
+++ b/apps/sandbox/src/pages/ReportPrototype.tsx
@@ -259,7 +259,7 @@ export function ReportPrototype() {
             </div>
 
             {/* ── フッター: 明細へのリンク ─────────────────────────────────── */}
-            <Link to="/meisai"
+            <Link to="/records"
               className="flex items-center justify-center gap-2 rounded-md py-3.5 text-[13px] font-bold"
               style={{
                 background:     D.brandLight,


### PR DESCRIPTION
## 概要

サンドボックス棚卸しの一環として、日本語パス `/meisai` を英語の `/records` に統一する。

Closes #370

## 変更内容

- `main.tsx`: ルートパスを `/meisai` → `/records` に変更
- `Gallery.tsx`: エントリのパスを更新
- `SandboxNav.tsx`: `PAGES` 配列のパスを更新

## Test plan

- [x] `http://localhost:5173/records` で明細ページが表示される
- [x] `http://localhost:5173/` のギャラリーから明細ページへのリンクが機能する
- [x] SandboxNav の前後ナビゲーションが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)