### PR TITLE
fix(web): クイック記録の登録成功後に入力をリセットし連続記録の二重登録を防ぐ

### DIFF
--- a/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QuickEntryDrawer } from "@/components/expense/QuickEntryDrawer";
 import type { CategoryItem } from "@/lib/api/types";
 
@@ -145,5 +145,119 @@ describe("QuickEntryDrawer", () => {
     render(<QuickEntryDrawer {...defaultProps} />);
     expect(screen.getByText("登録しました")).toBeInTheDocument();
     expect(screen.queryByText(/生活余力/)).not.toBeInTheDocument();
+  });
+
+  it("登録成功後、金額・メモがリセットされ二重登録できない（#461）", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: false },
+      vi.fn(),
+      false,
+    ]);
+    const { rerender } = render(<QuickEntryDrawer {...defaultProps} />);
+
+    // テンキーで 800 円を入力し、メモも入れる
+    fireEvent.click(screen.getByRole("button", { name: "8" }));
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+    fireEvent.change(screen.getByLabelText("メモ"), { target: { value: "コーヒー" } });
+    expect(screen.getByText("800")).toBeInTheDocument();
+
+    // 登録成功状態へ遷移させる
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: true, registeredAmount: 800, registeredBalanceType: 0 },
+      vi.fn(),
+      false,
+    ]);
+    rerender(<QuickEntryDrawer {...defaultProps} />);
+
+    // 金額・メモがリセットされている
+    expect(screen.queryByText("800")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("メモ")).toHaveValue("");
+    // 記録ボタンは成功フィードバックに置き換わり、そのままの再送信ができない
+    expect(screen.getByText("記録しました！")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /記録する/ })).not.toBeInTheDocument();
+  });
+
+  it("成功フィードバックは一定時間後に記録ボタンへ戻る（#461）", async () => {
+    vi.useFakeTimers();
+    try {
+      const { useActionState } = await import("react");
+      vi.mocked(useActionState).mockReturnValue([
+        { error: null, success: true, registeredAmount: 800, registeredBalanceType: 0 },
+        vi.fn(),
+        false,
+      ]);
+      render(<QuickEntryDrawer {...defaultProps} />);
+      expect(screen.getByText("記録しました！")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(screen.queryByText("記録しました！")).not.toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /記録する/ })).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("金額入力中、「記録後の残り」プレビューが表示される（#461）", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: false },
+      vi.fn(),
+      false,
+    ]);
+    render(
+      <QuickEntryDrawer
+        {...defaultProps}
+        dailyBudget={{ amount: 2400, remaining: 2000 }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "5" }));
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+    expect(screen.getByText("記録後の残り：")).toBeInTheDocument();
+    expect(screen.getByText("¥1,500")).toBeInTheDocument();
+  });
+
+  it("記録後の残りが1日予算の20%未満のとき、警告色で表示される（#461）", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: false },
+      vi.fn(),
+      false,
+    ]);
+    render(
+      <QuickEntryDrawer
+        {...defaultProps}
+        dailyBudget={{ amount: 2400, remaining: 2000 }}
+      />,
+    );
+    // 1,800円入力 → 残り200円（2400×20%=480円 未満）
+    fireEvent.click(screen.getByRole("button", { name: "1" }));
+    fireEvent.click(screen.getByRole("button", { name: "8" }));
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+    fireEvent.click(screen.getByRole("button", { name: "0" }));
+    const value = screen.getByText("¥200");
+    expect(value).toHaveStyle({ color: "#f43f5e" });
+  });
+
+  it("収入タブでは「記録後の残り」プレビューを表示しない（#461）", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: false },
+      vi.fn(),
+      false,
+    ]);
+    render(
+      <QuickEntryDrawer
+        {...defaultProps}
+        dailyBudget={{ amount: 2400, remaining: 2000 }}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "収入" }));
+    fireEvent.click(screen.getByRole("button", { name: "5" }));
+    expect(screen.queryByText("記録後の残り：")).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
@@ -243,6 +243,30 @@ describe("QuickEntryDrawer", () => {
     expect(value).toHaveStyle({ color: "#f43f5e" });
   });
 
+  it("ドロワーを閉じて再オープンすると、前回の成功メッセージ・フィードバックがクリアされる（#461）", async () => {
+    const { useActionState } = await import("react");
+    vi.mocked(useActionState).mockReturnValue([
+      { error: null, success: true, registeredAmount: 4000, registeredBalanceType: 0 },
+      vi.fn(),
+      false,
+    ]);
+    const { rerender } = render(
+      <QuickEntryDrawer {...defaultProps} effectiveDailyExpense={8000} />,
+    );
+    expect(screen.getByText("登録しました")).toBeInTheDocument();
+    expect(screen.getByText(/生活余力/)).toBeInTheDocument();
+
+    // 閉じて再オープン
+    rerender(
+      <QuickEntryDrawer {...defaultProps} open={false} effectiveDailyExpense={8000} />,
+    );
+    rerender(
+      <QuickEntryDrawer {...defaultProps} open={true} effectiveDailyExpense={8000} />,
+    );
+    expect(screen.queryByText("登録しました")).not.toBeInTheDocument();
+    expect(screen.queryByText(/生活余力/)).not.toBeInTheDocument();
+  });
+
   it("収入タブでは「記録後の残り」プレビューを表示しない（#461）", async () => {
     const { useActionState } = await import("react");
     vi.mocked(useActionState).mockReturnValue([

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -41,11 +41,14 @@ export function HomeClient({
   const dailyBudgetRemaining = dashboard.dailyBudget?.remaining;
   useEffect(() => {
     setEffectiveDailyExpense(effectiveDailyExpense);
-    setDailyBudget(
-      dailyBudgetAmount !== undefined && dailyBudgetRemaining !== undefined
-        ? { amount: dailyBudgetAmount, remaining: dailyBudgetRemaining }
-        : null,
-    );
+    // 値が変わらない限り参照を維持し、コンテキスト経由の不要な再レンダリングを避ける
+    setDailyBudget((prev) => {
+      if (dailyBudgetAmount === undefined || dailyBudgetRemaining === undefined) return null;
+      if (prev && prev.amount === dailyBudgetAmount && prev.remaining === dailyBudgetRemaining) {
+        return prev;
+      }
+      return { amount: dailyBudgetAmount, remaining: dailyBudgetRemaining };
+    });
     return () => {
       setEffectiveDailyExpense(null);
       setDailyBudget(null);

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -35,12 +35,28 @@ export function HomeClient({
   const effectiveDailyExpense =
     livingMarginResult.status === "ok" ? livingMarginResult.effectiveDailyExpense : null;
 
-  // BottomNav（FAB）側の QuickEntryDrawer にも E を届ける（レイアウト横断のためコンテキスト経由）
-  const { setEffectiveDailyExpense } = useLivingMargin();
+  // BottomNav（FAB）側の QuickEntryDrawer にも E と1日予算を届ける（レイアウト横断のためコンテキスト経由）
+  const { setEffectiveDailyExpense, setDailyBudget } = useLivingMargin();
+  const dailyBudgetAmount = dashboard.dailyBudget?.amount;
+  const dailyBudgetRemaining = dashboard.dailyBudget?.remaining;
   useEffect(() => {
     setEffectiveDailyExpense(effectiveDailyExpense);
-    return () => setEffectiveDailyExpense(null);
-  }, [effectiveDailyExpense, setEffectiveDailyExpense]);
+    setDailyBudget(
+      dailyBudgetAmount !== undefined && dailyBudgetRemaining !== undefined
+        ? { amount: dailyBudgetAmount, remaining: dailyBudgetRemaining }
+        : null,
+    );
+    return () => {
+      setEffectiveDailyExpense(null);
+      setDailyBudget(null);
+    };
+  }, [
+    effectiveDailyExpense,
+    setEffectiveDailyExpense,
+    dailyBudgetAmount,
+    dailyBudgetRemaining,
+    setDailyBudget,
+  ]);
 
   return (
     <main className="mx-auto w-full max-w-7xl flex-1 px-4 py-4 md:px-6 md:py-5">
@@ -98,6 +114,7 @@ export function HomeClient({
         expenseCategories={expenseCategories}
         incomeCategories={incomeCategories}
         effectiveDailyExpense={effectiveDailyExpense}
+        dailyBudget={dashboard.dailyBudget}
       />
     </main>
   );

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -2,13 +2,14 @@
 
 import { useActionState, useState, useEffect, useCallback } from "react";
 import {
-  Delete, PenLine, ChevronDown, Receipt,
+  Delete, PenLine, ChevronDown, Receipt, Check,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 import { formatLivingMarginImpact } from "@budget/common";
 import { createExpenseAction } from "@/lib/actions/expense";
 import type { ExpenseActionState } from "@/lib/actions/expense";
+import type { DailyBudgetSnapshot } from "@/components/providers/LivingMarginProvider";
 import type { CategoryItem } from "@/lib/api/types";
 import { getCategoryIcon } from "@/lib/categoryTokens";
 import { SPRING } from "@/lib/motion";
@@ -21,10 +22,16 @@ type Props = {
   incomeCategories: CategoryItem[];
   /** 実効日次支出 E（円/日）。生活余力の即時フィードバックに使用（算出不能時は null / 未指定） */
   effectiveDailyExpense?: number | null;
+  /** 1日予算と今日の残額。「記録後の残り」プレビューに使用（未取得時は null / 未指定） */
+  dailyBudget?: DailyBudgetSnapshot | null;
 };
 
 const VISIBLE_COUNT = 4;
 const MAX_AMOUNT = 9_999_999;
+/** 成功フィードバック（✓ 記録しました！）の表示時間（ms） */
+const SUCCESS_FEEDBACK_MS = 1600;
+/** 「記録後の残り」を警告色にする閾値（1日予算に対する残額の比率） */
+const REMAINING_WARN_RATIO = 0.2;
 const initialState: ExpenseActionState = { error: null, success: false };
 
 export function QuickEntryDrawer({
@@ -34,6 +41,7 @@ export function QuickEntryDrawer({
   expenseCategories,
   incomeCategories,
   effectiveDailyExpense = null,
+  dailyBudget = null,
 }: Props) {
   const [balanceType, setBalanceType] = useState<0 | 1>(0);
   const [categoryId, setCategoryId] = useState<number>(expenseCategories[0]?.id ?? 0);
@@ -43,10 +51,43 @@ export function QuickEntryDrawer({
   const [date] = useState<string>(() => new Date().toISOString().slice(0, 10));
   const [state, formAction, isPending] = useActionState(createExpenseAction, initialState);
 
+  // 登録成功後の一時的な成功フィードバック（✓ 記録しました！）表示中フラグ
+  const [justSubmitted, setJustSubmitted] = useState(false);
+
+  // 登録成功のたびに入力をリセットし、ドロワーは開いたまま連続記録できるようにする（#461）。
+  // state は action 実行ごとに新しいオブジェクトが返るため、成功1回につき1回だけ調整する
+  //（レンダー中の状態調整パターン。effect 内の同期 setState を避ける）。
+  const [handledState, setHandledState] = useState<ExpenseActionState>(initialState);
+  if (state !== handledState) {
+    setHandledState(state);
+    if (state.success) {
+      setAmountStr("");
+      setMemo("");
+      setJustSubmitted(true);
+    }
+  }
+
+  // 成功フィードバックを一定時間で通常の記録ボタンへ戻す
+  useEffect(() => {
+    if (!justSubmitted) return;
+    const timer = setTimeout(() => setJustSubmitted(false), SUCCESS_FEEDBACK_MS);
+    return () => clearTimeout(timer);
+  }, [justSubmitted]);
+
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;
   const visible = showAll ? categories : categories.slice(0, VISIBLE_COUNT);
   const rest = categories.slice(VISIBLE_COUNT);
   const brandColor = balanceType === 0 ? "#e07236" : "#27a08f";
+
+  // 「記録後の残り」プレビュー（支出のみ・金額入力中のみ）。サンドボックス AmountPanel 準拠（#461）
+  const previewRemaining =
+    balanceType === 0 && dailyBudget !== null && amountStr !== "" && Number(amountStr) > 0
+      ? Math.max(0, dailyBudget.remaining - Number(amountStr))
+      : null;
+  const previewWarn =
+    previewRemaining !== null &&
+    dailyBudget !== null &&
+    previewRemaining < dailyBudget.amount * REMAINING_WARN_RATIO;
 
   function handleTypeChange(type: 0 | 1) {
     setBalanceType(type);
@@ -182,6 +223,28 @@ export function QuickEntryDrawer({
                 {amountStr === "" ? "0" : Number(amountStr).toLocaleString("ja-JP")}
               </span>
             </div>
+
+            {/* 記録後の残り — 常時レンダリングし opacity 制御で高さを固定（レイアウトシフト防止） */}
+            {dailyBudget !== null && balanceType === 0 && (
+              <div
+                className="mt-1 text-[11px] transition-opacity duration-150"
+                style={{
+                  color: "rgba(28,20,16,0.45)",
+                  opacity: previewRemaining !== null ? 1 : 0,
+                }}
+                aria-hidden={previewRemaining === null}
+              >
+                記録後の残り：
+                <span
+                  className="ml-0.5 font-bold tabular-nums"
+                  style={{ color: previewWarn ? "#f43f5e" : "#1c1410" }}
+                >
+                  {previewRemaining !== null
+                    ? `¥${previewRemaining.toLocaleString("ja-JP")}`
+                    : ""}
+                </span>
+              </div>
+            )}
           </div>
 
           {/* カテゴリグリッド */}
@@ -366,22 +429,44 @@ export function QuickEntryDrawer({
             </p>
           )}
 
-          {/* 記録する */}
-          <button
-            type="submit"
-            disabled={isPending || !amountStr}
-            className="flex w-full items-center justify-center gap-2 rounded-2xl py-3 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
-            style={{ background: "var(--color-brand-primary)" }}
-          >
-            {isPending ? (
-              "登録中..."
+          {/* 記録する（成功直後は一時的に ✓ 記録しました！ へ変化。サンドボックス SubmitButton 準拠） */}
+          <AnimatePresence mode="wait" initial={false}>
+            {justSubmitted ? (
+              <motion.div
+                key="submitted"
+                initial={{ scale: 0.85, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                exit={{ scale: 0.9, opacity: 0 }}
+                transition={SPRING.quick}
+                className="flex w-full items-center justify-center gap-2 rounded-2xl py-3 text-base font-extrabold text-white"
+                style={{ background: "linear-gradient(135deg, #35b5a2, #27a08f)" }}
+                role="status"
+              >
+                <Check size={18} strokeWidth={2.5} />
+                記録しました！
+              </motion.div>
             ) : (
-              <>
-                <Receipt size={16} />
-                記録する
-              </>
+              <motion.button
+                key="submit"
+                type="submit"
+                disabled={isPending || !amountStr}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                transition={SPRING.quick}
+                className="flex w-full items-center justify-center gap-2 rounded-2xl py-3 text-base font-extrabold text-white transition-all active:scale-95 disabled:opacity-40"
+                style={{ background: "var(--color-brand-primary)" }}
+              >
+                {isPending ? (
+                  "登録中..."
+                ) : (
+                  <>
+                    <Receipt size={16} />
+                    記録する
+                  </>
+                )}
+              </motion.button>
             )}
-          </button>
+          </AnimatePresence>
         </form>
       </DrawerContent>
     </Drawer>

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -53,6 +53,8 @@ export function QuickEntryDrawer({
 
   // 登録成功後の一時的な成功フィードバック（✓ 記録しました！）表示中フラグ
   const [justSubmitted, setJustSubmitted] = useState(false);
+  // 画面に表示するフィードバック（エラー / 成功）。ドロワーを閉じたらクリアする
+  const [feedback, setFeedback] = useState<ExpenseActionState>(initialState);
 
   // 登録成功のたびに入力をリセットし、ドロワーは開いたまま連続記録できるようにする（#461）。
   // state は action 実行ごとに新しいオブジェクトが返るため、成功1回につき1回だけ調整する
@@ -60,10 +62,21 @@ export function QuickEntryDrawer({
   const [handledState, setHandledState] = useState<ExpenseActionState>(initialState);
   if (state !== handledState) {
     setHandledState(state);
+    setFeedback(state);
     if (state.success) {
       setAmountStr("");
       setMemo("");
       setJustSubmitted(true);
+    }
+  }
+
+  // ドロワーを閉じたら前回のフィードバックをクリアする（再オープン時に残さない）
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+    if (!open) {
+      setFeedback(initialState);
+      setJustSubmitted(false);
     }
   }
 
@@ -405,20 +418,20 @@ export function QuickEntryDrawer({
           </div>
 
           {/* エラー / 成功 */}
-          {state.error && (
+          {feedback.error && (
             <p className="rounded-xl border border-[#f87171]/40 bg-[#fee2e2] px-3 py-2 text-sm font-medium text-[#1c1410]">
-              {state.error}
+              {feedback.error}
             </p>
           )}
-          {state.success && (
+          {feedback.success && (
             <p className="rounded-xl border border-[#4caf82]/40 bg-[#f0fdf6] px-3 py-2 text-sm font-bold text-[#4caf82]">
               登録しました
               {/* 生活余力の即時フィードバック（#418）: 支出登録時のみ・事実の数字だけを示す */}
-              {state.registeredBalanceType === 0 &&
+              {feedback.registeredBalanceType === 0 &&
                 effectiveDailyExpense !== null &&
-                state.registeredAmount !== undefined && (
+                feedback.registeredAmount !== undefined && (
                   (() => {
-                    const impact = formatLivingMarginImpact(state.registeredAmount, effectiveDailyExpense);
+                    const impact = formatLivingMarginImpact(feedback.registeredAmount, effectiveDailyExpense);
                     return impact ? (
                       <span className="mt-0.5 block text-xs font-semibold" style={{ color: "rgba(28,20,16,0.55)" }}>
                         {impact}

--- a/apps/web/src/components/layout/BottomNav.tsx
+++ b/apps/web/src/components/layout/BottomNav.tsx
@@ -19,8 +19,9 @@ type Props = {
 export function BottomNav({ userId, expenseCategories, incomeCategories }: Props) {
   const pathname = usePathname();
   const [drawerOpen, setDrawerOpen] = useState(false);
-  // ホーム（HomeClient）が設定する実効日次支出 E。生活余力の即時フィードバックに使う（#418）
-  const { effectiveDailyExpense } = useLivingMargin();
+  // ホーム（HomeClient）が設定する実効日次支出 E と1日予算。
+  // 生活余力の即時フィードバック（#418）と「記録後の残り」プレビュー（#461）に使う
+  const { effectiveDailyExpense, dailyBudget } = useLivingMargin();
 
   const isActive = (href: string) =>
     href === "/" ? pathname === "/" : pathname.startsWith(href);
@@ -38,6 +39,7 @@ export function BottomNav({ userId, expenseCategories, incomeCategories }: Props
         expenseCategories={expenseCategories}
         incomeCategories={incomeCategories}
         effectiveDailyExpense={effectiveDailyExpense}
+        dailyBudget={dailyBudget}
       />
 
       {/* ボトムナビゲーションバー（モバイルのみ表示） */}

--- a/apps/web/src/components/providers/LivingMarginProvider.tsx
+++ b/apps/web/src/components/providers/LivingMarginProvider.tsx
@@ -3,26 +3,42 @@
 import { createContext, useContext, useState } from "react";
 import type { ReactNode } from "react";
 
+/** 1日予算のスナップショット（「記録後の残り」プレビューに使用） */
+export type DailyBudgetSnapshot = {
+  /** 1日予算（円） */
+  amount: number;
+  /** 今日の残額（円） */
+  remaining: number;
+};
+
 type LivingMarginContextValue = {
   /** 実効日次支出 E（円/日）。ダッシュボード未取得・算出不能時は null */
   effectiveDailyExpense: number | null;
   setEffectiveDailyExpense: (value: number | null) => void;
+  /** 1日予算と今日の残額。設定未完了・ダッシュボード未取得時は null */
+  dailyBudget: DailyBudgetSnapshot | null;
+  setDailyBudget: (value: DailyBudgetSnapshot | null) => void;
 };
 
 /**
- * 生活余力の実効日次支出 E を、ダッシュボード（HomeClient）から
+ * ダッシュボード（HomeClient）が持つ生活余力・1日予算の情報を、
  * レイアウト側の QuickEntryDrawer（BottomNav の FAB）へ届けるためのコンテキスト。
- * 支出登録直後の即時フィードバック（#418）に使用する。
+ * 支出登録直後の即時フィードバック（#418）と「記録後の残り」プレビュー（#461）に使用する。
  */
 const LivingMarginContext = createContext<LivingMarginContextValue>({
   effectiveDailyExpense: null,
   setEffectiveDailyExpense: () => undefined,
+  dailyBudget: null,
+  setDailyBudget: () => undefined,
 });
 
 export function LivingMarginProvider({ children }: { children: ReactNode }) {
   const [effectiveDailyExpense, setEffectiveDailyExpense] = useState<number | null>(null);
+  const [dailyBudget, setDailyBudget] = useState<DailyBudgetSnapshot | null>(null);
   return (
-    <LivingMarginContext.Provider value={{ effectiveDailyExpense, setEffectiveDailyExpense }}>
+    <LivingMarginContext.Provider
+      value={{ effectiveDailyExpense, setEffectiveDailyExpense, dailyBudget, setDailyBudget }}
+    >
       {children}
     </LivingMarginContext.Provider>
   );

--- a/apps/web/src/components/providers/LivingMarginProvider.tsx
+++ b/apps/web/src/components/providers/LivingMarginProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useState } from "react";
-import type { ReactNode } from "react";
+import type { Dispatch, ReactNode, SetStateAction } from "react";
 
 /** 1日予算のスナップショット（「記録後の残り」プレビューに使用） */
 export type DailyBudgetSnapshot = {
@@ -17,7 +17,7 @@ type LivingMarginContextValue = {
   setEffectiveDailyExpense: (value: number | null) => void;
   /** 1日予算と今日の残額。設定未完了・ダッシュボード未取得時は null */
   dailyBudget: DailyBudgetSnapshot | null;
-  setDailyBudget: (value: DailyBudgetSnapshot | null) => void;
+  setDailyBudget: Dispatch<SetStateAction<DailyBudgetSnapshot | null>>;
 };
 
 /**


### PR DESCRIPTION
## 概要

`QuickEntryDrawer` は登録成功後も金額・メモが残ったまま「記録する」ボタンが活性で、もう一度押すと同じ内容が二重登録される（#461）。サンドボックス `HomePrototype.tsx` の `handleSubmit` / `SubmitButton` / `AmountPanel`（previewRemaining）の挙動に準拠して修正する。

## 変更内容

- **登録成功時の入力リセット**: 成功のたびに金額・メモをリセットし、ドロワーは開いたまま連続記録できるようにする。action state の変化は「レンダー中の状態調整」パターンで1回だけ処理する（react-hooks の effect 内同期 setState 禁止ルールに準拠）
- **成功フィードバック**: 記録ボタンを一時的（1.6秒）に「✓ 記録しました！」へ変化させる。表示中はボタン自体が置き換わるため再送信できず、復帰後も金額が空のため disabled になる
- **「記録後の残り」プレビュー**: 支出タブで金額入力中、「記録後の残り：¥N」を表示（残りが1日予算の20%未満なら警告色 #f43f5e）。高さ固定＋opacity 制御でレイアウトシフトを防止
- **配線**: 1日予算スナップショット（amount/remaining）を `LivingMarginProvider` に追加し、HomeClient → BottomNav（FAB）/ HomeClient 直下の両ドロワーへ供給
- Storybook の `Expense/QuickEntryDrawer` Open ストーリーに dailyBudget を追加

## 影響範囲

- クイック記録ドロワーのみ。既存の「登録しました」メッセージと生活余力フィードバック（#418）は維持（E2E の expectSuccess 互換）
- `/expenses/new` フォームは対象外（本 Issue のスコープはクイック記録）

## Test plan

- [x] 単体テスト 6 件追加（リセット・再送信不可・フィードバック復帰・プレビュー表示・警告色・収入タブ非表示）→ 16/16 パス
- [x] lint / type-check / next build パス
- [x] 実アプリ（テスト DB + 本番ビルド）で3状態を目視確認（下記スクリーンショット）

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（ID 操作なし）
- [x] マジックナンバーを排除し、定数化されているか（SUCCESS_FEEDBACK_MS / REMAINING_WARN_RATIO として定数化）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（After 3状態を実アプリ390pxで撮影しユーザーへ送付済み。CLI から PR への画像添付は GitHub API 非対応のためチャット経由。Before は現行本番のドロワー = プレビュー行なし・ボタン変化なし）
- [x] ドキュメントを追加・移動・削除した場合、SSOT マップを更新したか（該当なし）

## スクリーンショット

After（390px・実アプリで撮影、チャットへ送付済み）:
1. 金額入力中 —「記録後の残り：¥45,500」プレビュー表示
2. 残りが1日予算の20%未満 — 金額が警告色
3. 登録成功直後 — 金額 ¥0 にリセット・メモ空・「✓ 記録しました！」フィードバック

Closes #461
Sprint: 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q
