### PR TITLE
feat(web): DailyBudgetHero を「今日の状況」相当へ強化する（進捗バー・4状態バッジ・貯蓄インサイト）

### DIFF
--- a/apps/web/src/__tests__/components/DailyBudgetHero.test.tsx
+++ b/apps/web/src/__tests__/components/DailyBudgetHero.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { DailyBudgetHero } from "@/components/dashboard/DailyBudgetHero";
+
+// 基準日を固定して決定論的に検証する（7月15日 / 31日月）
+const TODAY = new Date("2026-07-15T00:00:00");
+
+const baseProps = {
+  // amount 2400 / remaining はテストごとに消化率から導出
+  monthSummary: { expense: 120_000, income: 300_000 },
+  savingsGoal: 30_000,
+  today: TODAY,
+};
+
+function budget(remaining: number) {
+  return { amount: 2400, remaining, ratio: remaining / 2400, daysUntilPayday: 10 };
+}
+
+describe("DailyBudgetHero — 4状態バッジと進捗バー（#459）", () => {
+  it("消化率 ≤ 50% のとき「好調」バッジ", () => {
+    render(<DailyBudgetHero {...baseProps} dailyBudget={budget(1400)} todayExpense={1000} />);
+    expect(screen.getByText("好調")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "日予算の消化率 42%" })).toBeInTheDocument();
+  });
+
+  it("消化率 51〜80% のとき「順調」バッジ", () => {
+    render(<DailyBudgetHero {...baseProps} dailyBudget={budget(720)} todayExpense={1680} />);
+    expect(screen.getByText("順調")).toBeInTheDocument();
+  });
+
+  it("消化率 81〜100% のとき「注意」バッジ", () => {
+    render(<DailyBudgetHero {...baseProps} dailyBudget={budget(240)} todayExpense={2160} />);
+    expect(screen.getByText("注意")).toBeInTheDocument();
+  });
+
+  it("消化率 > 100% のとき「超過」バッジ（バーは100%でキャップ）", () => {
+    render(<DailyBudgetHero {...baseProps} dailyBudget={budget(-600)} todayExpense={3000} />);
+    expect(screen.getByText("超過")).toBeInTheDocument();
+    expect(screen.getByRole("img", { name: "日予算の消化率 125%" })).toBeInTheDocument();
+  });
+
+  it("今日の支出 / 日予算 が表示される", () => {
+    render(<DailyBudgetHero {...baseProps} dailyBudget={budget(1400)} todayExpense={1000} />);
+    expect(screen.getByText("¥1,000 / ¥2,400")).toBeInTheDocument();
+  });
+});
+
+describe("DailyBudgetHero — 貯蓄インサイト（#459）", () => {
+  it("達成率 ≥ 150% のとき、+X% 達成見込みメッセージ", () => {
+    // projected = 120000（today 0 扱いにするため todayExpense を月支出に含めない値で）
+    render(
+      <DailyBudgetHero
+        {...baseProps}
+        dailyBudget={budget(2400)}
+        todayExpense={0}
+        monthSummary={{ expense: 120_000, income: 300_000 }}
+      />,
+    );
+    // projectedSavings = 180000 / 30000 = 600% → +500%
+    expect(screen.getByText("今日この調子なら目標 +500% 達成見込み！")).toBeInTheDocument();
+  });
+
+  it("赤字見込みのとき、赤字メッセージ", () => {
+    render(
+      <DailyBudgetHero
+        {...baseProps}
+        dailyBudget={budget(-600)}
+        todayExpense={0}
+        monthSummary={{ expense: 350_000, income: 300_000 }}
+      />,
+    );
+    expect(screen.getByText("このペースだと今月赤字になりそう")).toBeInTheDocument();
+  });
+
+  it("目標未設定（0）のとき、消化率ベースの文言に縮退する", () => {
+    render(
+      <DailyBudgetHero
+        {...baseProps}
+        savingsGoal={0}
+        dailyBudget={budget(1400)}
+        todayExpense={1000}
+      />,
+    );
+    expect(screen.getByText("今日は予算内に収まっています")).toBeInTheDocument();
+  });
+
+  it("目標未設定かつ超過のとき、超過文言に縮退する", () => {
+    render(
+      <DailyBudgetHero
+        {...baseProps}
+        savingsGoal={0}
+        dailyBudget={budget(-600)}
+        todayExpense={3000}
+      />,
+    );
+    expect(screen.getByText("今日は日予算を超えています")).toBeInTheDocument();
+  });
+});
+
+describe("DailyBudgetHero — 設定未完了", () => {
+  it("dailyBudget が null のとき、設定への案内を表示する", () => {
+    render(<DailyBudgetHero {...baseProps} dailyBudget={null} todayExpense={0} />);
+    expect(screen.getByText("設定を完了すると1日予算が表示されます")).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/DailyBudgetHero.stories.tsx
+++ b/apps/web/src/components/dashboard/DailyBudgetHero.stories.tsx
@@ -3,41 +3,66 @@ import { DailyBudgetHero } from './DailyBudgetHero'
 import { fixtureDailyBudget } from '@/__fixtures__/dashboard'
 
 /**
- * ホーム最上部の「今日使えるお金」ヒーロー。
- * 残額比率に応じて safe（余裕）/ caution（注意）/ danger（ピンチ）の
- * 3トーンでカラーとバッジが切り替わる。
+ * ホーム最上部の「今日使えるお金」ヒーロー（#459 で「今日の状況」相当へ強化）。
+ * - カード背景: 残額比率による3トーン（safe/caution/danger）
+ * - バッジ・進捗バー: 日予算消化率による4状態（好調 ≤50% / 順調 ≤80% / 注意 ≤100% / 超過）
+ * - 貯蓄インサイト: 月末予測（calcSavingsForecast）による1行メッセージ
+ * 基準日を固定（2026-07-15）して表示を決定論化している。
  */
 const meta: Meta<typeof DailyBudgetHero> = {
   title: 'Dashboard/DailyBudgetHero',
   component: DailyBudgetHero,
   parameters: { layout: 'padded' },
   tags: ['autodocs'],
+  args: {
+    monthSummary: { expense: 120_000, income: 300_000 },
+    savingsGoal: 30_000,
+    today: new Date('2026-07-15T00:00:00'),
+  },
 }
 
 export default meta
 type Story = StoryObj<typeof DailyBudgetHero>
 
-/** 残額 80% 以上: 「余裕」バッジ（グリーン系トーン） */
-export const Safe: Story = {
+/** 好調（消化率 ≤ 50%・緑）+ 目標大幅達成見込みのインサイト */
+export const Great: Story = {
   args: {
     dailyBudget: fixtureDailyBudget('safe'),
     todayExpense: 360,
   },
 }
 
-/** 残額 20〜80%: 「注意」バッジ（アンバー系トーン） */
-export const Caution: Story = {
+/** 順調（消化率 51〜80%・緑） */
+export const Steady: Story = {
   args: {
     dailyBudget: fixtureDailyBudget('caution'),
-    todayExpense: 1320,
+    todayExpense: 1_680,
   },
 }
 
-/** 残額 20% 未満: 「ピンチ」バッジ（レッド系トーン） */
-export const Danger: Story = {
+/** 注意（消化率 81〜100%・ピンク） */
+export const Caution: Story = {
+  args: {
+    dailyBudget: fixtureDailyBudget('caution'),
+    todayExpense: 2_160,
+  },
+}
+
+/** 超過（消化率 > 100%・赤）+ 赤字見込みインサイト */
+export const Over: Story = {
   args: {
     dailyBudget: fixtureDailyBudget('danger'),
-    todayExpense: 2160,
+    todayExpense: 3_000,
+    monthSummary: { expense: 290_000, income: 300_000 },
+  },
+}
+
+/** 貯蓄目標未設定: インサイトが消化率ベースの文言に縮退する */
+export const NoGoal: Story = {
+  args: {
+    dailyBudget: fixtureDailyBudget('safe'),
+    todayExpense: 360,
+    savingsGoal: 0,
   },
 }
 

--- a/apps/web/src/components/dashboard/DailyBudgetHero.tsx
+++ b/apps/web/src/components/dashboard/DailyBudgetHero.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Wallet } from "lucide-react";
+import {
+  Wallet, Sparkles, TrendingUp, AlertTriangle, AlertCircle,
+  type LucideIcon,
+} from "lucide-react";
+import { calcSavingsForecast } from "@budget/common";
 import { SPRING } from "@/lib/motion";
 
 type Tone = "safe" | "caution" | "danger";
@@ -12,11 +16,125 @@ function budgetTone(ratio: number): Tone {
   return "danger";
 }
 
-const TONE_LABELS: Record<Tone, string> = {
-  safe: "余裕",
-  caution: "注意",
-  danger: "ピンチ",
+/** 日予算消化率による4状態バッジ（TodayStatusPalettePrototype 準拠 / #459） */
+type SpendStatus = "great" | "steady" | "caution" | "over";
+
+const SPEND_STATUS = {
+  /** 好調: 消化率 ≤ 50% */
+  great: 0.5,
+  /** 順調: 消化率 ≤ 80% */
+  steady: 0.8,
+  /** 注意: 消化率 ≤ 100%（超えると超過） */
+  caution: 1.0,
+} as const;
+
+function spendStatusOf(spendPct: number): SpendStatus {
+  if (spendPct <= SPEND_STATUS.great) return "great";
+  if (spendPct <= SPEND_STATUS.steady) return "steady";
+  if (spendPct <= SPEND_STATUS.caution) return "caution";
+  return "over";
+}
+
+/** バッジ・進捗バーのカラー（great/steady=緑・caution=ピンク・over=赤。forecast トークンを共用） */
+const SPEND_STATUS_UI: Record<
+  SpendStatus,
+  { label: string; color: string; badgeBg: string; bar: string }
+> = {
+  great: {
+    label: "好調",
+    color: "var(--color-forecast-safe)",
+    badgeBg: "var(--color-forecast-safe-badge-bg)",
+    bar: "var(--color-forecast-safe-bar)",
+  },
+  steady: {
+    label: "順調",
+    color: "var(--color-forecast-safe)",
+    badgeBg: "var(--color-forecast-safe-badge-bg)",
+    bar: "var(--color-forecast-safe-bar)",
+  },
+  caution: {
+    label: "注意",
+    color: "var(--color-forecast-caution)",
+    badgeBg: "var(--color-forecast-caution-badge-bg)",
+    bar: "var(--color-forecast-caution-bar)",
+  },
+  over: {
+    label: "超過",
+    color: "var(--color-forecast-danger)",
+    badgeBg: "var(--color-forecast-danger-badge-bg)",
+    bar: "var(--color-forecast-danger-bar)",
+  },
 };
+
+type Insight = { Icon: LucideIcon; color: string; bg: string; message: string };
+
+/**
+ * 貯蓄インサイト1行メッセージ（サンドボックス savingsInsight 準拠）。
+ * 目標未設定時は消化率ベースの文言に縮退する。
+ */
+function buildInsight(params: {
+  spendStatus: SpendStatus;
+  savingsGoal: number;
+  achievementRate: number | null;
+  projectedSavings: number;
+}): Insight {
+  const { spendStatus, savingsGoal, achievementRate, projectedSavings } = params;
+
+  if (savingsGoal <= 0) {
+    return spendStatus === "over"
+      ? {
+          Icon: AlertCircle,
+          color: "var(--color-forecast-danger)",
+          bg: "var(--color-forecast-danger-badge-bg)",
+          message: "今日は日予算を超えています",
+        }
+      : {
+          Icon: TrendingUp,
+          color: "var(--color-forecast-safe)",
+          bg: "var(--color-forecast-safe-badge-bg)",
+          message: "今日は予算内に収まっています",
+        };
+  }
+
+  if (achievementRate !== null && achievementRate >= 1.5) {
+    return {
+      Icon: Sparkles,
+      color: "var(--color-brand-primary)",
+      bg: "var(--color-brand-light)",
+      message: `今日この調子なら目標 +${Math.round((achievementRate - 1) * 100)}% 達成見込み！`,
+    };
+  }
+  if (achievementRate !== null && achievementRate >= 1.0) {
+    return {
+      Icon: TrendingUp,
+      color: "var(--color-forecast-safe)",
+      bg: "var(--color-forecast-safe-badge-bg)",
+      message: "このペースなら今月の貯蓄目標達成見込み",
+    };
+  }
+  if (achievementRate !== null && achievementRate >= 0.5) {
+    return {
+      Icon: AlertTriangle,
+      color: "var(--color-forecast-caution)",
+      bg: "var(--color-forecast-caution-badge-bg)",
+      message: "あと少し節約すると目標達成できそう",
+    };
+  }
+  if (projectedSavings < 0) {
+    return {
+      Icon: AlertCircle,
+      color: "var(--color-forecast-danger)",
+      bg: "var(--color-forecast-danger-badge-bg)",
+      message: "このペースだと今月赤字になりそう",
+    };
+  }
+  return {
+    Icon: AlertCircle,
+    color: "var(--color-brand-primary)",
+    bg: "var(--color-brand-light)",
+    message: "支出を抑えると目標に近づきます",
+  };
+}
 
 type Props = {
   dailyBudget: {
@@ -26,9 +144,21 @@ type Props = {
     daysUntilPayday: number;
   } | null;
   todayExpense: number;
+  /** 今月の収支（貯蓄インサイトの月末予測に使用） */
+  monthSummary: { expense: number; income: number };
+  /** 月間貯蓄目標（円）。未設定は 0（インサイトが消化率ベースに縮退） */
+  savingsGoal: number;
+  /** 基準日。Storybook / VRT / テストで決定論的にレンダリングするための注入口（既定: 現在日時） */
+  today?: Date;
 };
 
-export function DailyBudgetHero({ dailyBudget, todayExpense }: Props) {
+export function DailyBudgetHero({
+  dailyBudget,
+  todayExpense,
+  monthSummary,
+  savingsGoal,
+  today,
+}: Props) {
   if (!dailyBudget) {
     return (
       <div
@@ -42,6 +172,28 @@ export function DailyBudgetHero({ dailyBudget, todayExpense }: Props) {
   }
 
   const tone = budgetTone(dailyBudget.ratio);
+
+  // 日予算消化率 → 4状態バッジ + 進捗バー（#459）
+  const spendPct = dailyBudget.amount > 0 ? todayExpense / dailyBudget.amount : 0;
+  const spendStatus = spendStatusOf(spendPct);
+  const statusUi = SPEND_STATUS_UI[spendStatus];
+
+  // 貯蓄インサイト（月末予測は #458 と同じ共有ロジック）
+  const now = today ?? new Date();
+  const forecast = calcSavingsForecast({
+    monthIncome: monthSummary.income,
+    monthExpense: monthSummary.expense,
+    todayExpense,
+    savingsGoal,
+    dayOfMonth: now.getDate(),
+    daysInMonth: new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate(),
+  });
+  const insight = buildInsight({
+    spendStatus,
+    savingsGoal,
+    achievementRate: forecast.achievementRate,
+    projectedSavings: forecast.projectedSavings,
+  });
 
   return (
     <motion.div
@@ -60,13 +212,10 @@ export function DailyBudgetHero({ dailyBudget, todayExpense }: Props) {
           今日使えるお金
         </span>
         <span
-          className="rounded-full px-2 py-0.5 text-[10px] font-bold"
-          style={{
-            background: `var(--color-status-${tone}-badge)`,
-            color: "#fff",
-          }}
+          className="rounded-full px-2.5 py-0.5 text-[10px] font-bold"
+          style={{ background: statusUi.badgeBg, color: statusUi.color }}
         >
-          {TONE_LABELS[tone]}
+          {statusUi.label}
         </span>
       </div>
 
@@ -77,10 +226,43 @@ export function DailyBudgetHero({ dailyBudget, todayExpense }: Props) {
         &yen;{dailyBudget.remaining.toLocaleString()}
       </div>
 
-      <div className="mt-3 flex items-center gap-4 text-xs" style={{ color: "var(--foreground)", opacity: 0.55 }}>
-        <span>1日予算 &yen;{dailyBudget.amount.toLocaleString()}</span>
-        <span>|</span>
-        <span>今日の支出 &yen;{todayExpense.toLocaleString()}</span>
+      {/* 今日の支出 / 日予算 の進捗バー（#459） */}
+      <div
+        className="mt-3 mb-1.5 flex justify-between text-[11px]"
+        style={{ color: "var(--foreground)", opacity: 0.55 }}
+      >
+        <span>今日の支出</span>
+        <span className="font-semibold tabular-nums">
+          &yen;{todayExpense.toLocaleString()} / &yen;{dailyBudget.amount.toLocaleString()}
+        </span>
+      </div>
+      <div
+        className="h-2 overflow-hidden rounded-full"
+        style={{ background: "rgba(28,20,16,0.06)" }}
+        role="img"
+        aria-label={`日予算の消化率 ${Math.round(spendPct * 100)}%`}
+      >
+        <motion.div
+          className="h-full rounded-full"
+          initial={{ width: 0 }}
+          animate={{ width: `${Math.min(100, Math.round(spendPct * 100))}%` }}
+          transition={{ ...SPRING.smooth, delay: 0.3 }}
+          style={{ background: statusUi.bar }}
+        />
+      </div>
+
+      {/* 貯蓄インサイト（#459） */}
+      <div
+        className="mt-3 flex items-center gap-2 rounded-xl px-3 py-2.5"
+        style={{ background: insight.bg }}
+      >
+        <insight.Icon size={13} style={{ color: insight.color, flexShrink: 0 }} aria-hidden />
+        <span
+          className="text-[11px] font-semibold leading-tight"
+          style={{ color: insight.color }}
+        >
+          {insight.message}
+        </span>
       </div>
 
       <div className="mt-2 text-[11px] font-medium" style={{ color: "var(--foreground)", opacity: 0.4 }}>

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -74,6 +74,8 @@ export function HomeClient({
           <DailyBudgetHero
             dailyBudget={dashboard.dailyBudget}
             todayExpense={dashboard.todayExpense}
+            monthSummary={dashboard.monthSummary}
+            savingsGoal={dashboard.savingsGoal}
           />
         </motion.div>
 


### PR DESCRIPTION
## 概要

現行の DailyBudgetHero は残額のテキスト表示と3段階バッジのみで、「今日のペースは良いのか悪いのか」の評価がなかった（#459）。サンドボックス `HomePrototype.tsx` Block 1 / `TodayStatusPalettePrototype.tsx` に準拠し、一瞥で今日の家計ステータスと次のアクションが分かるよう強化する。

## 変更内容

- **進捗バー**: 今日の支出 / 日予算 の消化率バー（消化率で色が変わる: 緑→ピンク→赤）
- **4状態ステータスバッジ**: 好調（≤50%）/ 順調（≤80%）/ 注意（≤100%）/ 超過（>100%）。従来の「余裕/注意/ピンチ」バッジを置換。閾値は SPEND_STATUS として定数化
- **貯蓄インサイト1行**: #458 の `calcSavingsForecast` を共用し、達成率に応じた5種のメッセージ（例:「このペースなら今月の貯蓄目標達成見込み」「このペースだと今月赤字になりそう」）。目標未設定時は消化率ベースの文言に縮退
- **カラー整合**: カード背景の3トーン（`--color-status-*`・残額比率基準）は既存のまま維持。バッジ・バー・インサイトは #458 で定義した `--color-forecast-*` セマンティックトークンを共用（TodayStatusPalettePrototype と同一の hex 値）
- **決定論化**: `today` prop による基準日注入（#484 と同パターン）。Storybook 6本・テスト10件を追加

## 影響範囲

- ホームのヒーローカードのみ。HomeClient から monthSummary / savingsGoal を渡す配線を追加
- 設定未完了時（dailyBudget null）の案内表示は不変

## Test plan

- [x] テスト10件（4状態バッジ境界・バー表示・キャップ・インサイト4種・縮退2種・設定未完了）→ web 全129件パス
- [x] lint / type-check / next build / build-storybook パス
- [x] Storybook 6ストーリーをヘッドレスブラウザで実レンダリング確認・スクリーンショット撮影

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界を跨ぐ不正な依存はないか（予測計算は @budget/common を共用）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（消化率閾値は SPEND_STATUS 定数・カラーはセマンティックトークン）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（After 5状態を Storybook 390px で撮影しユーザーへチャット送付済み。CLI から PR への画像添付は GitHub API 非対応。Before = 残額テキスト+3段階バッジのみのヒーロー）
- [x] ドキュメントを追加・移動・削除した場合、SSOT マップを更新したか（該当なし）

## スクリーンショット

After（Storybook 390px・チャットへ送付済み）: 好調 / 順調 / 注意 / 超過 / 目標未設定 の5状態

Closes #459
Sprint: 31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q