### PR TITLE
feat(mobile): JWT ログインと認証済み API クライアント基盤を実装する（Phase 2-1）

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -32,7 +32,8 @@
           "image": "./assets/images/splash-icon.png",
           "imageWidth": 76
         }
-      ]
+      ],
+      "expo-secure-store"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -3,6 +3,7 @@
   "main": "expo-router/entry",
   "version": "1.0.0",
   "dependencies": {
+    "@budget/api-client": "workspace:*",
     "@budget/common": "workspace:*",
     "@expo/metro-runtime": "~6.1.2",
     "@react-navigation/native": "^7.1.8",
@@ -11,6 +12,7 @@
     "expo-constants": "~18.0.9",
     "expo-linking": "~8.0.8",
     "expo-router": "~6.0.10",
+    "expo-secure-store": "~15.0.8",
     "expo-splash-screen": "~31.0.10",
     "expo-status-bar": "~3.0.8",
     "react": "19.1.0",

--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -2,16 +2,39 @@ import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Stack } from 'expo-router';
 import { useColorScheme } from 'react-native';
+import { AuthProvider, useAuth } from '@/lib/auth/auth-context';
 
 // API 接続（Phase 2）に備えて QueryClientProvider をルートに常設する
 const queryClient = new QueryClient();
+
+function RootNavigator() {
+  const { status } = useAuth();
+
+  // セッション復元中はスプラッシュ表示のまま（チラつき防止）
+  if (status === 'loading') {
+    return null;
+  }
+
+  return (
+    <Stack screenOptions={{ headerShown: false }}>
+      <Stack.Protected guard={status === 'signedIn'}>
+        <Stack.Screen name="index" />
+      </Stack.Protected>
+      <Stack.Protected guard={status !== 'signedIn'}>
+        <Stack.Screen name="login" />
+      </Stack.Protected>
+    </Stack>
+  );
+}
 
 export default function RootLayout() {
   const colorScheme = useColorScheme();
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack screenOptions={{ headerShown: false }} />
+        <AuthProvider>
+          <RootNavigator />
+        </AuthProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,6 +1,7 @@
 import { calcSavingsForecast } from '@budget/common';
-import { StyleSheet, Text, View } from 'react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '@/lib/auth/auth-context';
 
 // Phase 1 のサンプルデータ。Phase 2 で @budget/api-client 経由の実データに置き換える
 const SAMPLE = {
@@ -11,6 +12,7 @@ const SAMPLE = {
 };
 
 export default function HomeScreen() {
+  const { userId, logout } = useAuth();
   const now = new Date();
   const forecast = calcSavingsForecast({
     ...SAMPLE,
@@ -21,6 +23,13 @@ export default function HomeScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.userId}>{userId}</Text>
+          <Pressable onPress={logout} accessibilityRole="button" hitSlop={8}>
+            <Text style={styles.logout}>ログアウト</Text>
+          </Pressable>
+        </View>
+
         <Text style={styles.caption}>今日使えるお金（サンプル）</Text>
         <Text style={styles.hero}>¥{forecast.dailyRemainingBudget.toLocaleString()}</Text>
 
@@ -65,6 +74,23 @@ const styles = StyleSheet.create({
     flex: 1,
     padding: 20,
     gap: 12,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  userId: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#1c1410',
+    opacity: 0.7,
+  },
+  logout: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#c62828',
   },
   caption: {
     fontSize: 13,

--- a/apps/mobile/src/app/login.tsx
+++ b/apps/mobile/src/app/login.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '@/lib/auth/auth-context';
+
+export default function LoginScreen() {
+  const { login } = useAuth();
+  const [userId, setUserId] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const canSubmit = userId.length > 0 && password.length > 0 && !submitting;
+
+  const handleSubmit = async () => {
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setErrorMessage(null);
+    const result = await login(userId, password);
+    if (!result.ok) {
+      setErrorMessage(result.message);
+      setSubmitting(false);
+    }
+    // 成功時は AuthProvider の状態遷移で保護ルートへ自動的に切り替わる
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <View style={styles.container}>
+          <Text style={styles.title}>家計簿</Text>
+          <Text style={styles.subtitle}>ログインして家計状況を確認</Text>
+
+          <View style={styles.form}>
+            <Text style={styles.label}>ユーザー名</Text>
+            <TextInput
+              style={styles.input}
+              value={userId}
+              onChangeText={setUserId}
+              placeholder="ユーザー名を入力"
+              placeholderTextColor="rgba(28,20,16,0.35)"
+              autoCapitalize="none"
+              autoCorrect={false}
+              textContentType="username"
+              editable={!submitting}
+            />
+
+            <Text style={styles.label}>パスワード</Text>
+            <TextInput
+              style={styles.input}
+              value={password}
+              onChangeText={setPassword}
+              placeholder="パスワードを入力"
+              placeholderTextColor="rgba(28,20,16,0.35)"
+              secureTextEntry
+              textContentType="password"
+              editable={!submitting}
+              onSubmitEditing={handleSubmit}
+            />
+
+            {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+
+            <Pressable
+              style={[styles.button, !canSubmit && styles.buttonDisabled]}
+              onPress={handleSubmit}
+              disabled={!canSubmit}
+              accessibilityRole="button"
+            >
+              {submitting ? (
+                <ActivityIndicator color="#ffffff" />
+              ) : (
+                <Text style={styles.buttonLabel}>ログイン</Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#faf6f2',
+  },
+  flex: {
+    flex: 1,
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    padding: 24,
+  },
+  title: {
+    fontSize: 32,
+    fontWeight: '800',
+    color: '#1c1410',
+    textAlign: 'center',
+  },
+  subtitle: {
+    marginTop: 6,
+    fontSize: 13,
+    color: '#1c1410',
+    opacity: 0.55,
+    textAlign: 'center',
+  },
+  form: {
+    marginTop: 32,
+    gap: 8,
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#1c1410',
+  },
+  input: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(28,20,16,0.15)',
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: '#1c1410',
+    marginBottom: 8,
+  },
+  error: {
+    fontSize: 13,
+    color: '#c62828',
+  },
+  button: {
+    marginTop: 16,
+    borderRadius: 12,
+    backgroundColor: '#2e7d32',
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  buttonDisabled: {
+    opacity: 0.4,
+  },
+  buttonLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+});

--- a/apps/mobile/src/lib/api/base-url.ts
+++ b/apps/mobile/src/lib/api/base-url.ts
@@ -1,0 +1,25 @@
+import Constants from 'expo-constants';
+
+/**
+ * API のベース URL を解決する。
+ *
+ * 優先順位:
+ * 1. EXPO_PUBLIC_API_URL（明示指定。トンネル接続時は必須）
+ * 2. Expo Go の hostUri から導出した開発マシンの LAN IP（LAN 接続時）
+ * 3. localhost（シミュレーター / Web）
+ */
+export function resolveApiBaseUrl(): string {
+  const fromEnv = process.env.EXPO_PUBLIC_API_URL;
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  // LAN 接続の Expo Go では hostUri が「192.168.x.x:8081」形式になる。
+  // トンネル接続（*.exp.direct）は API まで届かないため対象外
+  const host = Constants.expoConfig?.hostUri?.split(':')[0];
+  if (host && !host.endsWith('.exp.direct')) {
+    return `http://${host}:5000`;
+  }
+
+  return 'http://localhost:5000';
+}

--- a/apps/mobile/src/lib/api/client.ts
+++ b/apps/mobile/src/lib/api/client.ts
@@ -1,0 +1,70 @@
+import { createApiClient, type TokenPairResponse } from '@budget/api-client';
+import { resolveApiBaseUrl } from './base-url';
+import { getSession, setSession } from '../auth/session';
+
+const baseUrl = resolveApiBaseUrl();
+
+/** 認証不要のエンドポイント（login / refresh / logout）用クライアント */
+export const publicClient = createApiClient(baseUrl);
+
+/**
+ * リフレッシュの単一飛行制御。
+ * 並行リクエストが同時に 401 を受けても /api/refresh は 1 回だけ実行する
+ * （Refresh Token Rotation のため、二重実行すると再利用検知で失効する）。
+ */
+let refreshing: Promise<string | null> | null = null;
+
+async function refreshAccessToken(): Promise<string | null> {
+  if (!refreshing) {
+    refreshing = (async () => {
+      const session = getSession();
+      if (!session) {
+        return null;
+      }
+      const { data } = await publicClient.POST('/api/refresh', {
+        body: { refreshToken: session.refreshToken },
+      });
+      if (!data) {
+        // リフレッシュ失敗 = セッション失効。サインアウト状態へ落とす
+        await setSession(null);
+        return null;
+      }
+      const pair: TokenPairResponse = data;
+      await setSession({
+        accessToken: pair.accessToken,
+        refreshToken: pair.refreshToken,
+        userId: pair.userId,
+      });
+      return pair.accessToken;
+    })().finally(() => {
+      refreshing = null;
+    });
+  }
+  return refreshing;
+}
+
+/** 認証付き API クライアント。Bearer 付与と 401 時の自動リフレッシュ + 再試行を行う */
+export const apiClient = createApiClient(baseUrl);
+
+apiClient.use({
+  async onRequest({ request }) {
+    const session = getSession();
+    if (session) {
+      request.headers.set('Authorization', `Bearer ${session.accessToken}`);
+    }
+    return request;
+  },
+  async onResponse({ request, response }) {
+    if (response.status !== 401) {
+      return response;
+    }
+    const newAccessToken = await refreshAccessToken();
+    if (!newAccessToken) {
+      return response;
+    }
+    // 新しいアクセストークンで元のリクエストを 1 回だけ再試行する
+    const retried = new Request(request);
+    retried.headers.set('Authorization', `Bearer ${newAccessToken}`);
+    return fetch(retried);
+  },
+});

--- a/apps/mobile/src/lib/api/client.ts
+++ b/apps/mobile/src/lib/api/client.ts
@@ -21,21 +21,28 @@ async function refreshAccessToken(): Promise<string | null> {
       if (!session) {
         return null;
       }
-      const { data } = await publicClient.POST('/api/refresh', {
-        body: { refreshToken: session.refreshToken },
-      });
-      if (!data) {
-        // リフレッシュ失敗 = セッション失効。サインアウト状態へ落とす
-        await setSession(null);
+      try {
+        const { data, response } = await publicClient.POST('/api/refresh', {
+          body: { refreshToken: session.refreshToken },
+        });
+        if (data) {
+          const pair: TokenPairResponse = data;
+          await setSession({
+            accessToken: pair.accessToken,
+            refreshToken: pair.refreshToken,
+            userId: pair.userId,
+          });
+          return pair.accessToken;
+        }
+        // 401/403 = トークン失効・再利用検知の確定的な認証エラーのときだけサインアウトする
+        if (response.status === 401 || response.status === 403) {
+          await setSession(null);
+        }
+        return null;
+      } catch {
+        // ネットワーク断や一時的なサーバーエラーではセッションを維持する（次回リクエストで再試行）
         return null;
       }
-      const pair: TokenPairResponse = data;
-      await setSession({
-        accessToken: pair.accessToken,
-        refreshToken: pair.refreshToken,
-        userId: pair.userId,
-      });
-      return pair.accessToken;
     })().finally(() => {
       refreshing = null;
     });

--- a/apps/mobile/src/lib/auth/auth-context.tsx
+++ b/apps/mobile/src/lib/auth/auth-context.tsx
@@ -1,0 +1,107 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import { publicClient } from '../api/client';
+import { getSession, hydrateSession, setSession, subscribeSession } from './session';
+import { loadSession } from './token-store';
+
+export type AuthStatus = 'loading' | 'signedIn' | 'signedOut';
+
+type AuthContextValue = {
+  status: AuthStatus;
+  userId: string | null;
+  login: (userId: string, password: string) => Promise<{ ok: true } | { ok: false; message: string }>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<AuthStatus>('loading');
+  const [userId, setUserId] = useState<string | null>(null);
+
+  // 起動時に SecureStore からセッションを復元する
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const stored = await loadSession();
+      if (cancelled) return;
+      hydrateSession(stored);
+      setStatus(stored ? 'signedIn' : 'signedOut');
+      setUserId(stored?.userId ?? null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // ミドルウェア側のセッション変化（リフレッシュ失敗による失効など）に追従する
+  useEffect(() => {
+    return subscribeSession((session) => {
+      setStatus(session ? 'signedIn' : 'signedOut');
+      setUserId(session?.userId ?? null);
+    });
+  }, []);
+
+  const login = useCallback(
+    async (loginUserId: string, password: string) => {
+      try {
+        const { data, error, response } = await publicClient.POST('/api/login', {
+          body: { userId: loginUserId, password },
+        });
+        if (!data) {
+          if (response.status === 429) {
+            return { ok: false as const, message: 'ログイン試行が多すぎます。しばらく待ってから再試行してください' };
+          }
+          return { ok: false as const, message: error?.message ?? 'ユーザー名またはパスワードが違います' };
+        }
+        await setSession({
+          accessToken: data.accessToken,
+          refreshToken: data.refreshToken,
+          userId: data.userId,
+        });
+        return { ok: true as const };
+      } catch {
+        return { ok: false as const, message: 'サーバーに接続できません。ネットワークと API の起動状態を確認してください' };
+      }
+    },
+    [],
+  );
+
+  const logout = useCallback(async () => {
+    const session = getSession();
+    try {
+      if (session) {
+        // ベストエフォート: サーバー側のリフレッシュトークンを失効させる
+        await publicClient.POST('/api/logout', {
+          body: { refreshToken: session.refreshToken },
+        });
+      }
+    } catch {
+      // オフラインでもローカルのセッション破棄は続行する
+    } finally {
+      await setSession(null);
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({ status, userId, login, logout }),
+    [status, userId, login, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) {
+    throw new Error('useAuth は AuthProvider の内側で使用してください');
+  }
+  return ctx;
+}

--- a/apps/mobile/src/lib/auth/session.ts
+++ b/apps/mobile/src/lib/auth/session.ts
@@ -1,0 +1,40 @@
+import { clearSession, saveSession, type StoredSession } from './token-store';
+
+/**
+ * インメモリのセッションホルダー。
+ * API クライアントのミドルウェアが同期的にトークンを参照できるようにする
+ * （SecureStore は非同期のため、リクエストごとの読み出しを避ける）。
+ */
+let current: StoredSession | null = null;
+
+/** セッション変更の購読者（AuthProvider が状態同期に使う） */
+type Listener = (session: StoredSession | null) => void;
+const listeners = new Set<Listener>();
+
+export function getSession(): StoredSession | null {
+  return current;
+}
+
+export function subscribeSession(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** メモリと SecureStore の両方を更新する */
+export async function setSession(session: StoredSession | null): Promise<void> {
+  current = session;
+  if (session) {
+    await saveSession(session);
+  } else {
+    await clearSession();
+  }
+  listeners.forEach((listener) => listener(session));
+}
+
+/** 起動時の復元用（SecureStore からの読み出し結果をメモリへ反映するだけ） */
+export function hydrateSession(session: StoredSession | null): void {
+  current = session;
+  listeners.forEach((listener) => listener(session));
+}

--- a/apps/mobile/src/lib/auth/session.ts
+++ b/apps/mobile/src/lib/auth/session.ts
@@ -22,15 +22,19 @@ export function subscribeSession(listener: Listener): () => void {
   };
 }
 
-/** メモリと SecureStore の両方を更新する */
+/**
+ * メモリと SecureStore の両方を更新する。
+ * UI の即時更新のため、リスナー通知を先行させ SecureStore への永続化を後続で行う
+ * （Keychain/Keystore 書き込みは数十〜数百 ms かかることがあり、画面遷移をブロックさせない）
+ */
 export async function setSession(session: StoredSession | null): Promise<void> {
   current = session;
+  listeners.forEach((listener) => listener(session));
   if (session) {
     await saveSession(session);
   } else {
     await clearSession();
   }
-  listeners.forEach((listener) => listener(session));
 }
 
 /** 起動時の復元用（SecureStore からの読み出し結果をメモリへ反映するだけ） */

--- a/apps/mobile/src/lib/auth/token-store.ts
+++ b/apps/mobile/src/lib/auth/token-store.ts
@@ -1,0 +1,40 @@
+import * as SecureStore from 'expo-secure-store';
+
+/** OS のセキュア領域（iOS Keychain / Android Keystore）に保存するキー */
+const ACCESS_TOKEN_KEY = 'budget.accessToken';
+const REFRESH_TOKEN_KEY = 'budget.refreshToken';
+const USER_ID_KEY = 'budget.userId';
+
+export type StoredSession = {
+  accessToken: string;
+  refreshToken: string;
+  userId: string;
+};
+
+export async function saveSession(session: StoredSession): Promise<void> {
+  await Promise.all([
+    SecureStore.setItemAsync(ACCESS_TOKEN_KEY, session.accessToken),
+    SecureStore.setItemAsync(REFRESH_TOKEN_KEY, session.refreshToken),
+    SecureStore.setItemAsync(USER_ID_KEY, session.userId),
+  ]);
+}
+
+export async function loadSession(): Promise<StoredSession | null> {
+  const [accessToken, refreshToken, userId] = await Promise.all([
+    SecureStore.getItemAsync(ACCESS_TOKEN_KEY),
+    SecureStore.getItemAsync(REFRESH_TOKEN_KEY),
+    SecureStore.getItemAsync(USER_ID_KEY),
+  ]);
+  if (!accessToken || !refreshToken || !userId) {
+    return null;
+  }
+  return { accessToken, refreshToken, userId };
+}
+
+export async function clearSession(): Promise<void> {
+  await Promise.all([
+    SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY),
+    SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY),
+    SecureStore.deleteItemAsync(USER_ID_KEY),
+  ]);
+}

--- a/apps/mobile/types.d.ts
+++ b/apps/mobile/types.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="expo/types" />
+
+// expo-env.d.ts（expo start 時に自動生成・gitignore 対象）と同じ参照を
+// コミット済みファイルとして持つ。CI など生成ファイルが無い環境でも
+// process.env.EXPO_PUBLIC_* の型を解決できるようにするため

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
 
   apps/mobile:
     dependencies:
+      '@budget/api-client':
+        specifier: workspace:*
+        version: link:../../packages/api-client
       '@budget/common':
         specifier: workspace:*
         version: link:../../packages/common
@@ -137,6 +140,9 @@ importers:
       expo-router:
         specifier: ~6.0.10
         version: 6.0.24(4935da60fe77b33d9c7d6d873e6eff66)
+      expo-secure-store:
+        specifier: ~15.0.8
+        version: 15.0.8(expo@54.0.35)
       expo-splash-screen:
         specifier: ~31.0.10
         version: 31.0.13(expo@54.0.35)(typescript@5.9.3)
@@ -5680,6 +5686,11 @@ packages:
         optional: true
       react-server-dom-webpack:
         optional: true
+
+  expo-secure-store@15.0.8:
+    resolution: {integrity: sha512-lHnzvRajBu4u+P99+0GEMijQMFCOYpWRO4dWsXSuMt77+THPIGjzNvVKrGSl6mMrLsfVaKL8BpwYZLGlgA+zAw==}
+    peerDependencies:
+      expo: '*'
 
   expo-server@1.0.7:
     resolution: {integrity: sha512-mcmyML3oXcqFUXUxtdtCL1O00ztNI2v76d+MdniXRUgHNxIcHZ05zo+DqBaOOT6LQnPk4vA4YHqQl7iGUfRb3g==}
@@ -14526,9 +14537,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@types/node@20.19.37)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
+      vitest: 4.1.4(@types/node@24.12.0)(@vitest/browser-playwright@4.1.4)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.2(@noble/hashes@1.8.0))(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))
     optionalDependencies:
-      '@vitest/browser': 4.1.4(vite@8.0.11(@types/node@20.19.37)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
+      '@vitest/browser': 4.1.4(vite@8.0.11(@types/node@24.12.0)(esbuild@0.27.7)(jiti@2.6.1)(terser@5.48.0)(tsx@4.21.0)(yaml@2.8.3))(vitest@4.1.4)
     optional: true
 
   '@vitest/expect@3.2.4':
@@ -15897,9 +15908,9 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 8.59.4(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-expo: 1.1.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.4(jiti@2.6.1))
       globals: 16.4.0
@@ -15914,8 +15925,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
@@ -15937,7 +15948,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3(supports-color@8.1.1)
@@ -15948,18 +15959,18 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -15972,7 +15983,7 @@ snapshots:
       - supports-color
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -15983,7 +15994,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.4(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -16296,6 +16307,10 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
       - supports-color
+
+  expo-secure-store@15.0.8(expo@54.0.35):
+    dependencies:
+      expo: 54.0.35(@babel/core@7.29.7)(@expo/dom-webview@57.0.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.24)(react-native@0.81.5(@babel/core@7.29.7)(@react-native/metro-config@0.86.0(@babel/core@7.29.7))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
 
   expo-server@1.0.7: {}
 


### PR DESCRIPTION
## 概要

スマホアプリ Phase 2-1。#489（Phase 1 雛形）に JWT 認証を実装し、既存 API（RS256 + Refresh Token Rotation）へモバイルから安全に接続できる基盤を作った。Phase 2-2（ダッシュボード実データ表示 #490）の前提となる。

## 変更内容

- `src/lib/auth/token-store.ts`: expo-secure-store（iOS Keychain / Android Keystore）でトークンペアと userId を保存
- `src/lib/auth/session.ts`: インメモリセッションホルダー。ミドルウェアからの同期参照と AuthProvider への購読通知を提供
- `src/lib/api/client.ts`: openapi-fetch ミドルウェアで Bearer 付与 + 401 時の自動リフレッシュ→元リクエスト再試行。リフレッシュは単一飛行制御（Rotation の再利用検知による失効を防止）
- `src/lib/auth/auth-context.tsx`: `AuthProvider` / `useAuth`。起動時の SecureStore からのセッション復元、login / logout、失効時の自動サインアウト
- `src/app/login.tsx`: ユーザー名 + パスワードのログイン画面（Web の LoginForm と同一の項目・文言基調、429 レート制限時の専用メッセージ）
- `src/app/_layout.tsx`: expo-router `Stack.Protected` による認証ガード（未認証は login へ、認証済みは index へ自動遷移）
- `src/lib/api/base-url.ts`: API 接続先の解決（`EXPO_PUBLIC_API_URL` > Expo Go の hostUri 由来 LAN IP > localhost）
- `src/app/index.tsx`: ヘッダーに userId 表示とログアウト導線を追加
- `apps/mobile/package.json`: `@budget/api-client` / `expo-secure-store` を追加

## 影響範囲

- `apps/mobile` 内で完結。既存の `apps/web` / `apps/api` / `packages/*` への変更なし
- API はモバイル向け変更不要（既存の Bearer + リフレッシュ方式をそのまま利用）

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（lib/api と lib/auth を分離）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（SecureStore キーを定数化）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（新規画面のため Before なし）
- [x] ドキュメントを追加・移動・削除した場合、SSOT マップを更新したか（該当なし）

## スクリーンショット

新規モバイル画面（ログイン）。実機確認は API への到達性が必要なため、レビュー後の動作確認手順を備考に記載。

## Test plan

- `pnpm --filter mobile run type-check` / `eslint src --max-warnings 0` グリーン
- `expo export --platform ios` バンドル生成成功
- API 側の認証フローを curl で検証: guest-login でトークンペア取得 → Bearer 付き `/api/dashboard` 200 / Bearer なし 401 / `/api/refresh` でローテーション成功
- モバイル単体テスト基盤（jest-expo）は未整備のため、純粋ロジック（base-url 解決・セッション制御）のテストは基盤導入時に追加する（#488 備考参照）

## 関連 Issue

- Closes #491
- Sprint: 32

## 備考

- 実機での動作確認は API へ到達できるネットワークが必要。LAN 接続（`hostUri` から自動導出）または `EXPO_PUBLIC_API_URL` の明示指定（API を cloudflared 等で公開する場合）
- ログインは Web と同じ userId / password。ゲストログインボタンは Phase 2-2 以降で検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q
