### PR TITLE
fix: 初期設定フラグ管理を修正し、未設定ユーザーのルーティングを制御する

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -267,23 +267,14 @@
     background-color: #fff0e0;
   }
 
-  /* 入力フィールド — フォーカス時に背景変化 */
-  .input-pop {
-    @apply w-full rounded-xl bg-white px-3 py-2 text-sm outline-none;
-    border: 1px solid rgba(28, 20, 16, 0.08);
-    transition: border-color 0.2s var(--ease-standard), background-color 0.2s var(--ease-standard);
-  }
-  .input-pop:focus {
-    border-color: #f18840;
-    background-color: #fff6ee;
-  }
-
-  /* 入力フィールド — input-pop のエイリアス（InitialSetupWizard 等で使用） */
+  /* 入力フィールド — フォーカス時に背景変化（input-field は InitialSetupWizard 用エイリアス） */
+  .input-pop,
   .input-field {
     @apply w-full rounded-xl bg-white px-3 py-2 text-sm outline-none;
     border: 1px solid rgba(28, 20, 16, 0.08);
     transition: border-color 0.2s var(--ease-standard), background-color 0.2s var(--ease-standard);
   }
+  .input-pop:focus,
   .input-field:focus {
     border-color: #f18840;
     background-color: #fff6ee;

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -277,6 +277,17 @@
     border-color: #f18840;
     background-color: #fff6ee;
   }
+
+  /* 入力フィールド — input-pop のエイリアス（InitialSetupWizard 等で使用） */
+  .input-field {
+    @apply w-full rounded-xl bg-white px-3 py-2 text-sm outline-none;
+    border: 1px solid rgba(28, 20, 16, 0.08);
+    transition: border-color 0.2s var(--ease-standard), background-color 0.2s var(--ease-standard);
+  }
+  .input-field:focus {
+    border-color: #f18840;
+    background-color: #fff6ee;
+  }
 }
 
 body {

--- a/apps/web/src/lib/actions/auth.ts
+++ b/apps/web/src/lib/actions/auth.ts
@@ -3,8 +3,12 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { serverFetch, ApiError } from "../api/client";
+import { getSettings } from "../api/settings";
 import type { LoginResponse, LogoutResponse } from "../api/types";
 import { loginSchema } from "@budget/common";
+
+/** 初回設定完了 Cookie の有効期間（1年） */
+const SETUP_COOKIE_MAX_AGE = 365 * 24 * 60 * 60;
 
 // アクセストークン：15分（APIと揃える）
 const ACCESS_TOKEN_MAX_AGE = 15 * 60;
@@ -90,6 +94,23 @@ export async function loginAction(
       body: JSON.stringify(result.data),
     });
     await setTokenCookies({ ...res, userId: res.userId });
+
+    // DBの初回設定フラグをクッキーに同期
+    try {
+      const settings = await getSettings();
+      if (settings.initialSetupCompleted) {
+        const cookieStore = await cookies();
+        cookieStore.set("setup_completed", "1", {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === "production",
+          sameSite: "strict",
+          maxAge: SETUP_COOKIE_MAX_AGE,
+          path: "/",
+        });
+      }
+    } catch {
+      // 設定取得失敗時はクッキーなしで続行（middlewareが /setup にリダイレクト）
+    }
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) {
       return { error: "ユーザー名またはパスワードが正しくありません" };
@@ -108,6 +129,23 @@ export async function guestLoginAction(formData: FormData): Promise<void> {
     method: "POST",
   });
   await setTokenCookies({ ...res, userId: res.userId });
+
+  // DBの初回設定フラグをクッキーに同期
+  try {
+    const settings = await getSettings();
+    if (settings.initialSetupCompleted) {
+      const cookieStore = await cookies();
+      cookieStore.set("setup_completed", "1", {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        maxAge: SETUP_COOKIE_MAX_AGE,
+        path: "/",
+      });
+    }
+  } catch {
+    // 設定取得失敗時はクッキーなしで続行（middlewareが /setup にリダイレクト）
+  }
 
   // returnTo が / 始まりの場合のみ使用（オープンリダイレクト対策）
   const returnTo = String(formData.get("returnTo") ?? "");

--- a/apps/web/src/lib/actions/auth.ts
+++ b/apps/web/src/lib/actions/auth.ts
@@ -72,6 +72,27 @@ async function clearTokenCookies(): Promise<void> {
   cookieStore.delete("user_id");
 }
 
+/** DBの初回設定フラグをクッキーに同期する（完了済み→セット / 未完了→削除） */
+async function syncSetupCookie(): Promise<void> {
+  try {
+    const settings = await getSettings();
+    const cookieStore = await cookies();
+    if (settings.initialSetupCompleted) {
+      cookieStore.set("setup_completed", "1", {
+        httpOnly: true,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        maxAge: SETUP_COOKIE_MAX_AGE,
+        path: "/",
+      });
+    } else {
+      cookieStore.delete("setup_completed");
+    }
+  } catch {
+    // 設定取得失敗時はクッキーなしで続行（middlewareが /setup にリダイレクト）
+  }
+}
+
 /** ログイン Server Action */
 export async function loginAction(
   _prev: LoginState,
@@ -94,23 +115,7 @@ export async function loginAction(
       body: JSON.stringify(result.data),
     });
     await setTokenCookies({ ...res, userId: res.userId });
-
-    // DBの初回設定フラグをクッキーに同期
-    try {
-      const settings = await getSettings();
-      if (settings.initialSetupCompleted) {
-        const cookieStore = await cookies();
-        cookieStore.set("setup_completed", "1", {
-          httpOnly: true,
-          secure: process.env.NODE_ENV === "production",
-          sameSite: "strict",
-          maxAge: SETUP_COOKIE_MAX_AGE,
-          path: "/",
-        });
-      }
-    } catch {
-      // 設定取得失敗時はクッキーなしで続行（middlewareが /setup にリダイレクト）
-    }
+    await syncSetupCookie();
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) {
       return { error: "ユーザー名またはパスワードが正しくありません" };
@@ -129,23 +134,7 @@ export async function guestLoginAction(formData: FormData): Promise<void> {
     method: "POST",
   });
   await setTokenCookies({ ...res, userId: res.userId });
-
-  // DBの初回設定フラグをクッキーに同期
-  try {
-    const settings = await getSettings();
-    if (settings.initialSetupCompleted) {
-      const cookieStore = await cookies();
-      cookieStore.set("setup_completed", "1", {
-        httpOnly: true,
-        secure: process.env.NODE_ENV === "production",
-        sameSite: "strict",
-        maxAge: SETUP_COOKIE_MAX_AGE,
-        path: "/",
-      });
-    }
-  } catch {
-    // 設定取得失敗時はクッキーなしで続行（middlewareが /setup にリダイレクト）
-  }
+  await syncSetupCookie();
 
   // returnTo が / 始まりの場合のみ使用（オープンリダイレクト対策）
   const returnTo = String(formData.get("returnTo") ?? "");

--- a/apps/web/src/lib/actions/settings.ts
+++ b/apps/web/src/lib/actions/settings.ts
@@ -21,7 +21,7 @@ export async function saveUserSettingsAction(
     data: UpsertUserSettingsBody,
 ): Promise<{ error: string } | null> {
     try {
-        await putSettings(data);
+        await putSettings({ ...data, initialSetupCompleted: true });
         const cookieStore = await cookies();
         cookieStore.set("setup_completed", "1", {
             httpOnly: true,

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -96,5 +96,5 @@ export async function middleware(request: NextRequest) {
 export const config = {
   // /register, /forgot-password は公開ルートのため除外
   // /setup は認証が必要なため含める
-  matcher: ["/records", "/records/:path*", "/expenses/:path*", "/report", "/report/:path*", "/settings", "/settings/:path*", "/setup", "/my-page"],
+  matcher: ["/", "/calendar", "/records", "/records/:path*", "/expenses/:path*", "/report", "/report/:path*", "/settings", "/settings/:path*", "/setup", "/my-page"],
 };


### PR DESCRIPTION
## Summary
- `.input-field` CSSクラスを追加し、ウィザード入力欄の表示を修正
- ウィザード完了時に `initialSetupCompleted: true` をAPIに送信するよう修正
- middleware matcherに `/` と `/calendar` を追加し、未設定ユーザーを `/setup` にリダイレクト
- ログイン時にDBの `initialSetupCompleted` フラグをクッキーに同期

Closes #399

## Test plan
- [x] `pnpm --filter web build` でビルド成功
- [x] pre-commit hooks（format, lint, type-check, unit-test）すべて通過
- [x] pre-push hooks（integration-test, rebase-check）すべて通過
- [x] 新規ユーザーでログイン → `/setup` にリダイレクトされる
- [x] ウィザードの入力フィールドが正しく表示・入力できる
- [x] ウィザード完了 → ホーム画面で1日予算が表示される
- [x] ログアウト → 再ログイン → `/setup` に飛ばされない（DBフラグで同期）

🤖 Generated with [Claude Code](https://claude.com/claude-code)