### PR TITLE
fix(web,api): 貯蓄目標を永続化し1日予算の算出に控除として組み込む

### DIFF
--- a/apps/api/prisma/migrations/20260707155350_add_savings_goal_to_user_settings/migration.sql
+++ b/apps/api/prisma/migrations/20260707155350_add_savings_goal_to_user_settings/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE `user_settings` ADD COLUMN `savings_goal` INTEGER NOT NULL DEFAULT 0;
+

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -125,7 +125,7 @@ model UserSecurityAnswer {
   @@map("user_security_answers")
 }
 
-// ユーザー設定（総資産・月次収入・給料日・固定費・初回設定完了フラグ）
+// ユーザー設定（総資産・月次収入・給料日・固定費・貯蓄目標・初回設定完了フラグ）
 model UserSettings {
   id                    String   @id @db.VarChar(26)
   userId                String   @unique @db.VarChar(255) @map("user_id")
@@ -134,6 +134,7 @@ model UserSettings {
   paydayDay             Int      @default(25) @map("payday_day")
   fixedExpenses         Int      @default(0) @map("fixed_expenses")
   fixedExpensesDetail   Json?    @map("fixed_expenses_detail")
+  savingsGoal           Int      @default(0) @map("savings_goal")
   initialSetupCompleted Boolean  @default(false) @map("initial_setup_completed")
   createdAt             DateTime @default(now()) @db.DateTime(6) @map("created_at")
   updatedAt             DateTime @updatedAt @db.DateTime(6) @map("updated_at")

--- a/apps/api/src/__tests__/unit/use-cases/GetDashboardUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/GetDashboardUseCase.test.ts
@@ -38,6 +38,7 @@ const settings: UserSettings = {
     paydayDay: 25,
     fixedExpenses: 100_000,
     fixedExpensesDetail: null,
+    savingsGoal: 0,
     initialSetupCompleted: true,
     createdAt: new Date('2026-05-08T00:00:00.000Z'),
     updatedAt: new Date('2026-05-08T00:00:00.000Z'),
@@ -55,6 +56,34 @@ const settingsRepo: IUserSettingsRepository = {
     findByUserId: vi.fn(),
     upsert: vi.fn(),
 };
+
+describe('GetDashboardUseCase — dailyBudget の貯蓄目標控除（#457）', () => {
+    let useCase: GetDashboardUseCase;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        useCase = new GetDashboardUseCase(expenseRepo, settingsRepo);
+    });
+
+    it('savingsGoal が設定されているとき、可処分残高から控除して1日予算を算出する', async () => {
+        vi.mocked(expenseRepo.findByUserId).mockResolvedValue([]);
+        vi.mocked(settingsRepo.findByUserId).mockResolvedValue({ ...settings, savingsGoal: 60_000 });
+
+        const withGoal = await useCase.execute('user-001');
+
+        vi.mocked(settingsRepo.findByUserId).mockResolvedValue(settings);
+        const withoutGoal = await useCase.execute('user-001');
+
+        expect(withGoal.dailyBudget).not.toBeNull();
+        expect(withoutGoal.dailyBudget).not.toBeNull();
+        // 同一日数で割るため、控除分だけ1日予算が小さくなる
+        const days = withGoal.dailyBudget?.daysUntilPayday ?? 1;
+        expect(withGoal.dailyBudget?.amount).toBe(
+            Math.floor((settings.totalAssets - settings.fixedExpenses - 60_000) / days)
+        );
+        expect((withoutGoal.dailyBudget?.amount ?? 0) > (withGoal.dailyBudget?.amount ?? 0)).toBe(true);
+    });
+});
 
 describe('GetDashboardUseCase — livingMargin 入力の導出', () => {
     let useCase: GetDashboardUseCase;

--- a/apps/api/src/application/use-cases/dashboard/GetDashboardUseCase.ts
+++ b/apps/api/src/application/use-cases/dashboard/GetDashboardUseCase.ts
@@ -81,6 +81,7 @@ export class GetDashboardUseCase {
                 totalAssets: settings.totalAssets,
                 fixedExpenses: settings.fixedExpenses,
                 paydayDay: settings.paydayDay,
+                savingsGoal: settings.savingsGoal,
                 today,
             });
             const remaining = result.dailyBudget - todayExpense;

--- a/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
+++ b/apps/api/src/application/use-cases/settings/UpsertUserSettingsUseCase.ts
@@ -13,6 +13,8 @@ export type UpsertUserSettingsInput = {
     fixedExpenses: number;
     /** 固定費内訳（省略時は既存値を維持） */
     fixedExpensesDetail?: FixedExpensesDetail | null;
+    /** 月間貯蓄目標（円）。省略時は既存値を維持 */
+    savingsGoal?: number;
     /** 初回設定完了フラグ（省略時は既存値を維持） */
     initialSetupCompleted?: boolean;
 };
@@ -57,6 +59,9 @@ export class UpsertUserSettingsUseCase {
         if (fixedExpenses < 0) {
             return err(new ValidationError('固定費は0以上の値を入力してください'));
         }
+        if (input.savingsGoal !== undefined && input.savingsGoal < 0) {
+            return err(new ValidationError('貯蓄目標は0以上の値を入力してください'));
+        }
 
         const settings = await this.userSettingsRepository.upsert({
             userId: input.userId,
@@ -65,6 +70,7 @@ export class UpsertUserSettingsUseCase {
             paydayDay: input.paydayDay,
             fixedExpenses,
             fixedExpensesDetail: input.fixedExpensesDetail,
+            savingsGoal: input.savingsGoal,
             initialSetupCompleted: input.initialSetupCompleted,
         });
         return ok(settings);

--- a/apps/api/src/domain/models/UserSettings.ts
+++ b/apps/api/src/domain/models/UserSettings.ts
@@ -14,7 +14,7 @@ export type FixedExpensesDetail = {
     other: number;
 };
 
-/** ユーザー設定ドメインモデル（総資産・月次収入・給料日・固定費・初回設定完了フラグ） */
+/** ユーザー設定ドメインモデル（総資産・月次収入・給料日・固定費・貯蓄目標・初回設定完了フラグ） */
 export type UserSettings = {
     id: string;
     userId: string;
@@ -26,6 +26,8 @@ export type UserSettings = {
     fixedExpenses: number;
     /** 固定費内訳（null = 旧データ / 未設定） */
     fixedExpensesDetail: FixedExpensesDetail | null;
+    /** 月間貯蓄目標（円）。1日予算の算出時に控除する */
+    savingsGoal: number;
     /** 初回設定完了フラグ */
     initialSetupCompleted: boolean;
     createdAt: Date;

--- a/apps/api/src/domain/repositories/IUserSettingsRepository.ts
+++ b/apps/api/src/domain/repositories/IUserSettingsRepository.ts
@@ -1,12 +1,13 @@
 import type { UserSettings } from '../models/UserSettings';
 
-/** upsert 時の入力型: initialSetupCompleted / fixedExpensesDetail は省略可 */
+/** upsert 時の入力型: initialSetupCompleted / fixedExpensesDetail / savingsGoal は省略可（省略時は既存値を維持） */
 export type UpsertSettingsInput = Omit<
     UserSettings,
-    'id' | 'createdAt' | 'updatedAt' | 'initialSetupCompleted' | 'fixedExpensesDetail'
+    'id' | 'createdAt' | 'updatedAt' | 'initialSetupCompleted' | 'fixedExpensesDetail' | 'savingsGoal'
 > & {
     initialSetupCompleted?: boolean;
     fixedExpensesDetail?: UserSettings['fixedExpensesDetail'];
+    savingsGoal?: number;
 };
 
 export interface IUserSettingsRepository {

--- a/apps/api/src/infrastructure/persistence/PrismaUserSettingsRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaUserSettingsRepository.ts
@@ -52,6 +52,7 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
             paydayDay: record.paydayDay,
             fixedExpenses: record.fixedExpenses,
             fixedExpensesDetail: parseFixedExpensesDetail(record.fixedExpensesDetail),
+            savingsGoal: record.savingsGoal,
             initialSetupCompleted: record.initialSetupCompleted,
             createdAt: record.createdAt,
             updatedAt: record.updatedAt,
@@ -69,6 +70,7 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
                 paydayDay: settings.paydayDay,
                 fixedExpenses: settings.fixedExpenses,
                 fixedExpensesDetail: toPrismaJson(settings.fixedExpensesDetail),
+                savingsGoal: settings.savingsGoal ?? 0,
                 initialSetupCompleted: settings.initialSetupCompleted ?? false,
             },
             update: {
@@ -78,6 +80,9 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
                 fixedExpenses: settings.fixedExpenses,
                 ...(settings.fixedExpensesDetail !== undefined && {
                     fixedExpensesDetail: toPrismaJson(settings.fixedExpensesDetail),
+                }),
+                ...(settings.savingsGoal !== undefined && {
+                    savingsGoal: settings.savingsGoal,
                 }),
                 ...(settings.initialSetupCompleted !== undefined && {
                     initialSetupCompleted: settings.initialSetupCompleted,
@@ -92,6 +97,7 @@ export class PrismaUserSettingsRepository implements IUserSettingsRepository {
             paydayDay: record.paydayDay,
             fixedExpenses: record.fixedExpenses,
             fixedExpensesDetail: parseFixedExpensesDetail(record.fixedExpensesDetail),
+            savingsGoal: record.savingsGoal,
             initialSetupCompleted: record.initialSetupCompleted,
             createdAt: record.createdAt,
             updatedAt: record.updatedAt,

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -433,6 +433,11 @@ export const UserSettingsResponseSchema = z
         fixedExpensesDetail: FixedExpensesDetailSchema.nullable().openapi({
             description: '固定費内訳（null = 未設定）',
         }),
+        savingsGoal: z
+            .number()
+            .int()
+            .min(0)
+            .openapi({ description: '月間貯蓄目標（円）。1日予算の算出時に控除する', example: 30000 }),
         initialSetupCompleted: z.boolean().openapi({ description: '初回設定完了フラグ', example: false }),
     })
     .openapi('UserSettingsResponse');
@@ -463,6 +468,12 @@ export const UpsertUserSettingsBodySchema = z
         fixedExpensesDetail: FixedExpensesDetailSchema.nullable()
             .optional()
             .openapi({ description: '固定費内訳（省略時は既存値を維持）' }),
+        savingsGoal: z
+            .number({ invalid_type_error: '貯蓄目標は数値で入力してください' })
+            .int()
+            .min(0, '貯蓄目標は0以上の値を入力してください')
+            .optional()
+            .openapi({ description: '月間貯蓄目標（円）。省略時は既存値を維持', example: 30000 }),
         initialSetupCompleted: z
             .boolean({
                 invalid_type_error: '初回設定完了フラグは真偽値で入力してください',

--- a/apps/api/src/presentation/routes/settings.ts
+++ b/apps/api/src/presentation/routes/settings.ts
@@ -74,6 +74,7 @@ export function createSettingsRoutes({
                 paydayDay: settings?.paydayDay ?? 25,
                 fixedExpenses: settings?.fixedExpenses ?? 0,
                 fixedExpensesDetail: settings?.fixedExpensesDetail ?? null,
+                savingsGoal: settings?.savingsGoal ?? 0,
                 initialSetupCompleted: settings?.initialSetupCompleted ?? false,
             },
             200
@@ -82,8 +83,15 @@ export function createSettingsRoutes({
 
     app.openapi(upsertUserSettingsRoute, async (c) => {
         const userId = c.get('userId');
-        const { totalAssets, monthlyIncome, paydayDay, fixedExpenses, fixedExpensesDetail, initialSetupCompleted } =
-            c.req.valid('json');
+        const {
+            totalAssets,
+            monthlyIncome,
+            paydayDay,
+            fixedExpenses,
+            fixedExpensesDetail,
+            savingsGoal,
+            initialSetupCompleted,
+        } = c.req.valid('json');
         const result = await upsertUserSettingsUseCase.execute({
             userId,
             totalAssets,
@@ -91,6 +99,7 @@ export function createSettingsRoutes({
             paydayDay,
             fixedExpenses,
             fixedExpensesDetail,
+            savingsGoal,
             initialSetupCompleted,
         });
         if (!result.ok) {
@@ -103,6 +112,7 @@ export function createSettingsRoutes({
                 paydayDay: result.value.paydayDay,
                 fixedExpenses: result.value.fixedExpenses,
                 fixedExpensesDetail: result.value.fixedExpensesDetail,
+                savingsGoal: result.value.savingsGoal,
                 initialSetupCompleted: result.value.initialSetupCompleted,
             },
             200

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -16,6 +16,7 @@ export default async function SettingsPage() {
     fixedExpenses: 0,
     totalAssets: 0,
     fixedExpensesDetail: null,
+    savingsGoal: 0,
     initialSetupCompleted: false,
   }));
 

--- a/apps/web/src/components/settings/SettingsClient.tsx
+++ b/apps/web/src/components/settings/SettingsClient.tsx
@@ -10,6 +10,7 @@ import {
   User, ChevronRight,
 } from "lucide-react";
 import { SPRING, PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
+import { calcDailyBudget } from "@budget/common";
 import type { UserSettingsResponse, FixedExpensesDetail } from "@budget/api-client";
 import { AmountField } from "../common/AmountField";
 import { SalaryDayPicker } from "./SalaryDayPicker";
@@ -65,8 +66,8 @@ export function SettingsClient({ settings }: Props) {
   );
   const [currentBalance, setCurrentBalance] = useState(settings.totalAssets);
   const [savingsMode, setSavingsMode] = useState<SavingsMode>("monthly");
-  const [savingsMonthly, setSavingsMonthly] = useState(0);
-  const [savingsYearly, setSavingsYearly] = useState(0);
+  const [savingsMonthly, setSavingsMonthly] = useState(settings.savingsGoal);
+  const [savingsYearly, setSavingsYearly] = useState(settings.savingsGoal * 12);
 
   // 保存状態
   const [saving, setSaving] = useState(false);
@@ -77,7 +78,14 @@ export function SettingsClient({ settings }: Props) {
   const totalFixed = calcTotalFixed(fixedDetail);
   const monthlySavings = savingsMode === "monthly" ? savingsMonthly : Math.round(savingsYearly / 12);
   const disposable = monthlyIncome - totalFixed - monthlySavings;
-  const dailyBudget = Math.max(0, Math.floor(disposable / 30));
+  // 1日予算プレビューはホーム（dashboard）と同じ共有ロジックで算出し、表示を一致させる（#457）
+  const { dailyBudget } = calcDailyBudget({
+    totalAssets: currentBalance,
+    fixedExpenses: totalFixed,
+    paydayDay: salaryDay,
+    savingsGoal: monthlySavings,
+    today: new Date(),
+  });
   const budgetColor = getBudgetColor(dailyBudget);
 
   const inc = monthlyIncome || 1;
@@ -110,6 +118,7 @@ export function SettingsClient({ settings }: Props) {
         paydayDay: salaryDay,
         fixedExpenses: totalFixed,
         fixedExpensesDetail: fixedDetail,
+        savingsGoal: monthlySavings,
       });
       if (result.error) {
         throw new Error(result.error);

--- a/docs/database/schema.dbml
+++ b/docs/database/schema.dbml
@@ -82,6 +82,7 @@ Table user_settings {
   paydayDay Int [not null, default: 25]
   fixedExpenses Int [not null, default: 0]
   fixedExpensesDetail Json
+  savingsGoal Int [not null, default: 0]
   initialSetupCompleted Boolean [not null, default: false]
   createdAt DateTime [default: `now()`, not null]
   updatedAt DateTime [not null]

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -2183,6 +2183,11 @@ export interface components {
             fixedExpenses: number;
             fixedExpensesDetail: components["schemas"]["FixedExpensesDetail"];
             /**
+             * @description 月間貯蓄目標（円）。1日予算の算出時に控除する
+             * @example 30000
+             */
+            savingsGoal: number;
+            /**
              * @description 初回設定完了フラグ
              * @example false
              */
@@ -2210,6 +2215,11 @@ export interface components {
              */
             fixedExpenses: number;
             fixedExpensesDetail?: components["schemas"]["FixedExpensesDetail"] & unknown;
+            /**
+             * @description 月間貯蓄目標（円）。省略時は既存値を維持
+             * @example 30000
+             */
+            savingsGoal?: number;
             /**
              * @description 初回設定完了フラグ
              * @example true

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -883,6 +883,11 @@ components:
           example: 80000
         fixedExpensesDetail:
           $ref: "#/components/schemas/FixedExpensesDetail"
+        savingsGoal:
+          type: integer
+          minimum: 0
+          description: 月間貯蓄目標（円）。1日予算の算出時に控除する
+          example: 30000
         initialSetupCompleted:
           type: boolean
           description: 初回設定完了フラグ
@@ -893,6 +898,7 @@ components:
         - paydayDay
         - fixedExpenses
         - fixedExpensesDetail
+        - savingsGoal
         - initialSetupCompleted
     UpsertUserSettingsBody:
       type: object
@@ -922,6 +928,11 @@ components:
           allOf:
             - $ref: "#/components/schemas/FixedExpensesDetail"
             - description: 固定費内訳（省略時は既存値を維持）
+        savingsGoal:
+          type: integer
+          minimum: 0
+          description: 月間貯蓄目標（円）。省略時は既存値を維持
+          example: 30000
         initialSetupCompleted:
           type: boolean
           description: 初回設定完了フラグ

--- a/packages/common/src/__tests__/utils/budget.test.ts
+++ b/packages/common/src/__tests__/utils/budget.test.ts
@@ -59,6 +59,49 @@ describe('calcDailyBudget', () => {
         expect(result.dailyBudget).toBe(40000)
     })
 
+    it('貯蓄目標があるとき、可処分残高から控除して日割りする（#457）', () => {
+        const result = calcDailyBudget({
+            totalAssets: 300000,
+            fixedExpenses: 100000,
+            paydayDay: 25,
+            savingsGoal: 50000,
+            today,
+        })
+        // availableBalance = 300000 - 100000 - 50000 = 150000
+        // dailyBudget = floor(150000 / 5) = 30000
+        expect(result.availableBalance).toBe(150000)
+        expect(result.dailyBudget).toBe(30000)
+    })
+
+    it('貯蓄目標の控除で可処分残高が負になるとき、dailyBudget=0 を返す（#457）', () => {
+        const result = calcDailyBudget({
+            totalAssets: 120000,
+            fixedExpenses: 100000,
+            paydayDay: 25,
+            savingsGoal: 50000,
+            today,
+        })
+        expect(result.availableBalance).toBe(-30000)
+        expect(result.dailyBudget).toBe(0)
+    })
+
+    it('貯蓄目標を省略したとき、従来どおり控除なしで計算する（後方互換）', () => {
+        const withoutGoal = calcDailyBudget({
+            totalAssets: 300000,
+            fixedExpenses: 100000,
+            paydayDay: 25,
+            today,
+        })
+        const withZeroGoal = calcDailyBudget({
+            totalAssets: 300000,
+            fixedExpenses: 100000,
+            paydayDay: 25,
+            savingsGoal: 0,
+            today,
+        })
+        expect(withoutGoal).toEqual(withZeroGoal)
+    })
+
     it('可処分残高が0のとき、dailyBudget=0 を返す', () => {
         const result = calcDailyBudget({
             totalAssets: 100000,

--- a/packages/common/src/utils/budget.ts
+++ b/packages/common/src/utils/budget.ts
@@ -4,7 +4,7 @@ export type DailyBudgetResult = {
     dailyBudget: number;
     /** 次の給料日まで何日あるか */
     daysUntilPayday: number;
-    /** 固定費を差し引いた可処分残高（円） */
+    /** 固定費・貯蓄目標を差し引いた可処分残高（円） */
     availableBalance: number;
 };
 
@@ -45,23 +45,25 @@ export function calcDaysUntilPayday(today: Date, paydayDay: number): number {
 
 /**
  * 1日あたりの使える金額（1日予算）を算出する。
- * 「給料日まで固定費を引いた残高でどれだけ使えるか」の計算。
+ * 「給料日まで固定費・貯蓄目標を引いた残高でどれだけ使えるか」の計算。
  *
  * @param params.totalAssets - 現在の総資産（円）
  * @param params.fixedExpenses - 今月残りの固定費合計（円）
  * @param params.paydayDay - 給料日（1〜31）
  * @param params.today - 基準日
+ * @param params.savingsGoal - 月間貯蓄目標（円）。給料日まで確保する額として控除する（省略時 0）
  */
 export function calcDailyBudget(params: {
     totalAssets: number;
     fixedExpenses: number;
     paydayDay: number;
     today: Date;
+    savingsGoal?: number;
 }): DailyBudgetResult {
-    const { totalAssets, fixedExpenses, paydayDay, today } = params;
+    const { totalAssets, fixedExpenses, paydayDay, today, savingsGoal = 0 } = params;
 
     const daysUntilPayday = calcDaysUntilPayday(today, paydayDay);
-    const availableBalance = totalAssets - fixedExpenses;
+    const availableBalance = totalAssets - fixedExpenses - savingsGoal;
 
     const dailyBudget = availableBalance > 0
         ? Math.floor(availableBalance / daysUntilPayday)


### PR DESCRIPTION
## 概要

設定画面の貯蓄目標（月間/年間）がどこにも永続化されず、保存後リロードすると 0 に戻っていた。また画面内の1日予算プレビューが独自式（(収入−固定費−貯蓄)/30）で計算されており、サーバー側（資産ベース・給料日まで日割り）と恒常的に食い違っていた（#457）。貯蓄目標を DB に永続化し、1日予算計算の SSOT（`calcDailyBudget`）に控除として組み込む。

## 変更内容

- **DB**: `user_settings` に `savings_goal INT NOT NULL DEFAULT 0` を追加。`prisma migrate diff` で生成した create-only マイグレーションを `migrate deploy` で適用（既存データはデフォルト 0 で影響なし）
- **共通ロジック**: `calcDailyBudget` に `savingsGoal`（省略可・既定 0）を追加し、可処分残高 = 総資産 − 固定費 − 貯蓄目標 として日割り
- **API**: ドメインモデル・リポジトリ・`UpsertUserSettingsUseCase`（0以上バリデーション付き・省略時は既存値維持）・`GetDashboardUseCase`・OpenAPI スキーマ（GET/PUT）に `savingsGoal` を配線。openapi.yaml / api-client 型は再生成
- **Web**: 設定画面の貯蓄目標を `settings.savingsGoal` から復元（月間換算額）。保存ペイロードに月間換算額を含める。1日予算プレビューをホームと同じ共有ロジックへ統一

## 影響範囲

- 初回設定ウィザード（savingsGoal を送らない）は「省略時は既存値維持」のため影響なし
- 既存レコードは savings_goal=0 で従来と同じ計算結果（後方互換をテストで担保）
- ホーム「今月の貯蓄予測」カード（#458）の前提が整う

## Test plan

- [x] `calcDailyBudget` に控除・負残高・後方互換の3ケースを追加（common 97件パス）
- [x] `GetDashboardUseCase` に貯蓄控除の検証を追加（api unit 67件パス）
- [x] web unit 109件・lint・type-check・next build パス
- [x] 実アプリ（テスト DB + 本番ビルド）で E2E 検証: 30,000円/月 を保存→リロード復元、ホーム1日予算が控除後の ¥54,705（=(960,000−0−30,000)÷17日）で一致することを目視確認

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（各層の既存パターンに追従）
- [x] ID（ulid）の生成・利用箇所は適切か（既存 upsert の ulid 生成を踏襲）
- [x] マジックナンバーを排除し、定数化されているか（savingsGoal 既定値 0 は API スキーマ/DB デフォルトとして定義）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（After 3状態を実アプリ390pxで撮影しユーザーへチャット送付済み。CLI から PR への画像添付は GitHub API 非対応。Before = 貯蓄目標が保存されず 0 に戻る・プレビューとホームの数値不一致）
- [x] ドキュメントを追加・移動・削除した場合、SSOT マップを更新したか（schema.dbml は prisma generate による自動更新）

## スクリーンショット

After（390px・実アプリで撮影、チャットへ送付済み）:
1. 貯蓄目標 30,000円/月 を入力（年間換算 ≈¥360,000 表示）
2. 保存 → リロード後も復元されている
3. ホームの1日予算が控除後の ¥54,705 で設定プレビューと一致

Closes #457
Sprint: 30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q