### PR TITLE
feat(sandbox): SandboxButton コンポーネントを追加しボタン UI を統一

### DIFF
--- a/apps/sandbox/src/components/SandboxButton.tsx
+++ b/apps/sandbox/src/components/SandboxButton.tsx
@@ -10,6 +10,7 @@
 import { motion } from 'framer-motion'
 import { Link } from 'react-router-dom'
 import type { ReactNode } from 'react'
+import type { TargetAndTransition, VariantLabels } from 'framer-motion'
 import { D } from './designTokens'
 
 const SNAP = { type: 'spring' as const, stiffness: 600, damping: 35 }
@@ -43,6 +44,8 @@ interface ButtonProps {
   type?: 'button' | 'submit' | 'reset'
   disabled?: boolean
   className?: string
+  initial?: TargetAndTransition | VariantLabels | boolean
+  animate?: TargetAndTransition | VariantLabels
 }
 
 interface LinkButtonProps {
@@ -59,6 +62,8 @@ export function SandboxButton({
   type = 'button',
   disabled = false,
   className = '',
+  initial,
+  animate,
 }: ButtonProps) {
   return (
     <motion.button
@@ -69,6 +74,8 @@ export function SandboxButton({
       transition={SNAP}
       className={`${BASE} ${className}`}
       style={{ ...VARIANT[variant], opacity: disabled ? 0.4 : 1 }}
+      initial={initial}
+      animate={animate}
     >
       {children}
     </motion.button>

--- a/apps/sandbox/src/components/SandboxButton.tsx
+++ b/apps/sandbox/src/components/SandboxButton.tsx
@@ -1,0 +1,95 @@
+/**
+ * SandboxButton — サンドボックス共通ボタンコンポーネント
+ *
+ * variant:
+ *   primary  — ソリッドオレンジ・白文字（メインアクション用）
+ *   ghost    — ライトオレンジ背景・オレンジ文字（サブアクション・リンク用）
+ *   danger   — 透明背景・赤文字（破壊的アクション用）
+ */
+
+import { motion } from 'framer-motion'
+import { Link } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { D } from './designTokens'
+
+const SNAP = { type: 'spring' as const, stiffness: 600, damping: 35 }
+
+const BASE = 'flex items-center justify-center gap-2 rounded-xl py-3.5 text-sm font-bold w-full select-none'
+
+const VARIANT: Record<Variant, React.CSSProperties> = {
+  primary: {
+    background: D.brand,
+    color: '#ffffff',
+    boxShadow: `0 4px 16px ${D.brand}33`,
+  },
+  ghost: {
+    background: D.brandLight,
+    color: D.brand,
+    border: `1.5px solid rgba(241,136,64,0.22)`,
+    textDecoration: 'none',
+  },
+  danger: {
+    background: 'transparent',
+    color: D.danger,
+  },
+}
+
+type Variant = 'primary' | 'ghost' | 'danger'
+
+interface ButtonProps {
+  children: ReactNode
+  variant?: Variant
+  onClick?: () => void
+  type?: 'button' | 'submit' | 'reset'
+  disabled?: boolean
+  className?: string
+}
+
+interface LinkButtonProps {
+  children: ReactNode
+  variant?: Variant
+  to: string
+  className?: string
+}
+
+export function SandboxButton({
+  children,
+  variant = 'primary',
+  onClick,
+  type = 'button',
+  disabled = false,
+  className = '',
+}: ButtonProps) {
+  return (
+    <motion.button
+      type={type}
+      onClick={onClick}
+      disabled={disabled}
+      whileTap={{ scale: 0.97 }}
+      transition={SNAP}
+      className={`${BASE} ${className}`}
+      style={{ ...VARIANT[variant], opacity: disabled ? 0.4 : 1 }}
+    >
+      {children}
+    </motion.button>
+  )
+}
+
+export function SandboxLinkButton({
+  children,
+  variant = 'ghost',
+  to,
+  className = '',
+}: LinkButtonProps) {
+  return (
+    <motion.div whileTap={{ scale: 0.97 }} transition={SNAP}>
+      <Link
+        to={to}
+        className={`${BASE} ${className}`}
+        style={VARIANT[variant]}
+      >
+        {children}
+      </Link>
+    </motion.div>
+  )
+}

--- a/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
+++ b/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
@@ -866,7 +866,11 @@ export function PersonalSettingsPrototype() {
             </div>
 
             {/* 保存 */}
-            <SandboxButton onClick={handleSave}>
+            <SandboxButton
+              onClick={handleSave}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+            >
               設定を保存する
             </SandboxButton>
               </>

--- a/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
+++ b/apps/sandbox/src/pages/PersonalSettingsPrototype.tsx
@@ -27,6 +27,7 @@ const SPRING = {
 } as const
 
 import { D } from '../components/SandboxCard'
+import { SandboxButton } from '../components/SandboxButton'
 
 // ─── State ───────────────────────────────────────────────────────────────────
 const INITIAL_STATE = {
@@ -865,17 +866,9 @@ export function PersonalSettingsPrototype() {
             </div>
 
             {/* 保存 */}
-            <motion.button type="button"
-              className="w-full py-4 rounded-md text-sm font-extrabold text-white"
-              style={{ background: D.brand, boxShadow: `0 4px 20px ${D.brand}40` }}
-              whileTap={{ scale: 0.97 }}
-              onClick={handleSave}
-              transition={SPRING.SNAP}
-              initial={{ opacity: 0, y: 12 }}
-              animate={{ opacity: 1, y: 0 }}
-            >
+            <SandboxButton onClick={handleSave}>
               設定を保存する
-            </motion.button>
+            </SandboxButton>
               </>
             )}
           </div>

--- a/apps/sandbox/src/pages/ReportPrototype.tsx
+++ b/apps/sandbox/src/pages/ReportPrototype.tsx
@@ -4,13 +4,13 @@
  * 責務: 収支サマリー + カテゴリ別分析のみ。記録一覧なし。
  */
 
-import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import { ArrowRight } from 'lucide-react'
 import { EXPENSE_CATEGORY_TOKENS as ET } from '../tokens/categoryTokens'
 import { D } from '../components/SandboxCard'
 import { SandboxLayout } from '../components/SandboxLayout'
+import { SandboxLinkButton } from '../components/SandboxButton'
 
 const SPRING = {
   SNAP:   { type: 'spring', stiffness: 600, damping: 35 },
@@ -259,18 +259,10 @@ export function ReportPrototype() {
             </div>
 
             {/* ── フッター: 明細へのリンク ─────────────────────────────────── */}
-            <Link to="/records"
-              className="flex items-center justify-center gap-2 rounded-md py-3.5 text-[13px] font-bold"
-              style={{
-                background:     D.brandLight,
-                border:         `1.5px solid rgba(241,136,64,0.24)`,
-                color:          D.brand,
-                textDecoration: 'none',
-              }}
-            >
+            <SandboxLinkButton to="/records" variant="ghost">
               詳細な記録を見る
               <ArrowRight size={14} />
-            </Link>
+            </SandboxLinkButton>
 
           </motion.div>
         </AnimatePresence>


### PR DESCRIPTION
## 概要

サンドボックスのボタン UI が各ページで個別にインラインスタイルを書いており統一感がなかった問題を解消する。

`apps/sandbox/src/components/SandboxButton.tsx` を新設し、2 ページのメインアクションボタンに適用。

Closes #386

## 変更内容

### 新規: `SandboxButton.tsx`

| エクスポート | 用途 |
|---|---|
| `SandboxButton` | `<motion.button>` 要素。メインアクション用 |
| `SandboxLinkButton` | `react-router-dom` の `<Link>` ラッパー。ページ遷移ボタン用 |

バリアント:
- **`primary`** — ソリッドオレンジ・白文字・グロウシャドウ（デフォルト）
- **`ghost`** — ライトオレンジ背景・オレンジ文字・サブルボーダー
- **`danger`** — 透明背景・赤文字

共通スペック: `py-3.5 rounded-xl text-sm font-bold w-full` + `whileTap={{ scale: 0.97 }}`

`initial`/`animate` props を受け付け、呼び出し側で入場アニメーションを指定可能。

### 適用箇所

| ページ | ボタン | 変更 |
|---|---|---|
| `ReportPrototype` | 詳細な記録を見る | `<Link>` インラインスタイル → `SandboxLinkButton variant="ghost"` |
| `PersonalSettingsPrototype` | 設定を保存する | `motion.button` インラインスタイル → `SandboxButton variant="primary"`（入場アニメ `opacity 0→1, y 12→0` 復元） |

## Test plan

- [x] TypeScript エラーなし（`tsc --noEmit` パス）
- [x] lint / unit-test パス
- [x] `ReportPrototype` の「詳細な記録を見る」が ghost スタイルで表示される
- [x] `PersonalSettingsPrototype` の「設定を保存する」が primary スタイルで表示される
- [x] 両ボタンが同じ高さ・font・border-radius に揃っていること
- [x] 「設定を保存する」の入場アニメーション（フェードイン＋スライドアップ）が動作する

https://claude.ai/code/session_01LpowwyFxH9PMT35EsCebN2

---
_Generated by [Claude Code](https://claude.ai/code/session_01LpowwyFxH9PMT35EsCebN2)_