### PR TITLE
feat(web): framer-motion 導入 & 入力モーダル刷新（1画面完結レイアウト）

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -30,6 +30,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "framer-motion": "^12.38.0",
     "jose": "^6.2.2",
     "lucide-react": "^1.8.0",
     "next": "16.2.6",

--- a/apps/web/src/__tests__/components/ExpenseInputModal.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseInputModal.test.tsx
@@ -2,16 +2,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ExpenseInputModal } from '../../components/input/ExpenseInputModal'
 
-// Server Action をモック
 const mockCreateExpenseAction = vi.fn().mockResolvedValue({ error: null, success: true })
 vi.mock('@/lib/actions/expense', () => ({
     createExpenseAction: (...args: unknown[]) => mockCreateExpenseAction(...args),
 }))
 
-// calcExpenseImpact をモック
 vi.mock('@budget/common', () => ({
     calcExpenseImpact: vi.fn().mockReturnValue({ label: '約10分' }),
 }))
+
+// framer-motion のレイアウトアニメーションをテスト環境用に無効化
+vi.mock('framer-motion', async (importOriginal) => {
+    const actual = await importOriginal<typeof import('framer-motion')>()
+    return {
+        ...actual,
+        AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    }
+})
 
 describe('ExpenseInputModal', () => {
     const defaultProps = {
@@ -24,44 +31,64 @@ describe('ExpenseInputModal', () => {
         vi.clearAllMocks()
     })
 
-    it('初期表示: STEP1 が表示され、支出タブがアクティブである', () => {
+    it('初期表示: タイトルが表示され、支出タブがアクティブである', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        expect(screen.getByText(/STEP 1 \/ 3.*金額/)).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: '支出' })).toBeInTheDocument()
-        expect(screen.getByRole('button', { name: '収入' })).toBeInTheDocument()
-        // 支出ボタンがアクティブスタイルを持つ（text-white クラス）
-        const expenseBtn = screen.getByRole('button', { name: '支出' })
-        expect(expenseBtn.className).toContain('text-white')
+        expect(screen.getByText('支出・収入を記録')).toBeInTheDocument()
+        expect(screen.getByRole('tab', { name: '支出' })).toHaveAttribute('aria-selected', 'true')
+        expect(screen.getByRole('tab', { name: '収入' })).toHaveAttribute('aria-selected', 'false')
     })
 
-    it('収入タブをクリックしたとき: 収入ボタンがアクティブになる', () => {
+    it('初期表示: ¥0 が表示される', () => {
+        render(<ExpenseInputModal {...defaultProps} />)
+        expect(screen.getByText('¥')).toBeInTheDocument()
+        expect(screen.getByTestId('amount-display')).toHaveTextContent('0')
+    })
+
+    it('テンキー: 数字をタップすると金額が更新される', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        const incomeBtn = screen.getByRole('button', { name: '収入' })
-        fireEvent.click(incomeBtn)
+        fireEvent.click(screen.getByRole('button', { name: '1' }))
+        fireEvent.click(screen.getByRole('button', { name: '5' }))
+        fireEvent.click(screen.getByRole('button', { name: '0' }))
 
-        expect(incomeBtn.className).toContain('text-white')
-        // 支出ボタンは非アクティブ
-        const expenseBtn = screen.getByRole('button', { name: '支出' })
-        expect(expenseBtn.className).not.toContain('text-white')
+        expect(screen.getByText('150')).toBeInTheDocument()
+    })
+
+    it('テンキー: 000ボタンで3ゼロが追加される', () => {
+        render(<ExpenseInputModal {...defaultProps} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '1' }))
+        fireEvent.click(screen.getByRole('button', { name: '000' }))
+
+        expect(screen.getByText('1,000')).toBeInTheDocument()
+    })
+
+    it('テンキー: ⌫ボタンで最後の1文字が削除される', () => {
+        render(<ExpenseInputModal {...defaultProps} />)
+
+        fireEvent.click(screen.getByRole('button', { name: '1' }))
+        fireEvent.click(screen.getByRole('button', { name: '2' }))
+        fireEvent.click(screen.getByRole('button', { name: '1文字削除' }))
+
+        expect(screen.getByTestId('amount-display')).toHaveTextContent('1')
     })
 
     it('支出のとき: 金額入力後に家計への影響が表示される', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        // 支出タブはデフォルトで選択済み
         fireEvent.click(screen.getByRole('button', { name: '1' }))
         fireEvent.click(screen.getByRole('button', { name: '0' }))
         fireEvent.click(screen.getByRole('button', { name: '0' }))
 
-        expect(screen.getByText('家計への影響: 約10分')).toBeInTheDocument()
+        expect(screen.getByText(/家計への影響/)).toBeInTheDocument()
+        expect(screen.getByText('約10分')).toBeInTheDocument()
     })
 
-    it('収入のとき: 金額を入力しても家計への影響は表示されない', () => {
+    it('収入のとき: 金額入力後に家計への影響は表示されない', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        fireEvent.click(screen.getByRole('button', { name: '収入' }))
+        fireEvent.click(screen.getByRole('tab', { name: '収入' }))
         fireEvent.click(screen.getByRole('button', { name: '1' }))
         fireEvent.click(screen.getByRole('button', { name: '0' }))
         fireEvent.click(screen.getByRole('button', { name: '0' }))
@@ -69,77 +96,66 @@ describe('ExpenseInputModal', () => {
         expect(screen.queryByText(/家計への影響/)).not.toBeInTheDocument()
     })
 
-    it('STEP3 確認画面: 支出選択時に「支出」が表示される', async () => {
+    it('カテゴリ選択: クリックで別のカテゴリを選べる', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        // 金額入力
-        fireEvent.click(screen.getByRole('button', { name: '1' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        // カテゴリ選択へ
-        fireEvent.click(screen.getByRole('button', { name: 'カテゴリへ →' }))
-        // カテゴリ選択
-        fireEvent.click(screen.getByRole('button', { name: '食費' }))
+        // 「外食」カテゴリをクリック（visible の2番目）
+        fireEvent.click(screen.getByRole('button', { name: '外食' }))
 
-        // STEP3 確認画面
-        expect(screen.getByText(/STEP 3 \/ 3.*確定/)).toBeInTheDocument()
-        expect(screen.getByText(/食費 \/ 支出/)).toBeInTheDocument()
+        // 「外食」ボタンが選択状態になっていることを確認（aria 属性では管理していないため、
+        // 単にボタンが存在することを確認する）
+        expect(screen.getByRole('button', { name: '外食' })).toBeInTheDocument()
     })
 
-    it('STEP3 確認画面: 収入選択時に「収入」が表示される', async () => {
+    it('もっと見る: クリックで残りのカテゴリが表示される', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        // 収入タブを選択
-        fireEvent.click(screen.getByRole('button', { name: '収入' }))
-        // 金額入力
-        fireEvent.click(screen.getByRole('button', { name: '1' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        // カテゴリ選択へ
-        fireEvent.click(screen.getByRole('button', { name: 'カテゴリへ →' }))
-        // カテゴリ選択
-        fireEvent.click(screen.getByRole('button', { name: '食費' }))
+        // 初期表示では「もっと見る」ボタンがある
+        const moreBtn = screen.getByRole('button', { name: /もっと見る/ })
+        expect(moreBtn).toBeInTheDocument()
 
-        expect(screen.getByText(/食費 \/ 収入/)).toBeInTheDocument()
+        fireEvent.click(moreBtn)
+
+        // 展開後は折りたたむボタンが表示される
+        expect(screen.getByRole('button', { name: '折りたたむ' })).toBeInTheDocument()
+        // 展開後は「光熱費」など残りのカテゴリが表示される
+        expect(screen.getByRole('button', { name: '光熱費' })).toBeInTheDocument()
     })
 
-    it('確定ボタン押下（支出）: balanceType=0 で createExpenseAction が呼ばれる', async () => {
+    it('収入タブ切替: 収入カテゴリが表示される', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        // 金額入力
+        fireEvent.click(screen.getByRole('tab', { name: '収入' }))
+
+        expect(screen.getByRole('button', { name: '給料' })).toBeInTheDocument()
+    })
+
+    it('記録するボタン押下（支出）: balanceType=0 で createExpenseAction が呼ばれる', async () => {
+        render(<ExpenseInputModal {...defaultProps} />)
+
         fireEvent.click(screen.getByRole('button', { name: '1' }))
         fireEvent.click(screen.getByRole('button', { name: '0' }))
         fireEvent.click(screen.getByRole('button', { name: '0' }))
-        // カテゴリ選択へ → 選択
-        fireEvent.click(screen.getByRole('button', { name: 'カテゴリへ →' }))
-        fireEvent.click(screen.getByRole('button', { name: '食費' }))
-        // 確定
-        fireEvent.click(screen.getByRole('button', { name: '確定' }))
 
-        // createExpenseAction が呼ばれるまで待つ
+        fireEvent.click(screen.getByRole('button', { name: /記録する/ }))
+
         await vi.waitFor(() => {
             expect(mockCreateExpenseAction).toHaveBeenCalledOnce()
         })
 
         const [, formData] = mockCreateExpenseAction.mock.calls[0] as [unknown, FormData]
         expect(formData.get('balanceType')).toBe('0')
+        expect(formData.get('amount')).toBe('100')
     })
 
-    it('確定ボタン押下（収入）: balanceType=1 で createExpenseAction が呼ばれる', async () => {
+    it('記録するボタン押下（収入）: balanceType=1 で createExpenseAction が呼ばれる', async () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        // 収入タブを選択
-        fireEvent.click(screen.getByRole('button', { name: '収入' }))
-        // 金額入力
+        fireEvent.click(screen.getByRole('tab', { name: '収入' }))
         fireEvent.click(screen.getByRole('button', { name: '5' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        fireEvent.click(screen.getByRole('button', { name: '0' }))
-        // カテゴリ選択へ → 選択
-        fireEvent.click(screen.getByRole('button', { name: 'カテゴリへ →' }))
-        fireEvent.click(screen.getByRole('button', { name: '他' }))
-        // 確定
-        fireEvent.click(screen.getByRole('button', { name: '確定' }))
+        fireEvent.click(screen.getByRole('button', { name: '000' }))
+
+        fireEvent.click(screen.getByRole('button', { name: /記録する/ }))
 
         await vi.waitFor(() => {
             expect(mockCreateExpenseAction).toHaveBeenCalledOnce()
@@ -147,12 +163,13 @@ describe('ExpenseInputModal', () => {
 
         const [, formData] = mockCreateExpenseAction.mock.calls[0] as [unknown, FormData]
         expect(formData.get('balanceType')).toBe('1')
+        expect(formData.get('amount')).toBe('5000')
     })
 
-    it('キャンセルボタン押下: onClose が呼ばれる', () => {
+    it('閉じるボタン押下: onClose が呼ばれる', () => {
         render(<ExpenseInputModal {...defaultProps} />)
 
-        fireEvent.click(screen.getByRole('button', { name: 'キャンセル' }))
+        fireEvent.click(screen.getByRole('button', { name: '閉じる' }))
 
         expect(defaultProps.onClose).toHaveBeenCalledOnce()
     })

--- a/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
@@ -8,6 +8,15 @@ vi.mock("@/lib/actions/expense", () => ({
   createExpenseAction: vi.fn().mockResolvedValue({ error: null, success: false }),
 }));
 
+// AnimatePresence mode="wait" はジョムで exit アニメーションが完了しないためモックする
+vi.mock("framer-motion", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("framer-motion")>();
+  return {
+    ...actual,
+    AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  };
+});
+
 // useActionState のモック
 vi.mock("react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react")>();

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -21,6 +21,7 @@ type Props = {
 };
 
 const VISIBLE_COUNT = 4;
+const MAX_AMOUNT = 9_999_999;
 const initialState: ExpenseActionState = { error: null, success: false };
 
 export function QuickEntryDrawer({
@@ -35,12 +36,12 @@ export function QuickEntryDrawer({
   const [amountStr, setAmountStr] = useState("");
   const [showAll, setShowAll] = useState(false);
   const [memo, setMemo] = useState("");
+  const [date] = useState<string>(() => new Date().toISOString().slice(0, 10));
   const [state, formAction, isPending] = useActionState(createExpenseAction, initialState);
 
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;
   const visible = showAll ? categories : categories.slice(0, VISIBLE_COUNT);
   const rest = categories.slice(VISIBLE_COUNT);
-  const today = new Date().toISOString().split("T")[0];
   const brandColor = balanceType === 0 ? "#e07236" : "#27a08f";
 
   function handleTypeChange(type: 0 | 1) {
@@ -58,7 +59,7 @@ export function QuickEntryDrawer({
     setAmountStr((prev) => {
       if (prev === "" && (k === "0" || k === "000")) return prev;
       const next = prev + k;
-      if (Number(next) > 9_999_999) return prev;
+      if (Number(next) > MAX_AMOUNT) return prev;
       return next;
     });
   }
@@ -79,7 +80,7 @@ export function QuickEntryDrawer({
         >
           <input type="hidden" name="userId" value={userId} />
           <input type="hidden" name="balanceType" value={balanceType} />
-          <input type="hidden" name="date" value={today} />
+          <input type="hidden" name="date" value={date} />
           <input type="hidden" name="categoryId" value={categoryId} />
           <input type="hidden" name="amount" value={amountStr || "0"} />
           {memo && <input type="hidden" name="memo" value={memo} />}
@@ -332,7 +333,7 @@ export function QuickEntryDrawer({
           {/* 記録する */}
           <button
             type="submit"
-            disabled={isPending}
+            disabled={isPending || !amountStr}
             className="flex w-full items-center justify-center gap-2 rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
             style={{ background: "var(--color-brand-primary)" }}
           >

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -1,10 +1,16 @@
 "use client";
 
 import { useActionState, useState } from "react";
+import {
+  Delete, PenLine, ChevronDown, Receipt,
+} from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 import { createExpenseAction } from "@/lib/actions/expense";
 import type { ExpenseActionState } from "@/lib/actions/expense";
 import type { CategoryItem } from "@/lib/api/types";
+import { getCategoryIcon } from "@/lib/categoryTokens";
+import { SPRING } from "@/lib/motion";
 
 type Props = {
   userId: string;
@@ -14,146 +20,330 @@ type Props = {
   incomeCategories: CategoryItem[];
 };
 
+const VISIBLE_COUNT = 4;
 const initialState: ExpenseActionState = { error: null, success: false };
 
-export function QuickEntryDrawer({ userId, open, onOpenChange, expenseCategories, incomeCategories }: Props) {
+export function QuickEntryDrawer({
+  userId,
+  open,
+  onOpenChange,
+  expenseCategories,
+  incomeCategories,
+}: Props) {
   const [balanceType, setBalanceType] = useState<0 | 1>(0);
   const [categoryId, setCategoryId] = useState<number>(expenseCategories[0]?.id ?? 0);
-  const [state, formAction, isPending] = useActionState(
-    createExpenseAction,
-    initialState,
-  );
+  const [amountStr, setAmountStr] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const [memo, setMemo] = useState("");
+  const [state, formAction, isPending] = useActionState(createExpenseAction, initialState);
 
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;
-  const accentColor =
-    balanceType === 0 ? "var(--color-expense)" : "var(--color-income)";
+  const visible = showAll ? categories : categories.slice(0, VISIBLE_COUNT);
+  const rest = categories.slice(VISIBLE_COUNT);
   const today = new Date().toISOString().split("T")[0];
+  const brandColor = balanceType === 0 ? "#e07236" : "#27a08f";
 
   function handleTypeChange(type: 0 | 1) {
     setBalanceType(type);
     const cats = type === 0 ? expenseCategories : incomeCategories;
     setCategoryId(cats[0]?.id ?? 0);
+    setShowAll(false);
+  }
+
+  function handleNumKey(k: string) {
+    if (k === "⌫") {
+      setAmountStr((prev) => prev.slice(0, -1));
+      return;
+    }
+    setAmountStr((prev) => {
+      if (prev === "" && (k === "0" || k === "000")) return prev;
+      const next = prev + k;
+      if (Number(next) > 9_999_999) return prev;
+      return next;
+    });
   }
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent
-        className="rounded-t-3xl bg-white outline-none border-0"
+        className="rounded-t-3xl border-0 bg-[#fffdf5] outline-none"
         style={{ boxShadow: "0 -4px 32px rgba(28,20,16,0.16)" }}
         aria-describedby={undefined}
       >
-        {/* DrawerContent がドラッグハンドルを内包しているため省略 */}
-
-        <DrawerTitle className="px-5 pt-2 pb-1 text-sm font-extrabold text-[#1c1410]">
+        <DrawerTitle className="px-5 pb-1 pt-2 text-sm font-extrabold text-[#1c1410]">
           クイック記録
         </DrawerTitle>
 
-        <form action={formAction} className="px-5 pb-8 pt-2 flex flex-col gap-4">
+        <form action={formAction} className="flex flex-col gap-4 overflow-y-auto px-5 pb-10 pt-2"
+          style={{ maxHeight: "calc(94dvh - 48px)" }}
+        >
           <input type="hidden" name="userId" value={userId} />
           <input type="hidden" name="balanceType" value={balanceType} />
           <input type="hidden" name="date" value={today} />
           <input type="hidden" name="categoryId" value={categoryId} />
+          <input type="hidden" name="amount" value={amountStr || "0"} />
+          {memo && <input type="hidden" name="memo" value={memo} />}
 
-          {/* 種別タブ */}
-          <div className="flex rounded-xl border border-[#1c1410]/12 bg-[#f5f0eb] p-1">
+          {/* 支出 / 収入 セグメントコントロール */}
+          <div
+            className="flex p-1"
+            style={{ borderRadius: "10px", background: "rgba(28,20,16,0.06)" }}
+          >
             {([0, 1] as const).map((t) => (
-              <button
+              <motion.button
                 key={t}
                 type="button"
                 onClick={() => handleTypeChange(t)}
-                className="flex-1 rounded-lg py-2 text-sm font-bold transition-all"
-                style={
-                  balanceType === t
-                    ? {
-                        background:
-                          t === 0
-                            ? "var(--color-expense)"
-                            : "var(--color-income)",
-                        color: "#fff",
-                      }
-                    : { color: "rgba(28,20,16,0.4)" }
-                }
+                whileTap={{ scale: 0.97 }}
+                transition={SPRING.snap}
+                className="relative flex-1 py-2 text-sm font-bold"
+                style={{ borderRadius: "10px", zIndex: 1 }}
               >
-                {t === 0 ? "支出" : "収入"}
-              </button>
+                {balanceType === t && (
+                  <motion.div
+                    layoutId="drawer-tab-bg"
+                    className="absolute inset-0"
+                    style={{
+                      borderRadius: "10px",
+                      background:
+                        t === 0
+                          ? "linear-gradient(135deg, #f18840, #e07236)"
+                          : "linear-gradient(135deg, #35b5a2, #27a08f)",
+                      boxShadow:
+                        t === 0
+                          ? "0 2px 10px rgba(241,136,64,0.28)"
+                          : "0 2px 10px rgba(53,181,162,0.25)",
+                    }}
+                    transition={SPRING.base}
+                  />
+                )}
+                <span
+                  className="relative z-10"
+                  style={{ color: balanceType === t ? "#fff" : "rgba(28,20,16,0.45)" }}
+                >
+                  {t === 0 ? "支出" : "収入"}
+                </span>
+              </motion.button>
             ))}
           </div>
 
-          {/* 金額 */}
-          <div className="rounded-xl border border-[#1c1410]/12 bg-[#fafaf8] px-4 py-3">
-            <div className="flex items-baseline gap-1">
+          {/* 金額表示パネル */}
+          <div
+            className="relative overflow-hidden rounded-xl px-4 py-3"
+            style={{
+              background:
+                balanceType === 0
+                  ? "linear-gradient(135deg, #fff3e8, #ffe8d6)"
+                  : "linear-gradient(135deg, #edfaf7, #d4f5ef)",
+              border: `1.5px solid ${balanceType === 0 ? "rgba(241,136,64,0.22)" : "rgba(53,181,162,0.22)"}`,
+            }}
+          >
+            <div
+              className="mb-1 text-[10px] font-semibold"
+              style={{ color: "rgba(28,20,16,0.45)" }}
+            >
+              {balanceType === 0 ? "支出金額" : "収入金額"}
+            </div>
+            <div className="flex items-baseline gap-0.5">
               <span
-                className="text-xl font-extrabold"
-                style={{ color: accentColor }}
+                className="text-3xl font-black"
+                style={{ color: brandColor, letterSpacing: "-0.03em" }}
               >
                 ¥
               </span>
-              <input
-                name="amount"
-                type="number"
-                inputMode="numeric"
-                placeholder="0"
-                min={1}
-                required
-                className="flex-1 bg-transparent text-3xl font-extrabold tabular-nums outline-none placeholder:text-[#1c1410]/20"
-                style={{ color: accentColor }}
-                autoFocus
-              />
+              <span
+                className="text-3xl font-black tabular-nums"
+                style={{ color: brandColor, letterSpacing: "-0.03em" }}
+              >
+                {amountStr === "" ? "0" : Number(amountStr).toLocaleString("ja-JP")}
+              </span>
             </div>
-            {state.fieldErrors?.amount && (
-              <p className="mt-1 text-xs font-medium text-[#f87171]">
-                {state.fieldErrors.amount[0]}
-              </p>
-            )}
           </div>
 
-          {/* カテゴリ（横スクロール） */}
-          <div className="flex gap-2 overflow-x-auto pb-1 -mx-1 px-1">
-            {categories.map((c) => (
-              <button
-                key={c.id}
-                type="button"
-                onClick={() => setCategoryId(c.id)}
-                className="shrink-0 rounded-full border px-3 py-1.5 text-xs font-bold transition-all"
-                style={
-                  categoryId === c.id
-                    ? {
-                        background: accentColor,
-                        borderColor: accentColor,
-                        color: "#fff",
-                      }
-                    : {
-                        background: "#fff",
-                        borderColor: "rgba(28,20,16,0.12)",
-                        color: "rgba(28,20,16,0.6)",
-                      }
-                }
+          {/* カテゴリグリッド */}
+          <div>
+            <div
+              className="mb-2 text-[10px] font-semibold"
+              style={{ color: "rgba(28,20,16,0.45)" }}
+            >
+              カテゴリ
+              {!showAll && (
+                <span
+                  className="ml-1.5 text-[9px]"
+                  style={{ color: "rgba(28,20,16,0.30)" }}
+                >
+                  よく使う順
+                </span>
+              )}
+            </div>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={balanceType}
+                initial={{ opacity: 0, x: balanceType === 0 ? -6 : 6 }}
+                animate={{ opacity: 1, x: 0 }}
+                exit={{ opacity: 0, x: balanceType === 0 ? 6 : -6 }}
+                transition={{ duration: 0.12 }}
               >
-                {c.name}
-              </button>
+                <div className="grid grid-cols-4 gap-1.5">
+                  {visible.map((cat) => {
+                    const isSelected = categoryId === cat.id;
+                    const Icon = getCategoryIcon(cat.key);
+                    return (
+                      <motion.button
+                        key={cat.id}
+                        type="button"
+                        onClick={() => setCategoryId(cat.id)}
+                        whileTap={{ scale: 0.88 }}
+                        transition={SPRING.snap}
+                        className="relative flex flex-col items-center gap-1 overflow-hidden py-2 text-[10px] font-semibold"
+                        style={{ borderRadius: "10px" }}
+                      >
+                        {isSelected ? (
+                          <motion.div
+                            layoutId="cat-drawer-bg"
+                            className="absolute inset-0"
+                            style={{
+                              borderRadius: "10px",
+                              background: cat.bg,
+                              border: `1.5px solid ${cat.color}40`,
+                            }}
+                            transition={SPRING.base}
+                          />
+                        ) : (
+                          <div
+                            className="absolute inset-0"
+                            style={{
+                              borderRadius: "10px",
+                              background: "#fffdf5",
+                              border: "1px solid rgba(28,20,16,0.10)",
+                            }}
+                          />
+                        )}
+                        <span className="relative z-10">
+                          <Icon
+                            size={16}
+                            style={{
+                              color: isSelected ? cat.color : "rgba(28,20,16,0.35)",
+                            }}
+                            aria-hidden
+                          />
+                        </span>
+                        <span
+                          className="relative z-10 text-center leading-tight"
+                          style={{ color: isSelected ? cat.color : "rgba(28,20,16,0.55)" }}
+                        >
+                          {cat.name}
+                        </span>
+                      </motion.button>
+                    );
+                  })}
+                </div>
+                {rest.length > 0 && (
+                  <motion.button
+                    type="button"
+                    onClick={() => setShowAll(!showAll)}
+                    whileTap={{ scale: 0.96 }}
+                    transition={SPRING.snap}
+                    aria-expanded={showAll}
+                    className="mt-2 flex w-full items-center justify-center gap-1 py-1.5 text-[10px] font-semibold"
+                    style={{
+                      borderRadius: "10px",
+                      background: "#fffdf5",
+                      border: "1px solid rgba(28,20,16,0.10)",
+                      color: "rgba(28,20,16,0.45)",
+                    }}
+                  >
+                    <ChevronDown
+                      size={11}
+                      aria-hidden
+                      style={{
+                        transform: showAll ? "rotate(180deg)" : "rotate(0deg)",
+                        transition: "transform 0.2s",
+                      }}
+                    />
+                    {showAll ? "折りたたむ" : `もっと見る（${rest.length}件）`}
+                  </motion.button>
+                )}
+              </motion.div>
+            </AnimatePresence>
+          </div>
+
+          {/* テンキー */}
+          <div className="grid grid-cols-3 gap-1.5">
+            {["1", "2", "3", "4", "5", "6", "7", "8", "9", "000", "0", "⌫"].map((k) => (
+              <motion.button
+                key={k}
+                type="button"
+                onClick={() => handleNumKey(k)}
+                whileTap={{ scale: 0.84 }}
+                transition={SPRING.snap}
+                aria-label={k === "⌫" ? "1文字削除" : undefined}
+                className="flex h-11 items-center justify-center select-none text-base font-semibold"
+                style={{
+                  borderRadius: "10px",
+                  background: k === "⌫" ? "#fff0ea" : "#fffdf5",
+                  color: k === "⌫" ? "#f18840" : "#1c1410",
+                  border: "1px solid rgba(28,20,16,0.10)",
+                  boxShadow: "0 1px 3px rgba(28,20,16,0.06)",
+                }}
+              >
+                {k === "⌫" ? <Delete size={18} aria-hidden /> : k}
+              </motion.button>
             ))}
           </div>
 
+          {/* メモ（任意） */}
+          <div>
+            <div
+              className="mb-1.5 flex items-center gap-1 text-[10px] font-semibold"
+              style={{ color: "rgba(28,20,16,0.45)" }}
+            >
+              <PenLine size={10} />
+              メモ（任意）
+            </div>
+            <input
+              value={memo}
+              onChange={(e) => setMemo(e.target.value)}
+              className="h-10 w-full px-3 text-sm outline-none transition-colors"
+              style={{
+                fontSize: "16px",
+                border: `1.5px solid ${memo ? "#f18840" : "rgba(28,20,16,0.10)"}`,
+                borderRadius: "12px",
+                background: memo ? "#fff3e8" : "#fffdf5",
+                color: "#1c1410",
+              }}
+              placeholder="店名・用途など"
+              aria-label="メモ"
+            />
+          </div>
+
+          {/* エラー / 成功 */}
           {state.error && (
             <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
               {state.error}
             </p>
           )}
-
           {state.success && (
             <p className="rounded-xl border border-[#4caf82]/40 bg-[#f0fdf6] px-3 py-2 text-sm font-bold text-[#4caf82]">
               登録しました
             </p>
           )}
 
-          {/* 送信ボタン */}
+          {/* 記録する */}
           <button
             type="submit"
             disabled={isPending}
-            className="w-full rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
+            className="flex w-full items-center justify-center gap-2 rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
             style={{ background: "var(--color-brand-primary)" }}
           >
-            {isPending ? "登録中..." : "記録する"}
+            {isPending ? (
+              "登録中..."
+            ) : (
+              <>
+                <Receipt size={16} />
+                記録する
+              </>
+            )}
           </button>
         </form>
       </DrawerContent>

--- a/apps/web/src/components/input/ExpenseInputModal.tsx
+++ b/apps/web/src/components/input/ExpenseInputModal.tsx
@@ -36,6 +36,7 @@ const INCOME_CATS: Cat[] = [
 ];
 
 const VISIBLE_COUNT = 4;
+const MAX_AMOUNT = 9_999_999;
 const today = () => new Date().toISOString().slice(0, 10);
 const INITIAL_STATE: ExpenseActionState = { error: null, success: false };
 
@@ -52,6 +53,7 @@ export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
   const [memo, setMemo] = useState("");
   const [showAll, setShowAll] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
 
   const cats = balanceType === 0 ? EXPENSE_CATS : INCOME_CATS;
@@ -72,7 +74,7 @@ export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
     setAmountStr((prev) => {
       if (prev === "" && (k === "0" || k === "000")) return prev;
       const next = prev + k;
-      if (Number(next) > 9_999_999) return prev;
+      if (Number(next) > MAX_AMOUNT) return prev;
       return next;
     });
   }
@@ -94,13 +96,18 @@ export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
     fd.append("date", today());
     if (memo) fd.append("memo", memo);
 
+    setActionError(null);
     startTransition(async () => {
-      await createExpenseAction(INITIAL_STATE, fd);
-      setSubmitted(true);
-      setTimeout(() => {
-        setSubmitted(false);
-        onClose();
-      }, 800);
+      const result = await createExpenseAction(INITIAL_STATE, fd);
+      if (result.success) {
+        setSubmitted(true);
+        setTimeout(() => {
+          setSubmitted(false);
+          onClose();
+        }, 800);
+      } else {
+        setActionError(result.error ?? "登録に失敗しました");
+      }
     });
   }
 
@@ -417,6 +424,13 @@ export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
                 aria-label="メモ"
               />
             </div>
+
+            {/* エラー表示 */}
+            {actionError && (
+              <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-xs font-medium text-[#1c1410]">
+                {actionError}
+              </p>
+            )}
 
             {/* 記録ボタン */}
             <AnimatePresence mode="wait">

--- a/apps/web/src/components/input/ExpenseInputModal.tsx
+++ b/apps/web/src/components/input/ExpenseInputModal.tsx
@@ -1,229 +1,467 @@
 "use client";
 
-import { useState, useTransition } from "react";
-import { Delete } from "lucide-react";
+import { useState, useTransition, type ElementType } from "react";
+import {
+  ShoppingBasket, Utensils, Car, Zap, Smartphone,
+  Heart, ShoppingBag, Music, Tag,
+  Banknote, Gift, Briefcase, TrendingUp,
+  Delete, PenLine, X, Check, ChevronDown, Receipt,
+} from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
 import { calcExpenseImpact } from "@budget/common";
-import { createExpenseAction, type ExpenseActionState } from "@/lib/actions/expense";
+import { createExpenseAction } from "@/lib/actions/expense";
+import type { ExpenseActionState } from "@/lib/actions/expense";
+import { SPRING } from "@/lib/motion";
 
-type Step = "amount" | "category" | "confirm";
+type Cat = { id: number; key: string; name: string; color: string; bg: string; Icon: ElementType };
 
-interface Category {
-    id: number;
-    key: string;
-    label: string;
-}
-
-const CATEGORIES: Category[] = [
-    { id: 1, key: "food",          label: "食費" },
-    { id: 2, key: "transport",     label: "交通" },
-    { id: 3, key: "utilities",     label: "光熱" },
-    { id: 4, key: "entertainment", label: "娯楽" },
-    { id: 5, key: "medical",       label: "医療" },
-    { id: 6, key: "other",         label: "他" },
+const EXPENSE_CATS: Cat[] = [
+  { id: 1, key: "food",      name: "食費",   color: "#f18840", bg: "#fef5ee", Icon: ShoppingBasket },
+  { id: 2, key: "dining",    name: "外食",   color: "#fb923c", bg: "#fff4ee", Icon: Utensils       },
+  { id: 3, key: "transport", name: "交通費", color: "#60a5fa", bg: "#eff6ff", Icon: Car            },
+  { id: 4, key: "daily",     name: "日用品", color: "#38bdf8", bg: "#f0f9ff", Icon: ShoppingBag    },
+  { id: 5, key: "utility",   name: "光熱費", color: "#fbbf24", bg: "#fffbeb", Icon: Zap            },
+  { id: 6, key: "telecom",   name: "通信費", color: "#818cf8", bg: "#eef2ff", Icon: Smartphone     },
+  { id: 7, key: "medical",   name: "医療費", color: "#fb7185", bg: "#fff1f2", Icon: Heart          },
+  { id: 8, key: "leisure",   name: "趣味",   color: "#c084fc", bg: "#faf5ff", Icon: Music          },
+  { id: 9, key: "other",     name: "その他", color: "#94a3b8", bg: "#f8fafc", Icon: Tag            },
 ];
 
-const today = () => new Date().toISOString().slice(0, 10);
+const INCOME_CATS: Cat[] = [
+  { id: 17, key: "salary",     name: "給料",      color: "#2dd4bf", bg: "#f0fdfa", Icon: Banknote   },
+  { id: 18, key: "bonus",      name: "賞与",      color: "#10b981", bg: "#ecfdf5", Icon: Gift       },
+  { id: 19, key: "sideJob",    name: "副業",      color: "#22c55e", bg: "#f0fdf4", Icon: Briefcase  },
+  { id: 20, key: "investment", name: "投資・配当", color: "#34d399", bg: "#ecfdf5", Icon: TrendingUp },
+  { id: 21, key: "other",      name: "その他",    color: "#94a3b8", bg: "#f8fafc", Icon: Tag        },
+];
 
+const VISIBLE_COUNT = 4;
+const today = () => new Date().toISOString().slice(0, 10);
 const INITIAL_STATE: ExpenseActionState = { error: null, success: false };
 
 interface Props {
-    userId: string;
-    minutesPerYen: number;
-    onClose: () => void;
+  userId: string;
+  minutesPerYen: number;
+  onClose: () => void;
 }
 
-/** 支出入力モーダル（3ステップ）— 家計の寿命への影響をリアルタイム表示 */
 export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
-    const [step, setStep] = useState<Step>("amount");
-    const [amount, setAmount] = useState("");
-    const [category, setCategory] = useState<Category | null>(null);
-    // 0: 支出, 1: 収入
-    const [balanceType, setBalanceType] = useState<0 | 1>(0);
-    const [isPending, startTransition] = useTransition();
+  const [balanceType, setBalanceType] = useState<0 | 1>(0);
+  const [amountStr, setAmountStr] = useState("");
+  const [categoryId, setCategoryId] = useState(EXPENSE_CATS[0].id);
+  const [memo, setMemo] = useState("");
+  const [showAll, setShowAll] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [isPending, startTransition] = useTransition();
 
-    const numAmount = Number(amount);
-    // 家計への影響は支出時のみ表示する
-    const impact = balanceType === 0 && numAmount > 0 && minutesPerYen > 0
-        ? calcExpenseImpact(numAmount, minutesPerYen)
-        : null;
+  const cats = balanceType === 0 ? EXPENSE_CATS : INCOME_CATS;
+  const visible = showAll ? cats : cats.slice(0, VISIBLE_COUNT);
+  const rest = cats.slice(VISIBLE_COUNT);
 
-    function appendDigit(d: string) {
-        if (amount.length >= 9) return;
-        setAmount(prev => prev === "" && d === "0" ? "" : prev + d);
+  const numAmount = amountStr === "" ? 0 : Number(amountStr);
+  const impact =
+    balanceType === 0 && numAmount > 0 && minutesPerYen > 0
+      ? calcExpenseImpact(numAmount, minutesPerYen)
+      : null;
+
+  function handleNumKey(k: string) {
+    if (k === "⌫") {
+      setAmountStr((prev) => prev.slice(0, -1));
+      return;
     }
+    setAmountStr((prev) => {
+      if (prev === "" && (k === "0" || k === "000")) return prev;
+      const next = prev + k;
+      if (Number(next) > 9_999_999) return prev;
+      return next;
+    });
+  }
 
-    function backspace() {
-        setAmount(prev => prev.slice(0, -1));
-    }
+  function handleTypeChange(t: 0 | 1) {
+    setBalanceType(t);
+    const nextCats = t === 0 ? EXPENSE_CATS : INCOME_CATS;
+    setCategoryId(nextCats[0].id);
+    setShowAll(false);
+  }
 
-    function handleConfirm() {
-        if (!category || numAmount <= 0) return;
-        const fd = new FormData();
-        fd.append("userId", userId);
-        fd.append("amount", String(numAmount));
-        fd.append("balanceType", String(balanceType));
-        fd.append("categoryId", String(category.id));
-        fd.append("date", today());
+  function handleSubmit() {
+    if (numAmount <= 0) return;
+    const fd = new FormData();
+    fd.append("userId", userId);
+    fd.append("amount", String(numAmount));
+    fd.append("balanceType", String(balanceType));
+    fd.append("categoryId", String(categoryId));
+    fd.append("date", today());
+    if (memo) fd.append("memo", memo);
 
-        startTransition(async () => {
-            await createExpenseAction(INITIAL_STATE, fd);
-            onClose();
-        });
-    }
+    startTransition(async () => {
+      await createExpenseAction(INITIAL_STATE, fd);
+      setSubmitted(true);
+      setTimeout(() => {
+        setSubmitted(false);
+        onClose();
+      }, 800);
+    });
+  }
 
-    return (
-        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/40 backdrop-blur-sm sm:items-center">
-            <div
-                className="w-full max-w-sm rounded-t-[var(--radius-card)] bg-[var(--color-surface-subtle)] p-6 shadow-xl sm:rounded-[var(--radius-card)]"
-            >
-                {/* STEP 1: 金額入力 */}
-                {step === "amount" && (
-                    <>
-                        <p className="mb-1 text-xs font-medium text-zinc-400">STEP 1 / 3  —  金額</p>
+  const brandColor = balanceType === 0 ? "#e07236" : "#27a08f";
 
-                        {/* 支出 / 収入 タブ */}
-                        <div className="mb-3 flex rounded-[var(--radius-md)] border border-orange-100 bg-white p-0.5">
-                            <button
-                                type="button"
-                                onClick={() => setBalanceType(0)}
-                                className={`flex-1 rounded-[calc(var(--radius-md)-2px)] py-1.5 text-sm font-bold transition-colors ${
-                                    balanceType === 0
-                                        ? "bg-[var(--color-brand-primary)] text-white"
-                                        : "text-zinc-400 hover:text-zinc-600"
-                                }`}
-                            >
-                                支出
-                            </button>
-                            <button
-                                type="button"
-                                onClick={() => setBalanceType(1)}
-                                className={`flex-1 rounded-[calc(var(--radius-md)-2px)] py-1.5 text-sm font-bold transition-colors ${
-                                    balanceType === 1
-                                        ? "bg-[var(--color-brand-primary)] text-white"
-                                        : "text-zinc-400 hover:text-zinc-600"
-                                }`}
-                            >
-                                収入
-                            </button>
-                        </div>
-
-                        <div className="mb-4 border-b border-orange-100 py-3">
-                            <span className="text-4xl font-bold tabular-nums text-zinc-800">
-                                ¥ {amount === "" ? "0" : Number(amount).toLocaleString()}
-                            </span>
-                            {impact && (
-                                <p className="mt-1 text-xs" style={{ color: "var(--color-brand-secondary)" }}>
-                                    家計への影響: {impact.label}
-                                </p>
-                            )}
-                        </div>
-
-                        {/* テンキー */}
-                        <div className="mb-4 grid grid-cols-3 gap-1.5">
-                            {["7","8","9","4","5","6","1","2","3","","0","DEL"].map(k => (
-                                <button
-                                    key={k}
-                                    type="button"
-                                    disabled={k === ""}
-                                    onClick={() => k === "DEL" ? backspace() : appendDigit(k)}
-                                    className="rounded-[var(--radius-md)] border border-orange-100 bg-white py-4 text-lg font-bold text-zinc-700 hover:border-[var(--color-brand-primary)] hover:text-[var(--color-brand-primary)] disabled:invisible"
-                                >
-                                    {k === "DEL" ? <Delete size={18} className="mx-auto" /> : k}
-                                </button>
-                            ))}
-                        </div>
-
-                        <div className="flex gap-2">
-                            <button
-                                type="button"
-                                onClick={onClose}
-                                className="flex-1 rounded-[var(--radius-md)] border border-orange-100 bg-white py-3 text-sm text-zinc-500 hover:border-zinc-300"
-                            >
-                                キャンセル
-                            </button>
-                            <button
-                                type="button"
-                                disabled={numAmount <= 0}
-                                onClick={() => setStep("category")}
-                                className="flex-1 rounded-[var(--radius-md)] bg-[var(--color-brand-primary)] py-3 text-sm font-bold text-white hover:bg-[var(--color-brand-secondary)] disabled:opacity-30"
-                            >
-                                カテゴリへ →
-                            </button>
-                        </div>
-                    </>
-                )}
-
-                {/* STEP 2: カテゴリ選択 */}
-                {step === "category" && (
-                    <>
-                        <p className="mb-1 text-xs font-medium text-zinc-400">STEP 2 / 3  —  カテゴリ</p>
-                        <p className="mb-4 text-xl font-bold tabular-nums text-zinc-800">
-                            ¥ {numAmount.toLocaleString()}
-                        </p>
-
-                        <div className="mb-4 grid grid-cols-3 gap-1.5">
-                            {CATEGORIES.map(c => (
-                                <button
-                                    key={c.id}
-                                    type="button"
-                                    onClick={() => { setCategory(c); setStep("confirm"); }}
-                                    className="rounded-[var(--radius-md)] border border-orange-100 bg-white py-4 text-sm font-bold text-zinc-700 hover:border-[var(--color-brand-primary)] hover:text-[var(--color-brand-primary)]"
-                                >
-                                    {c.label}
-                                </button>
-                            ))}
-                        </div>
-
-                        <button
-                            type="button"
-                            onClick={() => setStep("amount")}
-                            className="w-full rounded-[var(--radius-md)] border border-orange-100 bg-white py-3 text-sm text-zinc-500 hover:border-zinc-300"
-                        >
-                            ← 金額に戻る
-                        </button>
-                    </>
-                )}
-
-                {/* STEP 3: 確定 */}
-                {step === "confirm" && category && (
-                    <>
-                        <p className="mb-1 text-xs font-medium text-zinc-400">STEP 3 / 3  —  確定</p>
-
-                        <div className="mb-5 rounded-[var(--radius-md)] border border-orange-100 bg-white p-4">
-                            <div className="mb-2 flex justify-between text-sm text-zinc-400">
-                                <span>{category.label} / {balanceType === 0 ? "支出" : "収入"}</span>
-                                <span>{today()}</span>
-                            </div>
-                            <p className="text-3xl font-bold tabular-nums text-zinc-800">
-                                ¥ {numAmount.toLocaleString()}
-                            </p>
-                            {impact && (
-                                <p className="mt-3 text-sm" style={{ color: "var(--color-brand-secondary)" }}>
-                                    家計への影響: <strong>{impact.label}</strong>
-                                </p>
-                            )}
-                        </div>
-
-                        <div className="flex gap-2">
-                            <button
-                                type="button"
-                                onClick={() => setStep("category")}
-                                className="flex-1 rounded-[var(--radius-md)] border border-orange-100 bg-white py-3 text-sm text-zinc-500 hover:border-zinc-300"
-                            >
-                                修正する
-                            </button>
-                            <button
-                                type="button"
-                                disabled={isPending}
-                                onClick={handleConfirm}
-                                className="flex-1 rounded-[var(--radius-md)] bg-[var(--color-brand-primary)] py-3 text-sm font-bold text-white hover:bg-[var(--color-brand-secondary)] disabled:opacity-50"
-                            >
-                                {isPending ? "記録中..." : "確定"}
-                            </button>
-                        </div>
-                    </>
-                )}
-            </div>
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+      style={{ background: "rgba(0,0,0,0.40)", backdropFilter: "blur(4px)" }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <motion.div
+        initial={{ y: 40, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        exit={{ y: 40, opacity: 0 }}
+        transition={SPRING.base}
+        className="w-full max-w-lg overflow-y-auto rounded-t-2xl bg-[#fffdf5] p-5 shadow-2xl sm:rounded-2xl"
+        style={{ maxHeight: "94dvh" }}
+      >
+        {/* ヘッダー */}
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-base font-extrabold" style={{ color: "#1c1410" }}>
+            支出・収入を記録
+          </h2>
+          <motion.button
+            type="button"
+            onClick={onClose}
+            whileTap={{ scale: 0.87 }}
+            transition={SPRING.snap}
+            aria-label="閉じる"
+            className="flex h-7 w-7 items-center justify-center rounded-full"
+            style={{ background: "rgba(28,20,16,0.07)", color: "rgba(28,20,16,0.45)" }}
+          >
+            <X size={15} />
+          </motion.button>
         </div>
-    );
+
+        {/* セグメントコントロール */}
+        <div className="mb-4">
+          <div
+            role="tablist"
+            aria-label="収支タイプ選択"
+            className="flex p-1"
+            style={{ borderRadius: "10px", background: "rgba(28,20,16,0.06)" }}
+          >
+            {([0, 1] as const).map((t) => (
+              <motion.button
+                key={t}
+                type="button"
+                role="tab"
+                aria-selected={balanceType === t}
+                onClick={() => handleTypeChange(t)}
+                whileTap={{ scale: 0.97 }}
+                transition={SPRING.snap}
+                className="relative flex-1 py-2 text-sm font-bold"
+                style={{ borderRadius: "10px", zIndex: 1 }}
+              >
+                {balanceType === t && (
+                  <motion.div
+                    layoutId="modal-tab-bg"
+                    className="absolute inset-0"
+                    style={{
+                      borderRadius: "10px",
+                      background:
+                        t === 0
+                          ? "linear-gradient(135deg, #f18840, #e07236)"
+                          : "linear-gradient(135deg, #35b5a2, #27a08f)",
+                      boxShadow:
+                        t === 0
+                          ? "0 2px 10px rgba(241,136,64,0.28)"
+                          : "0 2px 10px rgba(53,181,162,0.25)",
+                    }}
+                    transition={SPRING.base}
+                  />
+                )}
+                <span
+                  className="relative z-10"
+                  style={{ color: balanceType === t ? "#fff" : "rgba(28,20,16,0.45)" }}
+                >
+                  {t === 0 ? "支出" : "収入"}
+                </span>
+              </motion.button>
+            ))}
+          </div>
+        </div>
+
+        {/* モバイル: 縦積み / デスクトップ: 2カラム */}
+        <div className="sm:grid sm:grid-cols-2 sm:gap-4">
+          {/* 左: 金額表示 + テンキー */}
+          <div className="mb-4 space-y-3 sm:mb-0">
+            {/* AmountPanel */}
+            <div
+              className="relative overflow-hidden rounded-xl px-4 py-3"
+              style={{
+                background:
+                  balanceType === 0
+                    ? "linear-gradient(135deg, #fff3e8, #ffe8d6)"
+                    : "linear-gradient(135deg, #edfaf7, #d4f5ef)",
+                border: `1.5px solid ${balanceType === 0 ? "rgba(241,136,64,0.22)" : "rgba(53,181,162,0.22)"}`,
+              }}
+            >
+              <div
+                className="mb-1 text-[10px] font-semibold"
+                style={{ color: "rgba(28,20,16,0.45)" }}
+              >
+                {balanceType === 0 ? "支出金額" : "収入金額"}
+              </div>
+              <div className="flex items-baseline gap-0.5">
+                <span
+                  className="text-3xl font-black"
+                  style={{ color: brandColor, letterSpacing: "-0.03em" }}
+                >
+                  ¥
+                </span>
+                <span
+                  data-testid="amount-display"
+                  className="text-3xl font-black tabular-nums"
+                  style={{ color: brandColor, letterSpacing: "-0.03em" }}
+                >
+                  {amountStr === "" ? "0" : Number(amountStr).toLocaleString("ja-JP")}
+                </span>
+              </div>
+              {impact && (
+                <div
+                  className="mt-1 text-[11px]"
+                  style={{ color: "rgba(28,20,16,0.45)" }}
+                >
+                  家計への影響:{" "}
+                  <span className="font-bold" style={{ color: "#1c1410" }}>
+                    {impact.label}
+                  </span>
+                </div>
+              )}
+              <AnimatePresence>
+                {amountStr && (
+                  <motion.button
+                    type="button"
+                    initial={{ scale: 0, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    exit={{ scale: 0, opacity: 0 }}
+                    whileTap={{ scale: 0.8 }}
+                    transition={SPRING.snap}
+                    onClick={() => setAmountStr("")}
+                    className="absolute right-3 top-3 flex h-6 w-6 items-center justify-center rounded-full"
+                    style={{ background: "rgba(28,20,16,0.10)", color: "rgba(28,20,16,0.45)" }}
+                    aria-label="クリア"
+                  >
+                    <X size={12} />
+                  </motion.button>
+                )}
+              </AnimatePresence>
+            </div>
+
+            {/* Numpad */}
+            <div className="grid grid-cols-3 gap-1.5">
+              {["1", "2", "3", "4", "5", "6", "7", "8", "9", "000", "0", "⌫"].map((k) => (
+                <motion.button
+                  key={k}
+                  type="button"
+                  onClick={() => handleNumKey(k)}
+                  whileTap={{ scale: 0.84 }}
+                  transition={SPRING.snap}
+                  aria-label={k === "⌫" ? "1文字削除" : undefined}
+                  className="flex h-10 items-center justify-center select-none text-base font-semibold"
+                  style={{
+                    borderRadius: "10px",
+                    background: k === "⌫" ? "#fff0ea" : "#fffdf5",
+                    color: k === "⌫" ? "#f18840" : "#1c1410",
+                    border: "1px solid rgba(28,20,16,0.10)",
+                    boxShadow: "0 1px 3px rgba(28,20,16,0.06)",
+                  }}
+                >
+                  {k === "⌫" ? <Delete size={17} aria-hidden /> : k}
+                </motion.button>
+              ))}
+            </div>
+          </div>
+
+          {/* 右: カテゴリ + メモ + 記録ボタン */}
+          <div className="flex flex-col gap-3">
+            {/* CategoryGrid */}
+            <div
+              className="rounded-xl p-3"
+              style={{ border: "1px solid rgba(28,20,16,0.10)", background: "#fffdf5" }}
+            >
+              <div
+                className="mb-2 text-[10px] font-semibold"
+                style={{ color: "rgba(28,20,16,0.45)" }}
+              >
+                カテゴリ
+                {!showAll && (
+                  <span
+                    className="ml-1.5 text-[9px]"
+                    style={{ color: "rgba(28,20,16,0.30)" }}
+                  >
+                    よく使う順
+                  </span>
+                )}
+              </div>
+              <AnimatePresence mode="wait">
+                <motion.div
+                  key={balanceType}
+                  initial={{ opacity: 0, x: balanceType === 0 ? -6 : 6 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: balanceType === 0 ? 6 : -6 }}
+                  transition={{ duration: 0.12 }}
+                >
+                  <div className="grid grid-cols-4 gap-1.5">
+                    {visible.map((cat) => {
+                      const isSelected = categoryId === cat.id;
+                      const Icon = cat.Icon;
+                      return (
+                        <motion.button
+                          key={cat.id}
+                          type="button"
+                          onClick={() => setCategoryId(cat.id)}
+                          whileTap={{ scale: 0.88 }}
+                          transition={SPRING.snap}
+                          className="relative flex flex-col items-center gap-1 overflow-hidden py-2 text-[10px] font-semibold"
+                          style={{ borderRadius: "10px" }}
+                        >
+                          {isSelected ? (
+                            <motion.div
+                              layoutId="cat-modal-bg"
+                              className="absolute inset-0"
+                              style={{
+                                borderRadius: "10px",
+                                background: cat.bg,
+                                border: `1.5px solid ${cat.color}40`,
+                              }}
+                              transition={SPRING.base}
+                            />
+                          ) : (
+                            <div
+                              className="absolute inset-0"
+                              style={{
+                                borderRadius: "10px",
+                                background: "#fffdf5",
+                                border: "1px solid rgba(28,20,16,0.10)",
+                              }}
+                            />
+                          )}
+                          <span className="relative z-10">
+                            <Icon
+                              size={16}
+                              style={{
+                                color: isSelected ? cat.color : "rgba(28,20,16,0.35)",
+                              }}
+                              aria-hidden
+                            />
+                          </span>
+                          <span
+                            className="relative z-10 text-center leading-tight"
+                            style={{ color: isSelected ? cat.color : "rgba(28,20,16,0.55)" }}
+                          >
+                            {cat.name}
+                          </span>
+                        </motion.button>
+                      );
+                    })}
+                  </div>
+                  {rest.length > 0 && (
+                    <motion.button
+                      type="button"
+                      onClick={() => setShowAll(!showAll)}
+                      whileTap={{ scale: 0.96 }}
+                      transition={SPRING.snap}
+                      aria-expanded={showAll}
+                      className="mt-2 flex w-full items-center justify-center gap-1 py-1.5 text-[10px] font-semibold"
+                      style={{
+                        borderRadius: "10px",
+                        background: "#fffdf5",
+                        border: "1px solid rgba(28,20,16,0.10)",
+                        color: "rgba(28,20,16,0.45)",
+                      }}
+                    >
+                      <ChevronDown
+                        size={11}
+                        aria-hidden
+                        style={{
+                          transform: showAll ? "rotate(180deg)" : "rotate(0deg)",
+                          transition: "transform 0.2s",
+                        }}
+                      />
+                      {showAll ? "折りたたむ" : `もっと見る（${rest.length}件）`}
+                    </motion.button>
+                  )}
+                </motion.div>
+              </AnimatePresence>
+            </div>
+
+            {/* メモ */}
+            <div>
+              <div
+                className="mb-1.5 flex items-center gap-1 text-[10px] font-semibold"
+                style={{ color: "rgba(28,20,16,0.45)" }}
+              >
+                <PenLine size={10} />
+                メモ（任意）
+              </div>
+              <input
+                value={memo}
+                onChange={(e) => setMemo(e.target.value)}
+                className="h-9 w-full px-3 text-sm outline-none transition-colors"
+                style={{
+                  border: `1.5px solid ${memo ? "#f18840" : "rgba(28,20,16,0.10)"}`,
+                  borderRadius: "12px",
+                  background: memo ? "#fff3e8" : "#fffdf5",
+                  color: "#1c1410",
+                }}
+                placeholder="店名・用途など"
+                aria-label="メモ"
+              />
+            </div>
+
+            {/* 記録ボタン */}
+            <AnimatePresence mode="wait">
+              {submitted ? (
+                <motion.div
+                  key="success"
+                  initial={{ scale: 0.85, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.9, opacity: 0 }}
+                  transition={SPRING.quick}
+                  className="flex w-full items-center justify-center gap-2 rounded-xl py-3.5 text-sm font-bold text-white"
+                  style={{ background: "linear-gradient(135deg, #35b5a2, #27a08f)" }}
+                >
+                  <Check size={16} strokeWidth={2.5} />
+                  記録しました！
+                </motion.div>
+              ) : (
+                <motion.button
+                  key="submit"
+                  type="button"
+                  onClick={handleSubmit}
+                  disabled={numAmount <= 0 || isPending}
+                  whileTap={{ scale: 0.97 }}
+                  transition={SPRING.snap}
+                  className="flex w-full items-center justify-center gap-2 rounded-xl py-3.5 text-sm font-bold text-white disabled:opacity-40"
+                  style={(() => {
+                    if (!numAmount) return { background: "rgba(28,20,16,0.14)", boxShadow: "none", transition: "background 0.2s, box-shadow 0.2s" };
+                    if (balanceType === 0) return { background: "linear-gradient(135deg, #f18840, #e07236)", boxShadow: "0 4px 16px rgba(241,136,64,0.28)", transition: "background 0.2s, box-shadow 0.2s" };
+                    return { background: "linear-gradient(135deg, #35b5a2, #27a08f)", boxShadow: "0 4px 16px rgba(53,181,162,0.24)", transition: "background 0.2s, box-shadow 0.2s" };
+                  })()}
+                >
+                  {isPending ? (
+                    "記録中..."
+                  ) : (
+                    <>
+                      <Receipt size={15} />
+                      記録する
+                    </>
+                  )}
+                </motion.button>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
 }

--- a/apps/web/src/lib/categoryTokens.ts
+++ b/apps/web/src/lib/categoryTokens.ts
@@ -1,0 +1,37 @@
+import type { ElementType } from "react";
+import {
+  ShoppingBasket, Utensils, Car, Zap, Smartphone,
+  Building2, Landmark, Heart, Shield, ShoppingBag,
+  GraduationCap, Scissors, Shirt, Music, Tag,
+  CircleDashed, Banknote, Gift, Briefcase, Users,
+  Wallet, TrendingUp,
+} from "lucide-react";
+
+const ICON_MAP: Record<string, ElementType> = {
+  food: ShoppingBasket,
+  dining: Utensils,
+  transport: Car,
+  utility: Zap,
+  telecom: Smartphone,
+  housing: Building2,
+  tax: Landmark,
+  medical: Heart,
+  insurance: Shield,
+  daily: ShoppingBag,
+  education: GraduationCap,
+  beauty: Scissors,
+  clothing: Shirt,
+  leisure: Music,
+  other: Tag,
+  unclassified: CircleDashed,
+  salary: Banknote,
+  bonus: Gift,
+  sideJob: Briefcase,
+  pension: Users,
+  benefit: Wallet,
+  investment: TrendingUp,
+};
+
+export function getCategoryIcon(key: string): ElementType {
+  return ICON_MAP[key] ?? Tag;
+}

--- a/apps/web/src/lib/motion.ts
+++ b/apps/web/src/lib/motion.ts
@@ -1,0 +1,40 @@
+import type { Transition, Variants } from "framer-motion";
+
+// Spring プリセット（サンドボックスと共通定義）
+// SNAP(600) / QUICK(400) / BASE(300) / SMOOTH(200) / BAR(70)
+export const SPRING = {
+  snap:   { type: "spring", stiffness: 600, damping: 35 } satisfies Transition,
+  quick:  { type: "spring", stiffness: 400, damping: 30 } satisfies Transition,
+  base:   { type: "spring", stiffness: 300, damping: 28 } satisfies Transition,
+  smooth: { type: "spring", stiffness: 200, damping: 26 } satisfies Transition,
+  bar:    { type: "spring", stiffness: 70,  damping: 18 } satisfies Transition,
+} as const;
+
+// ページコンテンツのフェードイン（stagger ウォーターフォール）
+export const PAGE_VARIANTS: Variants = {
+  hidden:  {},
+  visible: { transition: { staggerChildren: 0.09, delayChildren: 0.04 } },
+};
+
+export const PAGE_ITEM_VARIANTS: Variants = {
+  hidden:  { opacity: 0, y: 22, filter: "blur(8px)" },
+  visible: { opacity: 1, y: 0,  filter: "blur(0px)", transition: SPRING.smooth },
+};
+
+// ドロワー・モーダル内コンテンツの stagger
+export const DRAWER_VARIANTS: Variants = {
+  hidden:  {},
+  visible: { transition: { staggerChildren: 0.07, delayChildren: 0.08 } },
+};
+
+export const DRAWER_ITEM_VARIANTS: Variants = {
+  hidden:  { opacity: 0, y: 14 },
+  visible: { opacity: 1, y: 0, transition: SPRING.quick },
+};
+
+// フェードのみ（レイアウト変化なし）
+export const FADE_VARIANTS: Variants = {
+  hidden:  { opacity: 0 },
+  visible: { opacity: 1, transition: SPRING.smooth },
+  exit:    { opacity: 0, transition: SPRING.smooth },
+};

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -30,6 +30,7 @@ Table category_list {
 
   indexes {
     (key, balanceType) [unique]
+    (balanceType, displayOrder) [unique]
   }
 }
 
@@ -38,7 +39,7 @@ Table budget_list {
   amount Int [not null]
   balanceType Int [not null]
   userId String [not null]
-  categoryId Int [not null, default: 1]
+  categoryId Int [not null]
   content String
   date String [not null]
   createdDate DateTime [default: `now()`, not null]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      framer-motion:
+        specifier: ^12.38.0
+        version: 12.38.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       jose:
         specifier: ^6.2.2
         version: 6.2.2
@@ -227,7 +230,7 @@ importers:
         version: 1.8.0(react@19.2.4)
       next:
         specifier: 16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 19.2.4
         version: 19.2.4
@@ -267,7 +270,7 @@ importers:
         version: 10.3.6(@types/react@19.2.14)(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/nextjs-vite':
         specifier: ^10.3.6
-        version: 10.3.6(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+        version: 10.3.6(esbuild@0.27.7)(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -6905,19 +6908,22 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   validate-npm-package-license@3.0.4:
@@ -9887,18 +9893,18 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  '@storybook/nextjs-vite@10.3.6(@babel/core@7.29.0)(esbuild@0.27.7)(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
+  '@storybook/nextjs-vite@10.3.6(esbuild@0.27.7)(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@storybook/builder-vite': 10.3.6(esbuild@0.27.7)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       '@storybook/react': 10.3.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)
       '@storybook/react-vite': 10.3.6(esbuild@0.27.7)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
-      next: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
       vite: 8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
-      vite-plugin-storybook-nextjs: 3.2.4(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      vite-plugin-storybook-nextjs: 3.2.4(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -13168,7 +13174,7 @@ snapshots:
 
   new-github-issue-url@0.2.1: {}
 
-  next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
@@ -13177,7 +13183,7 @@ snapshots:
       postcss: 8.5.15
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.6
       '@next/swc-darwin-x64': 16.2.6
@@ -14311,12 +14317,10 @@ snapshots:
 
   stubs@3.0.0: {}
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   supports-color@10.2.2: {}
 
@@ -14727,13 +14731,13 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  vite-plugin-storybook-nextjs@3.2.4(next@16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
+  vite-plugin-storybook-nextjs@3.2.4(next@16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@5.9.3)(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)):
     dependencies:
       '@next/env': 16.0.0
       image-size: 2.0.2
       magic-string: 0.30.21
       module-alias: 2.3.4
-      next: 16.2.6(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.6(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       storybook: 10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       ts-dedent: 2.2.0
       vite: 8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)


### PR DESCRIPTION
## 📋 概要

サンドボックスで設計した UI を本実装に段階適用するフェーズ 1 として、以下の 2 点を実施しました。

1. **framer-motion v12 の導入**（Closes #372）: サンドボックスで使用していたアニメーションライブラリを `apps/web` に追加し、プロジェクト共通のスプリング定数・バリアント定義ファイル `src/lib/motion.ts` を新設
2. **入力モーダルの刷新**（Closes #373）: 3 ステップウィザード形式だった `ExpenseInputModal` を 1 画面完結レイアウトに変更。`QuickEntryDrawer` も同レイアウトに統一し、カテゴリアイコン SSOT として `src/lib/categoryTokens.ts` を新設

## 🛠 変更内容

- `apps/web/package.json`: `framer-motion@^12.38.0` を追加
- `apps/web/src/lib/motion.ts`（新規）: `SPRING` プリセット 5 種・`PAGE_VARIANTS` / `DRAWER_VARIANTS` / `FADE_VARIANTS` などアニメーション定数を定義
- `apps/web/src/lib/categoryTokens.ts`（新規）: カテゴリ `key` → lucide-react アイコンのマッピング SSOT
- `apps/web/src/components/input/ExpenseInputModal.tsx`: 3 ステップ → 1 画面レイアウトに全面刷新。セグメントコントロール・金額パネル・テンキー・カテゴリグリッド（もっと見る展開）・メモ欄・記録ボタンで構成。`role="tab"` / `data-testid="amount-display"` を追加してアクセシビリティとテスト安定性を確保。`createExpenseAction` の戻り値チェックと失敗時エラー表示を追加
- `apps/web/src/components/expense/QuickEntryDrawer.tsx`: 横スクロールカテゴリリスト＋ `<input type="number">` → テンキー入力＋カテゴリグリッドに刷新。金額未入力時の submit ガード追加。`today` を `useState` lazy init に変更し SSR hydration 不整合を解消
- `apps/web/src/__tests__/components/ExpenseInputModal.test.tsx`: 旧ウィザードテストを新レイアウト向け 13 テストに全面書き換え
- `apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx`: `AnimatePresence` モックを追加して `mode="wait"` が jsdom で exit アニメーションを完了しない問題を修正

## 🔍 影響範囲

- `apps/web` の UI（支出・収入の入力画面）のみに影響
- `apps/api` / `packages/*` への変更なし
- 既存の `createExpenseAction` サーバーアクション・API インターフェースは変更なし
- 合計 177 unit tests がすべてパス済み

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か
- [x] マジックナンバーを排除し、定数化されているか
- [ ] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか
      <!-- UI変更を含むため、マージ前にレビュー担当者が `pnpm --filter web dev` で実際の画面を確認の上チェックを入れてください -->

## 📸 スクリーンショット

> UI/UX の変更を含むため、マージ前にレビュー担当者が実際の画面を確認してください。
> ローカルで `pnpm --filter web dev` を起動し、変更箇所（支出・収入入力モーダル／クイック記録ドロワー）を確認することを推奨します。

## 🧪 テスト内容

- `ExpenseInputModal`: テンキー操作・カテゴリ選択・もっと見る展開・支出収入タブ切替・記録ボタン押下（FormData 検証）・閉じるボタンの 13 テストを追加
- `QuickEntryDrawer`: 既存 7 テストが引き続きパスすることを確認（`AnimatePresence` モック追加で安定化）
- pre-commit フック（format / lint / type-check / openapi-sync / migration-sync / unit-test）全項目パス済み

## Test plan

- [x] 単体テスト（vitest）: 177 tests 全パス（web 21 ファイル・common 7 ファイル）
- [x] pre-commit フック（format / lint / type-check / openapi-sync / migration-sync / unit-test）全パス
- [x] UI 変更の手動確認はマージ後に `pnpm --filter web dev` で実施予定

## 🔗 関連 Issue

- Closes #372
- Closes #373
- Sprint: 26

## ⚠️ 備考

- マジックナンバーについて: `VISIBLE_COUNT = 4`・`MAX_AMOUNT = 9_999_999` は定数化済み。カラーコードはデザイントークンとして将来的に外出しを検討するが、現スプリントのスコープ外
- `categoryTokens.ts` は Phase 2 以降（QuickEntryDrawer・レポートページ等）でも共通利用予定
- `ExpenseInputModal` のカテゴリデータハードコード指摘（Gemini MEDIUM）: props 経由に変更するには呼び出し元を含む大きなリファクタが必要なため、別 Issue で対応予定