### PR TITLE
fix: QuickEntryDrawer の金額表示パネルが潰れる不具合を修正

### DIFF
--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -129,7 +129,7 @@ export function QuickEntryDrawer({
 
           {/* 金額表示パネル */}
           <div
-            className="relative overflow-hidden rounded-xl px-4 py-3"
+            className="relative shrink-0 rounded-xl px-4 py-3"
             style={{
               background:
                 balanceType === 0

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -75,7 +75,7 @@ export function QuickEntryDrawer({
           クイック記録
         </DrawerTitle>
 
-        <form action={formAction} className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-5 pt-2 pb-[calc(2.5rem+env(safe-area-inset-bottom,0px))]"
+        <form action={formAction} className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto px-5 pt-2 pb-[calc(2.5rem+env(safe-area-inset-bottom,0px))]"
         >
           <input type="hidden" name="userId" value={userId} />
           <input type="hidden" name="balanceType" value={balanceType} />
@@ -129,7 +129,7 @@ export function QuickEntryDrawer({
 
           {/* 金額表示パネル */}
           <div
-            className="relative shrink-0 rounded-xl px-4 py-3"
+            className="relative shrink-0 rounded-xl px-4 py-2"
             style={{
               background:
                 balanceType === 0
@@ -278,7 +278,7 @@ export function QuickEntryDrawer({
                 whileTap={{ scale: 0.84 }}
                 transition={SPRING.snap}
                 aria-label={k === "⌫" ? "1文字削除" : undefined}
-                className="flex h-11 items-center justify-center select-none text-base font-semibold"
+                className="flex h-10 items-center justify-center select-none text-base font-semibold"
                 style={{
                   borderRadius: "10px",
                   background: k === "⌫" ? "#fff0ea" : "#fffdf5",
@@ -333,7 +333,7 @@ export function QuickEntryDrawer({
           <button
             type="submit"
             disabled={isPending || !amountStr}
-            className="flex w-full items-center justify-center gap-2 rounded-2xl py-4 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
+            className="flex w-full items-center justify-center gap-2 rounded-2xl py-3 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
             style={{ background: "var(--color-brand-primary)" }}
           >
             {isPending ? (


### PR DESCRIPTION
## 概要

SP（389×710）でドロワーの「記録する」ボタンが見切れる問題を修正。2 点の変更を含む。

## 変更内容

### 1. 金額表示パネルが潰れる不具合修正（Closes #391）

**原因**: CSS Flexbox 仕様で `overflow: hidden` を持つフレックスアイテムは main axis の minimum size が 0 になる。vaul が `DrawerContent` に固定高さを設定すると圧縮アルゴリズムが金額パネルを潰し、`¥0` が非表示になっていた。

```diff
- className="relative overflow-hidden rounded-xl px-4 py-3"
+ className="relative shrink-0 rounded-xl px-4 py-3"
```

### 2. 全体レイアウト調整でボタン見切れを解消

コンテンツが約 60px オーバーしていたため、各要素を均一に縮小:

| 箇所 | 変更 | 削減 |
|------|------|------|
| form の `gap` | `gap-4` → `gap-3` | ≒ 24px |
| 金額パネル余白 | `py-3` → `py-2` | 8px |
| テンキーボタン高さ | `h-11` → `h-10` | 16px |
| 記録するボタン余白 | `py-4` → `py-3` | 8px |

## Test plan

- [x] SP 幅（389px）でドロワーを開き、金額表示（¥0）が正しく表示される
- [x] テンキーで数字を入力して金額が更新される
- [x] 「記録する」ボタンが見切れず表示される

Closes #391