### PR TITLE
feat: サンドボックスUIのデザインシステムを本番に統一

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --hostname 0.0.0.0",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/apps/web/src/app/error.tsx
+++ b/apps/web/src/app/error.tsx
@@ -16,8 +16,8 @@ export default function Error({ error, reset }: Props) {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#fdf8f5] px-4">
       <div
-        className="w-full max-w-sm rounded-2xl border-2 border-[#1c1410] bg-white p-8 text-center"
-        style={{ boxShadow: "4px 4px 0 #1c1410" }}
+        className="w-full max-w-sm rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-8 text-center"
+        style={{ boxShadow: "var(--shadow-card)" }}
       >
         <p className="text-6xl font-extrabold text-[#f18840]">500</p>
         <h1 className="mt-3 text-xl font-extrabold text-[#1c1410]">

--- a/apps/web/src/app/global-error.tsx
+++ b/apps/web/src/app/global-error.tsx
@@ -30,11 +30,11 @@ export default function GlobalError({ error, reset }: Props) {
               width: "100%",
               maxWidth: "360px",
               borderRadius: "16px",
-              border: "2px solid #1c1410",
+              border: "1px solid rgba(28,20,16,0.08)",
               backgroundColor: "white",
               padding: "32px",
               textAlign: "center",
-              boxShadow: "4px 4px 0 #1c1410",
+              boxShadow: "0 1px 4px rgba(28,20,16,0.08)",
             }}
           >
             <p style={{ fontSize: "48px", fontWeight: 900, color: "#f18840", margin: 0 }}>

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -88,19 +88,12 @@
   --color-status-danger-glow: rgba(244, 63, 94, 0.18);
 
   /* ボーダー */
-  --border-default: #e8c8b0;
+  --border-default: rgba(28, 20, 16, 0.08);
   --border-strong: #1c1410;
 
-  /* Soft Pop シャドウ（Refined Edition）
-   *  高優先UI（ボタン・モーダル）: 2px offset hard shadow
-   *  中優先カード: subtle soft shadow のみ
-   *  低優先ブロック: シャドウなし（bg差のみ）
-   */
-  --shadow-pop-sm: 1px 1px 0px 0px #1c1410;
-  --shadow-pop:    2px 2px 0px 0px #1c1410;
-  --shadow-pop-lg: 3px 3px 0px 0px #1c1410;
-  --shadow-card:   0 1px 4px 0 rgba(28, 20, 16, 0.07), 0 0 0 1px rgba(28, 20, 16, 0.06);
-  --shadow-card-hover: 0 4px 12px 0 rgba(28, 20, 16, 0.10), 0 0 0 1px rgba(28, 20, 16, 0.08);
+  /* シャドウ — サンドボックス準拠のソフトシャドウ */
+  --shadow-card:   0 2px 12px rgba(28, 20, 16, 0.08), 0 0 0 1px rgba(28, 20, 16, 0.06);
+  --shadow-card-hover: 0 4px 16px rgba(28, 20, 16, 0.12), 0 0 0 1px rgba(28, 20, 16, 0.08);
   --shadow-card-elevated: 0 4px 16px rgba(28, 20, 16, 0.09), 0 0 0 1px rgba(28, 20, 16, 0.06);
 
   /* モーションイージング（Material You: Emphasized） */
@@ -113,14 +106,11 @@
     --background: #1a1008;
     --foreground: #f0ebe5;
 
-    --border-default: #4a3020;
+    --border-default: rgba(240, 235, 229, 0.08);
     --border-strong: #f0ebe5;
 
-    --shadow-pop-sm: 1px 1px 0px 0px #f0ebe5;
-    --shadow-pop:    2px 2px 0px 0px #f0ebe5;
-    --shadow-pop-lg: 3px 3px 0px 0px #f0ebe5;
-    --shadow-card:   0 1px 4px 0 rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.06);
-    --shadow-card-hover: 0 4px 12px 0 rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.08);
+    --shadow-card:   0 2px 12px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.06);
+    --shadow-card-hover: 0 4px 16px rgba(0, 0, 0, 0.4), 0 0 0 1px rgba(255, 255, 255, 0.08);
 
     --color-brand-primary: #f29050;
     --color-brand-secondary: #e07840;
@@ -228,19 +218,19 @@
   --font-mono: var(--font-geist-mono);
 }
 
-/* ── Refined Geometric コンポーネントパターン ────────────────────
+/* ── コンポーネントパターン（サンドボックス準拠）────────────────
  *
- *  情報優先度による使い分け:
- *  高（メインボタン）: .btn-candy  — オレンジ + 2px ハードシャドウ
- *  中（カード）      : .card-pop   — soft shadow + 1px ボーダー
+ *  ソフトシャドウ＋薄ボーダーのクリーンなデザイン。
+ *  高（メインボタン）: .btn-candy  — オレンジ + グローシャドウ
+ *  中（カード）      : .card-pop   — soft shadow + 薄ボーダー
  *  低（背景要素）    : トーン差のみ（ボーダー・シャドウなし）
  *
    ──────────────────────────────────────────────────────────── */
 @layer components {
-  /* 中優先カード — soft shadow + 1px ボーダー（pop offset なし） */
+  /* 中優先カード — soft shadow + 薄ボーダー */
   .card-pop {
     @apply bg-white rounded-2xl p-6;
-    border: 1px solid rgba(28, 20, 16, 0.12);
+    border: 1px solid rgba(28, 20, 16, 0.08);
     box-shadow: var(--shadow-card);
     transition: box-shadow 0.2s var(--ease-standard);
   }
@@ -248,44 +238,44 @@
     box-shadow: var(--shadow-card-hover);
   }
 
-  /* 高優先プライマリボタン — オレンジ + 2px ハードシャドウ */
+  /* プライマリボタン — オレンジ + グローシャドウ */
   .btn-candy {
-    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm text-white bg-[#f18840] border-2 border-[#1c1410] cursor-pointer select-none;
-    box-shadow: var(--shadow-pop);
-    transition: transform 0.2s var(--ease-standard), box-shadow 0.2s var(--ease-standard);
+    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm text-white bg-[#f18840] cursor-pointer select-none;
+    box-shadow: 0 4px 16px rgba(241, 136, 64, 0.33);
+    transition: opacity 0.2s var(--ease-standard), transform 0.15s var(--ease-standard);
   }
   .btn-candy:hover {
-    transform: translate(-1px, -1px);
-    box-shadow: var(--shadow-pop-lg);
+    opacity: 0.92;
   }
   .btn-candy:active {
-    transform: translate(1px, 1px);
-    box-shadow: none;
+    transform: scale(0.97);
   }
 
-  /* セカンダリボタン — 1px ボーダー + ホバーでbg変化（シャドウなし） */
+  /* ゴーストボタン — ライトオレンジ背景 + 薄ブランドボーダー */
   .btn-ghost {
-    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm bg-white cursor-pointer select-none text-[#1c1410];
-    border: 1px solid rgba(28, 20, 16, 0.25);
+    @apply inline-flex items-center justify-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm cursor-pointer select-none;
+    background-color: #fff6ee;
+    color: #f18840;
+    border: 1.5px solid rgba(241, 136, 64, 0.22);
     transition: background-color 0.2s var(--ease-standard), border-color 0.2s var(--ease-standard);
   }
   .btn-ghost:hover {
-    background-color: #fff6ee;
-    border-color: rgba(28, 20, 16, 0.40);
+    background-color: #fff0e0;
+    border-color: rgba(241, 136, 64, 0.35);
   }
   .btn-ghost:active {
-    background-color: #fff6ee;
+    background-color: #fff0e0;
   }
 
-  /* 入力フィールド — フォーカス時にオレンジリング */
+  /* 入力フィールド — フォーカス時に背景変化 */
   .input-pop {
     @apply w-full rounded-xl bg-white px-3 py-2 text-sm outline-none;
-    border: 1px solid rgba(28, 20, 16, 0.18);
-    transition: border-color 0.2s var(--ease-standard), box-shadow 0.2s var(--ease-standard);
+    border: 1px solid rgba(28, 20, 16, 0.08);
+    transition: border-color 0.2s var(--ease-standard), background-color 0.2s var(--ease-standard);
   }
   .input-pop:focus {
     border-color: #f18840;
-    box-shadow: 0 0 0 3px rgba(241, 136, 64, 0.14);
+    background-color: #fff6ee;
   }
 }
 

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -4,8 +4,8 @@ export default function NotFound() {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#fdf8f5] px-4">
       <div
-        className="w-full max-w-sm rounded-2xl border-2 border-[#1c1410] bg-white p-8 text-center"
-        style={{ boxShadow: "4px 4px 0 #1c1410" }}
+        className="w-full max-w-sm rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-8 text-center"
+        style={{ boxShadow: "var(--shadow-card)" }}
       >
         <p className="text-6xl font-extrabold text-[#f18840]">404</p>
         <h1 className="mt-3 text-xl font-extrabold text-[#1c1410]">

--- a/apps/web/src/components/SwRegister.tsx
+++ b/apps/web/src/components/SwRegister.tsx
@@ -5,16 +5,32 @@ import { useEffect } from 'react';
 /**
  * Service Worker を登録するクライアントコンポーネント。
  * ルートレイアウトに配置し、ブラウザがサポートしている場合のみ登録する。
+ * 開発環境では SW を無効化し、古いキャッシュによる module factory エラーを防ぐ。
  */
 export function SwRegister() {
     useEffect(() => {
-        if ('serviceWorker' in navigator) {
-            navigator.serviceWorker
-                .register('/sw.js')
-                .catch(() => {
-                    // SW 登録失敗はアプリの動作に影響しないため握りつぶす
-                });
+        if (!('serviceWorker' in navigator)) return;
+
+        if (process.env.NODE_ENV === 'development') {
+            // 開発環境: 既存の SW を解除してキャッシュをクリア
+            navigator.serviceWorker.getRegistrations().then((registrations) => {
+                for (const reg of registrations) {
+                    reg.unregister();
+                }
+            });
+            caches.keys().then((keys) => {
+                for (const key of keys) {
+                    caches.delete(key);
+                }
+            });
+            return;
         }
+
+        navigator.serviceWorker
+            .register('/sw.js')
+            .catch(() => {
+                // SW 登録失敗はアプリの動作に影響しないため握りつぶす
+            });
     }, []);
 
     return null;

--- a/apps/web/src/components/SwRegister.tsx
+++ b/apps/web/src/components/SwRegister.tsx
@@ -18,11 +18,13 @@ export function SwRegister() {
                     reg.unregister();
                 }
             });
-            caches.keys().then((keys) => {
-                for (const key of keys) {
-                    caches.delete(key);
-                }
-            });
+            if (typeof caches !== 'undefined') {
+                caches.keys().then((keys) => {
+                    for (const key of keys) {
+                        caches.delete(key);
+                    }
+                });
+            }
             return;
         }
 

--- a/apps/web/src/components/common/Dialog.stories.tsx
+++ b/apps/web/src/components/common/Dialog.stories.tsx
@@ -59,7 +59,7 @@ export const Form: Story = {
             <input
               type="number"
               placeholder="例：150000"
-              className="rounded-xl border-2 border-[#1c1410]/20 px-4 py-2.5 text-sm focus:border-[#f18840] focus:outline-none focus:ring-2 focus:ring-[#f18840]/20"
+              className="rounded-xl border border-[rgba(28,20,16,0.08)] px-4 py-2.5 text-sm focus:border-[#f18840] focus:outline-none focus:bg-[#fff6ee]"
             />
           </label>
         </div>

--- a/apps/web/src/components/common/Drawer.stories.tsx
+++ b/apps/web/src/components/common/Drawer.stories.tsx
@@ -37,7 +37,7 @@ export const Basic: Story = {
             <input
               type="number"
               placeholder="0"
-              className="rounded-xl border-2 border-[#1c1410]/20 px-4 py-2.5 text-sm focus:border-[#f18840] focus:outline-none focus:ring-2 focus:ring-[#f18840]/20"
+              className="rounded-xl border border-[rgba(28,20,16,0.08)] px-4 py-2.5 text-sm focus:border-[#f18840] focus:outline-none focus:bg-[#fff6ee]"
             />
           </label>
         </div>

--- a/apps/web/src/components/common/LoadingSpinner.stories.tsx
+++ b/apps/web/src/components/common/LoadingSpinner.stories.tsx
@@ -39,7 +39,7 @@ export const InsideButton: Story = {
   render: () => (
     <button
       disabled
-      className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm text-white bg-[#f18840] border-2 border-[#1c1410] opacity-50 cursor-not-allowed"
+      className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl font-bold text-sm text-white bg-[#f18840] border border-[rgba(28,20,16,0.08)] opacity-50 cursor-not-allowed"
     >
       <LoadingSpinner size="sm" />
       <span>処理中...</span>

--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -60,8 +60,8 @@ export function BottomNav({ userId, expenseCategories, incomeCategories }: Props
             onClick={() => setDrawerOpen(!drawerOpen)}
             className="relative -top-3 flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform active:scale-95"
             style={{
-              background: "var(--color-brand-primary, #f08030)",
-              boxShadow: "0 4px 16px rgba(240,128,48,0.4)",
+              background: "linear-gradient(135deg, #f18840 0%, #e8622a 100%)",
+              boxShadow: "0 4px 20px rgba(241,136,64,0.45), 0 1px 4px rgba(241,136,64,0.20)",
             }}
           >
             {drawerOpen ? (

--- a/apps/web/src/components/layout/Header.tsx
+++ b/apps/web/src/components/layout/Header.tsx
@@ -48,10 +48,10 @@ export function Header({ userName }: Props) {
         {/* ロゴ */}
         <div className="flex h-14 items-center justify-center border-b border-[#1c1410]/10 px-3">
           {collapsed ? (
-            <LogoImage size={32} style={{ boxShadow: "var(--shadow-pop-sm)" }} />
+            <LogoImage size={32} style={{ boxShadow: "0 1px 4px rgba(28,20,16,0.08)" }} />
           ) : (
             <Link href="/" className="flex items-center gap-2 w-full">
-              <LogoImage size={32} style={{ flexShrink: 0, boxShadow: "var(--shadow-pop-sm)" }} />
+              <LogoImage size={32} style={{ flexShrink: 0, boxShadow: "0 1px 4px rgba(28,20,16,0.08)" }} />
               <div className="flex flex-col leading-none">
                 <span className="text-sm font-extrabold text-[#1c1410]">家計かんり</span>
                 <span className="text-[10px] text-[#1c1410]/40">家計を、もっとシンプルに。</span>
@@ -133,7 +133,7 @@ export function Header({ userName }: Props) {
       {/* ─── モバイル: ミニヘッダー（md未満） ────────────────────── */}
       <header className="sticky top-0 z-20 flex h-14 items-center justify-between border-b border-[#1c1410]/10 bg-[#fffdf5]/90 px-4 backdrop-blur-md md:hidden">
         <Link href="/" className="flex items-center gap-2">
-          <LogoImage size={28} style={{ boxShadow: "var(--shadow-pop-sm)" }} />
+          <LogoImage size={28} style={{ boxShadow: "0 1px 4px rgba(28,20,16,0.08)" }} />
           <span className="text-sm font-extrabold text-[#1c1410]">家計かんり</span>
         </Link>
         <Link href="/expenses/new" className="btn-candy text-xs px-3 py-1.5">

--- a/apps/web/src/components/login/LoginForm.tsx
+++ b/apps/web/src/components/login/LoginForm.tsx
@@ -57,7 +57,7 @@ export function LoginForm({ returnTo }: Props) {
             width={48}
             height={48}
             className="rounded-2xl"
-            style={{ boxShadow: "var(--shadow-pop-sm)" }}
+            style={{ boxShadow: "0 1px 4px rgba(28,20,16,0.08)" }}
           />
           <span className="text-2xl font-extrabold text-[#1c1410] tracking-tight">
             Budget
@@ -68,7 +68,7 @@ export function LoginForm({ returnTo }: Props) {
         </p>
       </div>
 
-      <section className="w-full max-w-sm rounded-2xl border border-[#e8c8b0] bg-white p-8">
+      <section className="w-full max-w-sm rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-8" style={{ boxShadow: "var(--shadow-card)" }}>
         <h1 className="mb-5 text-lg font-bold text-[#1c1410]">ログイン</h1>
 
         <Suspense>
@@ -136,7 +136,7 @@ export function LoginForm({ returnTo }: Props) {
           </button>
         </form>
 
-        <div className="mt-4 border-t border-[#e8c8b0] pt-4 space-y-3">
+        <div className="mt-4 border-t border-[rgba(28,20,16,0.08)] pt-4 space-y-3">
           <form action={guestLoginAction}>
             {returnTo && (
               <input type="hidden" name="returnTo" value={returnTo} />

--- a/apps/web/src/components/recovery/ForgotPasswordFlow.tsx
+++ b/apps/web/src/components/recovery/ForgotPasswordFlow.tsx
@@ -82,7 +82,7 @@ function VerifyStep({
         <form action={formAction} className="flex flex-col gap-4">
             <input type="hidden" name="userId" value={userId} />
 
-            <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] px-4 py-3">
+            <div className="rounded-xl border border-[rgba(28,20,16,0.08)] bg-[#fffdf5] px-4 py-3">
                 <p className="text-xs font-bold text-[#1c1410]/40 mb-1">秘密の質問</p>
                 <p className="text-sm font-bold text-[#1c1410]">{questionText}</p>
             </div>
@@ -182,13 +182,13 @@ export function ForgotPasswordFlow() {
     return (
         <div className="flex min-h-screen items-center justify-center bg-[#fffdf5] px-4">
             <section
-                className="w-full max-w-sm rounded-2xl border-2 border-[#1c1410] bg-white p-8"
-                style={{ boxShadow: "var(--shadow-pop)" }}
+                className="w-full max-w-sm rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-8"
+                style={{ boxShadow: "var(--shadow-card)" }}
             >
                 <div className="mb-2 flex items-center gap-3">
                     <span
-                        className="flex h-8 w-8 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-xs font-extrabold text-white"
-                        style={{ boxShadow: "var(--shadow-pop-sm)" }}
+                        className="flex h-8 w-8 items-center justify-center rounded-xl border border-[rgba(28,20,16,0.08)] bg-[#f18840] text-xs font-extrabold text-white"
+                        style={{ boxShadow: "0 1px 4px rgba(28,20,16,0.08)" }}
                     >
                         B
                     </span>
@@ -234,7 +234,7 @@ export function ForgotPasswordFlow() {
                 )}
                 {step === "reset" && <ResetStep resetToken={resetToken} />}
 
-                <div className="mt-6 border-t border-[#e8c8b0] pt-4 text-center">
+                <div className="mt-6 border-t border-[rgba(28,20,16,0.08)] pt-4 text-center">
                     <Link
                         href="/login"
                         className="text-sm font-semibold text-[#1c1410]/40 underline underline-offset-2 hover:text-[#f18840] transition-colors"

--- a/apps/web/src/components/register/RegisterForm.tsx
+++ b/apps/web/src/components/register/RegisterForm.tsx
@@ -49,14 +49,14 @@ export function RegisterForm() {
             />
 
             <section
-                className="w-full max-w-md rounded-2xl border-2 border-[#1c1410] bg-white p-8"
-                style={{ boxShadow: "var(--shadow-pop)" }}
+                className="w-full max-w-md rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-8"
+                style={{ boxShadow: "var(--shadow-card)" }}
             >
                 <div className="mb-6 flex items-start justify-between gap-4">
                     <div className="flex items-center gap-3">
                         <span
-                            className="flex h-10 w-10 items-center justify-center rounded-xl border-2 border-[#1c1410] bg-[#f18840] text-base font-extrabold text-white"
-                            style={{ boxShadow: "var(--shadow-pop-sm)" }}
+                            className="flex h-10 w-10 items-center justify-center rounded-xl border border-[rgba(28,20,16,0.08)] bg-[#f18840] text-base font-extrabold text-white"
+                            style={{ boxShadow: "0 1px 4px rgba(28,20,16,0.08)" }}
                         >
                             B
                         </span>
@@ -117,7 +117,7 @@ export function RegisterForm() {
                     </div>
 
                     {/* 秘密の質問 */}
-                    <div className="rounded-xl border border-[#e8c8b0] bg-[#fffdf5] p-4 space-y-3">
+                    <div className="rounded-xl border border-[rgba(28,20,16,0.08)] bg-[#fffdf5] p-4 space-y-3">
                         <p className="text-sm font-extrabold text-[#1c1410]">
                             秘密の質問
                         </p>
@@ -182,7 +182,7 @@ export function RegisterForm() {
                     </button>
                 </form>
 
-                <div className="mt-4 border-t border-[#e8c8b0] pt-4 text-center">
+                <div className="mt-4 border-t border-[rgba(28,20,16,0.08)] pt-4 text-center">
                     <p className="text-sm text-[#1c1410]/60">
                         すでにアカウントをお持ちですか？{" "}
                         <Link

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -9,13 +9,13 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          'text-white bg-[#f18840] border-2 border-[#1c1410] [box-shadow:var(--shadow-pop)] hover:translate-x-[-1px] hover:translate-y-[-1px] hover:[box-shadow:var(--shadow-pop-lg)] active:translate-x-[1px] active:translate-y-[1px] active:[box-shadow:none]',
+          'text-white bg-[#f18840] [box-shadow:0_4px_16px_rgba(241,136,64,0.33)] hover:opacity-92 active:scale-[0.97]',
         secondary:
-          'text-[#1c1410] bg-white border border-[#1c1410]/25 hover:bg-[#fff6ee] hover:border-[#1c1410]/40',
+          'text-[#f18840] bg-[#fff6ee] border-[1.5px] border-[rgba(241,136,64,0.22)] hover:bg-[#fff0e0] hover:border-[rgba(241,136,64,0.35)]',
         ghost:
           'text-[#1c1410]/70 bg-transparent hover:bg-[#1c1410]/5',
         destructive:
-          'text-white bg-[#f43f5e] border-2 border-[#1c1410] [box-shadow:var(--shadow-pop)] hover:translate-x-[-1px] hover:translate-y-[-1px] hover:[box-shadow:var(--shadow-pop-lg)] active:translate-x-[1px] active:translate-y-[1px] active:[box-shadow:none]',
+          'text-[#f43f5e] bg-transparent hover:bg-[#f43f5e]/5 active:scale-[0.97]',
         link:
           'text-[#f18840] underline underline-offset-2 hover:text-[#e07030] p-0 h-auto',
       },

--- a/apps/web/src/components/ui/button.tsx
+++ b/apps/web/src/components/ui/button.tsx
@@ -9,7 +9,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         primary:
-          'text-white bg-[#f18840] [box-shadow:0_4px_16px_rgba(241,136,64,0.33)] hover:opacity-92 active:scale-[0.97]',
+          'text-white bg-[#f18840] [box-shadow:0_4px_16px_rgba(241,136,64,0.33)] hover:opacity-[0.92] active:scale-[0.97]',
         secondary:
           'text-[#f18840] bg-[#fff6ee] border-[1.5px] border-[rgba(241,136,64,0.22)] hover:bg-[#fff0e0] hover:border-[rgba(241,136,64,0.35)]',
         ghost:

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -9,7 +9,7 @@ function Checkbox({ className, ...props }: React.ComponentProps<typeof CheckboxP
   return (
     <CheckboxPrimitive.Root
       className={cn(
-        'peer size-5 shrink-0 rounded-md border-2 border-[#1c1410]/30 bg-white',
+        'peer size-5 shrink-0 rounded-md border-[1.5px] border-[rgba(28,20,16,0.15)] bg-white',
         'transition-colors',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#f18840]/40',
         'disabled:cursor-not-allowed disabled:opacity-50',

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -41,7 +41,7 @@ function DialogContent({
       <DialogPrimitive.Content
         className={cn(
           'fixed left-1/2 top-1/2 z-50 w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2',
-          'grid gap-4 rounded-2xl border-2 border-[#1c1410]/10 bg-white p-6 shadow-lg',
+          'grid gap-4 rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-6 shadow-lg',
           'sm:max-w-lg',
           'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',

--- a/apps/web/src/components/ui/drawer.tsx
+++ b/apps/web/src/components/ui/drawer.tsx
@@ -35,7 +35,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         className={cn(
           'fixed bottom-0 inset-x-0 z-50 flex flex-col',
-          'mt-24 max-h-[80vh] rounded-t-2xl border-t-2 border-[#1c1410]/10 bg-white',
+          'mt-24 max-h-[80vh] rounded-t-2xl border-t border-[rgba(28,20,16,0.08)] bg-white',
           className,
         )}
         {...props}

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -13,10 +13,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'flex w-full rounded-xl border-2 border-[#1c1410]/20 bg-white px-4 py-2.5 text-sm text-[#1c1410] placeholder:text-[#1c1410]/40',
+          'flex w-full rounded-xl border border-[rgba(28,20,16,0.08)] bg-white px-4 py-2.5 text-sm text-[#1c1410] placeholder:text-[#1c1410]/40',
           'min-h-[44px]',
           'transition-colors',
-          'focus:outline-none focus:border-[#f18840] focus:ring-2 focus:ring-[#f18840]/20',
+          'focus:outline-none focus:border-[#f18840] focus:bg-[#fff6ee]',
           'disabled:cursor-not-allowed disabled:opacity-50',
           'file:border-0 file:bg-transparent file:text-sm file:font-medium',
           className,

--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -20,7 +20,7 @@ function PopoverContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          'z-50 w-72 rounded-2xl border-2 border-[#1c1410]/10 bg-white p-4 shadow-lg outline-none',
+          'z-50 w-72 rounded-2xl border border-[rgba(28,20,16,0.08)] bg-white p-4 shadow-lg outline-none',
           'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -17,10 +17,10 @@ function SelectTrigger({
   return (
     <SelectPrimitive.Trigger
       className={cn(
-        'flex w-full items-center justify-between gap-2 rounded-xl border-2 border-[#1c1410]/20 bg-white px-4 py-2.5 text-sm text-[#1c1410]',
+        'flex w-full items-center justify-between gap-2 rounded-xl border border-[rgba(28,20,16,0.08)] bg-white px-4 py-2.5 text-sm text-[#1c1410]',
         'min-h-[44px] transition-colors',
         'placeholder:text-[#1c1410]/40',
-        'focus:outline-none focus:border-[#f18840] focus:ring-2 focus:ring-[#f18840]/20',
+        'focus:outline-none focus:border-[#f18840] focus:bg-[#fff6ee]',
         'disabled:cursor-not-allowed disabled:opacity-50',
         'data-[placeholder]:text-[#1c1410]/40',
         '[&>span]:truncate',
@@ -74,7 +74,7 @@ function SelectContent({
     <SelectPrimitive.Portal>
       <SelectPrimitive.Content
         className={cn(
-          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border-2 border-[#1c1410]/10 bg-white shadow-lg',
+          'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border border-[rgba(28,20,16,0.08)] bg-white shadow-lg',
           'data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
           'data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           'data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2',

--- a/apps/web/src/components/ui/sonner.tsx
+++ b/apps/web/src/components/ui/sonner.tsx
@@ -16,7 +16,7 @@ function Toaster({ ...props }: React.ComponentProps<typeof SonnerToaster>) {
       toastOptions={{
         classNames: {
           toast:
-            'rounded-xl border-2 border-[#1c1410]/10 bg-white text-[#1c1410] shadow-lg text-sm font-medium',
+            'rounded-xl border border-[rgba(28,20,16,0.08)] bg-white text-[#1c1410] shadow-lg text-sm font-medium',
           title: 'font-semibold',
           description: 'text-[#1c1410]/60',
           success: 'border-[#35b5a2]/30 bg-[#ecfaf8]',

--- a/apps/web/src/components/ui/textarea.tsx
+++ b/apps/web/src/components/ui/textarea.tsx
@@ -5,11 +5,11 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
   return (
     <textarea
       className={cn(
-        'flex w-full rounded-xl border-2 border-[#1c1410]/20 bg-white px-4 py-2.5 text-sm text-[#1c1410]',
+        'flex w-full rounded-xl border border-[rgba(28,20,16,0.08)] bg-white px-4 py-2.5 text-sm text-[#1c1410]',
         'min-h-[88px] resize-y',
         'placeholder:text-[#1c1410]/40',
         'transition-colors',
-        'focus:outline-none focus:border-[#f18840] focus:ring-2 focus:ring-[#f18840]/20',
+        'focus:outline-none focus:border-[#f18840] focus:bg-[#fff6ee]',
         'disabled:cursor-not-allowed disabled:opacity-50',
         className,
       )}


### PR DESCRIPTION
## Summary
- Candy-Popスタイル（2pxハードオフセットシャドウ、太ボーダー、translateホバー）をサンドボックスのソフトシャドウ＋薄ボーダー＋背景変化フォーカスに統一
- globals.css のデザイントークン更新で 18+ ページコンポーネントが自動修正
- UIプリミティブ（button, input, textarea, select, dialog, drawer, popover, sonner, checkbox）、レイアウト、認証ページ、エラーページ、Storybookを更新
- dev環境修正: LAN接続対応（--hostname 0.0.0.0）、SWキャッシュクリア

Closes #398

## Test plan
- [x] `pnpm --filter web build` ビルド成功
- [x] pre-commit hooks 全パス（format, lint, type-check, unit-test）
- [x] 統合テスト全40件パス
- [x] SP（スマホ）から表示確認
- [x] サンドボックスと横並び比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)