### PR TITLE
feat(web): ホーム「最近の記録」の行タップで明細の該当日へ遷移できるようにする

### DIFF
--- a/apps/web/src/__tests__/components/RecentExpenses.test.tsx
+++ b/apps/web/src/__tests__/components/RecentExpenses.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { RecentExpenses } from "@/components/dashboard/RecentExpenses";
+import {
+  fixtureAllCategories,
+  fixtureExpense,
+  localDateStr,
+} from "@/__fixtures__/dashboard";
+
+describe("RecentExpenses", () => {
+  it("各行が明細ページの該当日へのリンクになっている（#463）", () => {
+    const date = localDateStr(0);
+    render(
+      <RecentExpenses
+        recentExpenses={[
+          fixtureExpense({ date, amount: 800, categoryId: 1, content: "昼食" }),
+        ]}
+        allCategories={fixtureAllCategories}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /昼食 の記録を明細で見る/ });
+    expect(link).toHaveAttribute("href", `/records?date=${date}`);
+  });
+
+  it("記録がないとき、空状態メッセージを表示する", () => {
+    render(<RecentExpenses recentExpenses={[]} allCategories={fixtureAllCategories} />);
+    expect(screen.getByText("まだ記録がありません")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/components/RecordsPage.test.tsx
+++ b/apps/web/src/__tests__/components/RecordsPage.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { RecordsPage } from "@/components/records/RecordsPage";
+import { fixtureAllCategories, fixtureExpense } from "@/__fixtures__/dashboard";
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+describe("RecordsPage — 日付絞り込み（#463）", () => {
+  beforeEach(() => {
+    push.mockClear();
+  });
+
+  it("initialDate 指定時、日付絞り込みチップが表示される", () => {
+    render(
+      <RecordsPage
+        initialExpenses={[fixtureExpense({ date: "2026-07-08", amount: 800 })]}
+        allCategories={fixtureAllCategories}
+        initialPeriod="all"
+        initialSearch=""
+        initialDate="2026-07-08"
+      />,
+    );
+    expect(screen.getByText("7月8日の記録")).toBeInTheDocument();
+  });
+
+  it("チップの解除ボタンで date を含まない URL へ遷移する", () => {
+    render(
+      <RecordsPage
+        initialExpenses={[]}
+        allCategories={fixtureAllCategories}
+        initialPeriod="all"
+        initialSearch=""
+        initialDate="2026-07-08"
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "日付の絞り込みを解除" }));
+    expect(push).toHaveBeenCalledWith("/records?period=all", { scroll: false });
+  });
+
+  it("initialDate 未指定のとき、チップは表示されない", () => {
+    render(
+      <RecordsPage
+        initialExpenses={[]}
+        allCategories={fixtureAllCategories}
+        initialPeriod="month"
+        initialSearch=""
+      />,
+    );
+    expect(screen.queryByText(/の記録$/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/records/page.tsx
+++ b/apps/web/src/app/records/page.tsx
@@ -19,9 +19,12 @@ const VALID_PERIODS: Period[] = ["week", "month", "lastMonth", "all"];
 async function RecordsContent({
   period,
   search,
+  date,
 }: {
   period: Period;
   search: string;
+  /** YYYY-MM-DD。指定時はその日の記録に絞り込む（#463） */
+  date: string | null;
 }) {
   const [expensesResult, expenseCatsResult, incomeCatsResult] =
     await Promise.allSettled([
@@ -44,7 +47,8 @@ async function RecordsContent({
 
   if (expensesResult.status === "rejected") throw expensesResult.reason;
 
-  const expenses = expensesResult.value.expense ?? [];
+  const fetched = expensesResult.value.expense ?? [];
+  const expenses = date ? fetched.filter((e) => e.date === date) : fetched;
   const expenseCategories =
     expenseCatsResult.status === "fulfilled" ? expenseCatsResult.value : [];
   const incomeCategories =
@@ -57,6 +61,7 @@ async function RecordsContent({
       allCategories={allCategories}
       initialPeriod={period}
       initialSearch={search}
+      initialDate={date}
     />
   );
 }
@@ -64,15 +69,18 @@ async function RecordsContent({
 export default async function RecordsPageRoute({
   searchParams,
 }: {
-  searchParams: Promise<{ period?: string; search?: string }>;
+  searchParams: Promise<{ period?: string; search?: string; date?: string }>;
 }) {
   const cookieStore = await cookies();
   const userId = cookieStore.get("user_id")?.value ?? "Guest";
   const params = await searchParams;
 
-  const period: Period = VALID_PERIODS.includes(params.period as Period)
+  // date 指定時（ホームの行タップ遷移 #463）は全期間から該当日に絞り込む
+  const date = /^\d{4}-\d{2}-\d{2}$/.test(params.date ?? "") ? (params.date as string) : null;
+  const requestedPeriod: Period = VALID_PERIODS.includes(params.period as Period)
     ? (params.period as Period)
     : "month";
+  const period: Period = date ? "all" : requestedPeriod;
   const search = params.search ?? "";
 
   return (
@@ -87,7 +95,7 @@ export default async function RecordsPageRoute({
           </div>
         }
       >
-        <RecordsContent period={period} search={search} />
+        <RecordsContent period={period} search={search} date={date} />
       </Suspense>
     </AppShell>
   );

--- a/apps/web/src/app/records/page.tsx
+++ b/apps/web/src/app/records/page.tsx
@@ -28,7 +28,7 @@ async function RecordsContent({
 }) {
   const [expensesResult, expenseCatsResult, incomeCatsResult] =
     await Promise.allSettled([
-      getExpenses({ period, search: search || undefined }),
+      getExpenses({ period, search: search || undefined, date: date || undefined }),
       getCategories(0),
       getCategories(1),
     ]);
@@ -47,8 +47,8 @@ async function RecordsContent({
 
   if (expensesResult.status === "rejected") throw expensesResult.reason;
 
-  const fetched = expensesResult.value.expense ?? [];
-  const expenses = date ? fetched.filter((e) => e.date === date) : fetched;
+  // date は API 側でサーバーサイドフィルタされる（GET /expense?date=YYYY-MM-DD）
+  const expenses = expensesResult.value.expense ?? [];
   const expenseCategories =
     expenseCatsResult.status === "fulfilled" ? expenseCatsResult.value : [];
   const incomeCategories =

--- a/apps/web/src/components/dashboard/RecentExpenses.tsx
+++ b/apps/web/src/components/dashboard/RecentExpenses.tsx
@@ -4,6 +4,9 @@ import { useMemo, createElement } from "react";
 import Link from "next/link";
 import { motion } from "framer-motion";
 import { ChevronRight } from "lucide-react";
+
+// 行全体を明細（該当日）へのリンクにする（#463）。編集・削除は明細側で行う導線設計
+const MotionLink = motion.create(Link);
 import { SPRING } from "@/lib/motion";
 import { getCategoryIcon } from "@/lib/categoryTokens";
 import type { ExpenseResponse, CategoryItem } from "@/lib/api/types";
@@ -70,14 +73,18 @@ function RecordItem({
     : "";
 
   return (
-    <motion.div
-      className="flex w-full items-center gap-3 px-4 py-2.5"
+    <MotionLink
+      href={`/records?date=${item.date}`}
+      aria-label={`${item.content?.trim() || catName} の記録を明細で見る`}
+      className="flex w-full items-center gap-3 px-4 py-2.5 transition-colors hover:bg-[rgba(28,20,16,0.03)] active:bg-[rgba(28,20,16,0.05)]"
       style={{
+        textDecoration: "none",
         borderBottom: hasBorderBottom ? "1px solid var(--border-default)" : "none",
       }}
       initial={{ opacity: 0, y: 4 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ delay: index * 0.04, duration: 0.15, ease: "easeOut" }}
+      whileTap={{ scale: 0.99 }}
     >
       <div
         className="flex h-8 w-8 shrink-0 items-center justify-center"
@@ -116,7 +123,7 @@ function RecordItem({
       >
         {isIncome ? "+" : "−"}¥{item.amount.toLocaleString("ja-JP")}
       </div>
-    </motion.div>
+    </MotionLink>
   );
 }
 

--- a/apps/web/src/components/records/RecordsPage.tsx
+++ b/apps/web/src/components/records/RecordsPage.tsx
@@ -3,6 +3,7 @@
 import { useState, useMemo, useCallback, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
+import { X } from "lucide-react";
 import { PAGE_VARIANTS, PAGE_ITEM_VARIANTS, SPRING } from "@/lib/motion";
 import type { ExpenseResponse, CategoryItem } from "@/lib/api/types";
 import { PeriodFilter, type Period } from "./PeriodFilter";
@@ -14,13 +15,22 @@ type Props = {
   allCategories: CategoryItem[];
   initialPeriod: Period;
   initialSearch: string;
+  /** YYYY-MM-DD。指定時はその日の記録に絞り込み表示（#463） */
+  initialDate?: string | null;
 };
+
+/** "2026-07-08" → "7月8日" */
+function formatDateLabel(dateStr: string): string {
+  const [, m, d] = dateStr.split("-");
+  return `${Number(m)}月${Number(d)}日`;
+}
 
 export function RecordsPage({
   initialExpenses,
   allCategories,
   initialPeriod,
   initialSearch,
+  initialDate = null,
 }: Props) {
   const router = useRouter();
   const [, startTransition] = useTransition();
@@ -85,6 +95,29 @@ export function RecordsPage({
               backdropFilter: "blur(10px)",
             }}
           >
+            {/* 日付絞り込みチップ（ホームの行タップ遷移 #463。期間・検索の操作で解除される） */}
+            {initialDate && (
+              <div className="flex items-center gap-2 pb-1.5 pt-1">
+                <span
+                  className="inline-flex items-center gap-1 rounded-full border px-2.5 py-1 text-[11px] font-bold"
+                  style={{
+                    background: "var(--color-brand-light)",
+                    borderColor: "rgba(241,136,64,0.30)",
+                    color: "var(--color-brand-primary)",
+                  }}
+                >
+                  {formatDateLabel(initialDate)}の記録
+                  <button
+                    type="button"
+                    aria-label="日付の絞り込みを解除"
+                    className="ml-0.5 flex h-4 w-4 items-center justify-center rounded-full transition-colors hover:bg-[rgba(241,136,64,0.15)]"
+                    onClick={() => navigate(period, search)}
+                  >
+                    <X size={10} />
+                  </button>
+                </span>
+              </div>
+            )}
             {/* 期間フィルタ */}
             <div className="flex items-center gap-2 pb-1.5 pt-1">
               <PeriodFilter value={period} onChange={handlePeriodChange} />
@@ -146,7 +179,7 @@ export function RecordsPage({
         <motion.div variants={PAGE_ITEM_VARIANTS}>
           <AnimatePresence mode="wait">
             <motion.div
-              key={`${period}-${search}`}
+              key={`${period}-${search}-${initialDate ?? ""}`}
               initial={{ opacity: 0, y: 6 }}
               animate={{ opacity: 1, y: 0 }}
               exit={{ opacity: 0, y: -4 }}


### PR DESCRIPTION
## 概要

ホーム「最近の記録」の行は非インタラクティブな div で、タップしても何も起きなかった（#463）。サンドボックス `HomePrototype.tsx` の RecordItem（MotionLink）に準拠し、行全体を明細ページの該当日へのリンクにして「記録の確認 → 修正（#317）」への導線を最短にする。

## 変更内容

- **RecentExpenses**: 行を `/records?date=YYYY-MM-DD` への `motion.create(Link)` に変更。hover / active の背景フィードバックと whileTap、アクセシブルな aria-label を付与
- **明細ページ（records/page.tsx）**: `date` クエリ（YYYY-MM-DD 形式を検証）を解釈。指定時は全期間から該当日に絞り込み
- **RecordsPage**: 日付絞り込みチップ（「7月8日の記録 ×」）を表示。× ボタンまたは期間・検索の操作で絞り込みが解除される
- テスト5件を追加（リンク href / 空状態 / チップ表示 / 解除遷移 / 未指定時非表示）

## 影響範囲

- 既存の period / search クエリの挙動は不変（date はそれらの操作で自然に外れる）
- カレンダービュー（#462）が同じ `date` 受け口を再利用できる設計

## Test plan

- [x] 単体テスト5件追加（web 全126件パス）
- [x] lint / type-check / next build パス
- [x] 実アプリ（テスト DB + 本番ビルド）で行タップ → 該当日絞り込み表示 → チップ解除の一連の動作を確認（スクリーンショット撮影済み）

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界を跨ぐ不正な依存はないか（web 層のみの変更）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（日付形式の検証正規表現のみ・意図をコメントで明記）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（After 2枚を実アプリ390pxで撮影しユーザーへチャット送付済み。CLI から PR への画像添付は GitHub API 非対応。Before = 行が非インタラクティブで導線なし）
- [x] ドキュメントを追加・移動・削除した場合、SSOT マップを更新したか（該当なし）

## スクリーンショット

After（実アプリ390px・チャットへ送付済み）:
1. ホーム「最近の記録」の行がリンク化（hover/active フィードバック付き）
2. 行タップ → 明細の該当日絞り込み（チップ表示・× で解除）

Closes #463
Sprint: 31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q