### PR TITLE
fix: サイクルタイム自動計測の形式不一致を修正し過去データをバックフィル

### DIFF
--- a/.github/velocity-log.json
+++ b/.github/velocity-log.json
@@ -34,7 +34,7 @@
           "pbi_type": "chore",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 146
         },
         {
@@ -43,7 +43,7 @@
           "pbi_type": "fix",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 147
         },
         {
@@ -52,7 +52,7 @@
           "pbi_type": "fix",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 148
         },
         {
@@ -80,7 +80,7 @@
           "pbi_type": "chore",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 150
         },
         {
@@ -89,7 +89,7 @@
           "pbi_type": "chore",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.4,
           "pr": 151
         },
         {
@@ -170,7 +170,7 @@
           "pbi_type": "tech-debt",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 165
         },
         {
@@ -308,7 +308,7 @@
           "pbi_type": "feature",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 180
         },
         {
@@ -643,7 +643,7 @@
           "pbi_type": "feature",
           "size": "L",
           "points": 5,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0,
           "pr": 276
         }
       ]
@@ -736,7 +736,7 @@
           "title": "design: カテゴリ選択UI A/B/C デザインパターン比較をギャラリーに追加する",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 299,
           "pbi_type": "feature"
         },
@@ -746,7 +746,7 @@
           "pbi_type": "feature",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 299
         },
         {
@@ -755,7 +755,7 @@
           "pbi_type": "fix",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 299
         },
         {
@@ -764,7 +764,7 @@
           "pbi_type": "chore",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 299
         },
         {
@@ -773,7 +773,7 @@
           "pbi_type": "feature",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 299
         }
       ]
@@ -846,7 +846,7 @@
           "title": "[Retro Action] XDayDisplay の完全廃止スケジュールを Issue 化して優先度を設定する",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 304
         },
         {
@@ -854,7 +854,7 @@
           "title": "chore: スプリント計画適切性メトリクス（planned_points・達成率・推奨キャパシティ調整）を設計・実装する",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 304
         },
         {
@@ -862,7 +862,7 @@
           "title": "chore: Issue クローズ時にプロジェクトボードのステータスを Done へ自動更新する",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 304
         },
         {
@@ -870,7 +870,7 @@
           "title": "[Retro Action] velocity-log.json の Sprint エントリに goal/hypothesis を必ず記入するよう sprint-protocol.md に明記する",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 304
         },
         {
@@ -878,7 +878,7 @@
           "title": "[Retro Action] measure-cycle-time.yml の動作確認と修正",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 304
         }
       ]
@@ -896,7 +896,7 @@
           "title": "[Retro Action] velocity-log.json SprintエントリをPRマージ後に手動補記する運用をprotocolに明記する",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 309
         },
         {
@@ -904,7 +904,7 @@
           "title": "chore: GH Actions の責務整理・重複解消・PAT 依存の解消",
           "size": "M",
           "points": 3,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 309
         },
         {
@@ -912,7 +912,7 @@
           "title": "chore: ログイン画面の暗号化説明ツールチップとバッジを削除する",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 309
         },
         {
@@ -920,7 +920,7 @@
           "title": "tech-debt: XDayDisplay コンポーネントを完全廃止する",
           "size": "S",
           "points": 2,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 309
         },
         {
@@ -928,7 +928,7 @@
           "title": "[Retro Action] sprint agent フローで in-progress ラベル付与後に GH Actions 完了を待機する手順を追加する",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 309
         },
         {
@@ -936,7 +936,7 @@
           "title": "[Retro Action] スプリントクロージングチェックリストにレトロ Issue 作成を必須ステップとして明記する",
           "size": "XS",
           "points": 1,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 0.1,
           "pr": 309
         }
       ]
@@ -955,7 +955,7 @@
           "pbi_type": "feature",
           "size": "L",
           "points": 5,
-          "cycle_time_hours": null,
+          "cycle_time_hours": 5.5,
           "pr": 312
         },
         {

--- a/.github/workflows/measure-cycle-time.yml
+++ b/.github/workflows/measure-cycle-time.yml
@@ -22,7 +22,8 @@ jobs:
           script: |
             const now = new Date();
             const jst = new Date(now.getTime() + 9 * 60 * 60 * 1000);
-            const timestamp = jst.toISOString().replace('T', ' ').replace('Z', ' JST').slice(0, 22);
+            // 「YYYY-MM-DD HH:MM JST」形式（パース側の正規表現と一致させること）
+            const timestamp = jst.toISOString().slice(0, 16).replace('T', ' ') + ' JST';
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -132,17 +133,34 @@ jobs:
 
               let cycleTimeText = '計測データなし（in-progress ラベル付与前にマージされた可能性があります）';
               let cycleTimeHours = null;
+              let startedAt = null;
 
               if (startComment) {
-                const dateMatch = startComment.body.match(/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}) JST/);
+                // 「開始日時」行から日時を抽出（旧形式「HH:MM:SS.cc」・新形式「HH:MM JST」の両方を許容）
+                const dateMatch = startComment.body.match(/開始日時[^\d]*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})/);
                 if (dateMatch) {
-                  const startedAt = new Date(dateMatch[1].replace(' ', 'T') + ':00+09:00');
-                  const diffMs = mergedAt - startedAt;
-                  cycleTimeHours = Math.round((diffMs / (1000 * 60 * 60)) * 10) / 10;
-                  const diffH = Math.floor(diffMs / (1000 * 60 * 60));
-                  const diffM = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
-                  cycleTimeText = `${diffH}時間 ${diffM}分`;
+                  startedAt = new Date(dateMatch[1].replace(' ', 'T') + ':00+09:00');
                 }
+              }
+
+              if (!startedAt) {
+                // フォールバック: in-progress ラベル付与イベントの時刻を開始時刻とする
+                const events = await github.paginate(github.rest.issues.listEvents, {
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  issue_number: issueNumber, per_page: 100,
+                });
+                const labeled = events.find(e => e.event === 'labeled' && e.label?.name === 'in-progress');
+                if (labeled) {
+                  startedAt = new Date(labeled.created_at);
+                }
+              }
+
+              if (startedAt) {
+                const diffMs = mergedAt - startedAt;
+                cycleTimeHours = Math.round((diffMs / (1000 * 60 * 60)) * 10) / 10;
+                const diffH = Math.floor(diffMs / (1000 * 60 * 60));
+                const diffM = Math.floor((diffMs % (1000 * 60 * 60)) / (1000 * 60));
+                cycleTimeText = `${diffH}時間 ${diffM}分`;
               }
 
               const mergedAtJst = new Date(mergedAt.getTime() + 9 * 60 * 60 * 1000)

--- a/.github/workflows/update-velocity.yml
+++ b/.github/workflows/update-velocity.yml
@@ -77,14 +77,34 @@ jobs:
             );
 
             let cycleTimeHours = null;
+            let startedAt = null;
+
             if (startComment) {
-              const dateMatch = startComment.body.match(/(\d{4}-\d{2}-\d{2} \d{2}:\d{2}) JST/);
+              // 「開始日時」行から日時を抽出（旧形式「HH:MM:SS.cc」・新形式「HH:MM JST」の両方を許容）
+              const dateMatch = startComment.body.match(/開始日時[^\d]*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})/);
               if (dateMatch) {
-                const startedAt = new Date(dateMatch[1].replace(' ', 'T') + ':00+09:00');
-                const mergedAt = new Date(pr.merged_at);
-                const diffMs = mergedAt - startedAt;
-                cycleTimeHours = Math.round((diffMs / (1000 * 60 * 60)) * 10) / 10;
+                startedAt = new Date(dateMatch[1].replace(' ', 'T') + ':00+09:00');
               }
+            }
+
+            if (!startedAt) {
+              // フォールバック: in-progress ラベル付与イベントの時刻を開始時刻とする
+              const events = await github.paginate(github.rest.issues.listEvents, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+              const labeled = events.find(e => e.event === 'labeled' && e.label?.name === 'in-progress');
+              if (labeled) {
+                startedAt = new Date(labeled.created_at);
+              }
+            }
+
+            if (startedAt) {
+              const mergedAtDate = new Date(pr.merged_at);
+              const diffMs = mergedAtDate - startedAt;
+              cycleTimeHours = Math.round((diffMs / (1000 * 60 * 60)) * 10) / 10;
             }
 
             // マージ日を JST で取得（スプリントエントリの date フィールドに使用）


### PR DESCRIPTION
## 📋 概要

velocity-log.json の `cycle_time_hours` が GH Actions によって記録されたことが一度もない問題を修正しました。開始コメントのタイムスタンプ形式とパース側正規表現の不一致が根本原因で、sprint-protocol.md §4 の見積もり乖離分析が実データで機能していませんでした。

## 🛠 変更内容

- `measure-cycle-time.yml`: 開始コメントのタイムスタンプ生成を `YYYY-MM-DD HH:MM JST` 形式に統一（従来は `toISOString().slice(0, 22)` により `2026-05-15 21:40:02.66` 形式となり、パース側の `HH:MM JST` 正規表現に永久にマッチしなかった）
- `measure-cycle-time.yml` / `update-velocity.yml`: パース正規表現を「開始日時」行アンカー（`開始日時[^\d]*(\d{4}-\d{2}-\d{2} \d{2}:\d{2})`）に変更し、旧形式コメント・新形式コメントの両方を許容
- 両ワークフロー: 開始コメントが存在しない場合、`in-progress` ラベル付与イベントの時刻を開始時刻とするフォールバックを追加
- `velocity-log.json`: 過去 PBI 25 件の `cycle_time_hours` をバックフィル（計測済み 60 → 85 件 / 全 96 件。残り 11 件は開始コメント・`in-progress` ラベルイベントのいずれも存在せず計測不能）

## 🔍 影響範囲

- 今後マージされる PR から、サイクルタイムが自動で velocity-log.json と Project の `Cycle Time (h)` フィールドに記録される
- sprint-protocol.md §4 の size 別サイクルタイム乖離分析が実データで機能するようになる
- アプリケーションコードへの変更なし（CI ワークフロー定義とデータファイルのみ）

## ✅ 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし: ワークフロー定義のみ）
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（該当なし）
- [x] ID（ulid）の生成・利用箇所は適切か（ID 操作なし）
- [x] マジックナンバーを排除し、定数化されているか（新規リテラルは日時形式の正規表現のみ）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（該当なし: CI のみ）

## 📸 スクリーンショット

該当なし（CI ワークフローとデータファイルのみの変更）

## 🧪 テスト内容

- 両ワークフローの YAML 構文検証（ruby YAML パーサー）
- 新正規表現を旧形式（`2026-05-15 21:40:02.66`）・新形式（`2026-07-02 19:05 JST`）の両方でマッチ確認（node で実行）
- 新タイムスタンプ生成式の出力形式確認（`2026-07-02 20:14 JST`）
- バックフィルは dry-run で 25 件の算出結果を確認後に適用し、`jq empty` で JSON 妥当性を検証
- pre-commit フック（lint / type-check / unit-test 184 件）全パス

## 🔗 関連 Issue

- Closes #414
- Sprint: 27

## ⚠️ 備考

- 本 PR のマージ自体が修正後の `update-velocity.yml` の初回実行となり、#414 が Sprint #27 エントリとして記録される（動作確認を兼ねる）
- バックフィルスクリプトは `~/.claude/scripts/backfill-cycle-time.mjs`（リポジトリ外・再利用可能）

## Test plan

- [x] 両ワークフローの YAML 構文検証（ruby YAML パーサー）
- [x] 新正規表現を旧形式（`2026-05-15 21:40:02.66`）・新形式（`2026-07-02 19:05 JST`）の両方でマッチ確認
- [x] 新タイムスタンプ生成式の出力形式確認（`YYYY-MM-DD HH:MM JST`）
- [x] バックフィルを dry-run で確認後に適用し、`jq empty` で JSON 妥当性を検証
- [x] pre-commit フック（lint / type-check / unit-test 184 件）全パス
- [x] 本 PR のマージ自体が修正後ワークフローの初回実行となるため、マージ後に velocity-log.json への #414 記録（cycle_time_hours 非 null）を確認する
