### PR TITLE
feat(mobile): クイック記録（支出・収入の登録）を実装する（Phase 3）

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -19,6 +19,7 @@ function RootNavigator() {
     <Stack screenOptions={{ headerShown: false }}>
       <Stack.Protected guard={status === 'signedIn'}>
         <Stack.Screen name="index" />
+        <Stack.Screen name="entry" options={{ presentation: 'modal' }} />
       </Stack.Protected>
       <Stack.Protected guard={status !== 'signedIn'}>
         <Stack.Screen name="login" />

--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -1,0 +1,328 @@
+import { useState } from 'react';
+import { useRouter } from 'expo-router';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { useAuth } from '@/lib/auth/auth-context';
+import { useCategories } from '@/lib/api/use-categories';
+import { useCreateExpense } from '@/lib/api/use-create-expense';
+
+/** 収支区分（API スキーマ準拠: 0=支出, 1=収入） */
+const BALANCE_TYPE = { expense: 0, income: 1 } as const;
+
+function toDateString(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export default function EntryScreen() {
+  const router = useRouter();
+  const { userId } = useAuth();
+  const [balanceType, setBalanceType] = useState<0 | 1>(BALANCE_TYPE.expense);
+  const { data: categories, isPending: categoriesLoading } = useCategories(balanceType);
+  const createExpense = useCreateExpense();
+
+  const [amountText, setAmountText] = useState('');
+  const [categoryId, setCategoryId] = useState<number | null>(null);
+  const [dayOffset, setDayOffset] = useState<0 | 1>(0); // 0=今日, 1=昨日
+  const [content, setContent] = useState('');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const amount = Number(amountText);
+  const canSubmit =
+    Number.isInteger(amount) && amount > 0 && userId !== null && !createExpense.isPending;
+
+  const handleSelectBalanceType = (next: 0 | 1) => {
+    setBalanceType(next);
+    // 収支タイプが変わるとカテゴリ体系も変わるため選択をリセットする
+    setCategoryId(null);
+  };
+
+  const handleSubmit = async () => {
+    if (!canSubmit || userId === null) return;
+    setErrorMessage(null);
+    const date = new Date();
+    date.setDate(date.getDate() - dayOffset);
+    try {
+      await createExpense.mutateAsync({
+        amount,
+        balanceType,
+        userId,
+        date: toDateString(date),
+        ...(categoryId !== null ? { categoryId } : {}),
+        ...(content ? { content } : {}),
+      });
+      // 二重登録防止のため入力をリセットしてから戻る（Web #478 と同じ方針）
+      setAmountText('');
+      setContent('');
+      setCategoryId(null);
+      router.back();
+    } catch (e) {
+      setErrorMessage(e instanceof Error ? e.message : '記録の登録に失敗しました');
+    }
+  };
+
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+          <View style={styles.headerRow}>
+            <Text style={styles.title}>記録する</Text>
+            <Pressable onPress={() => router.back()} accessibilityRole="button" hitSlop={8}>
+              <Text style={styles.close}>閉じる</Text>
+            </Pressable>
+          </View>
+
+          {/* 支出 / 収入 切り替え */}
+          <View style={styles.segment}>
+            {(
+              [
+                { type: BALANCE_TYPE.expense, label: '支出' },
+                { type: BALANCE_TYPE.income, label: '収入' },
+              ] as const
+            ).map(({ type, label }) => (
+              <Pressable
+                key={type}
+                style={[styles.segmentItem, balanceType === type && styles.segmentItemActive]}
+                onPress={() => handleSelectBalanceType(type)}
+                accessibilityRole="button"
+              >
+                <Text
+                  style={[styles.segmentLabel, balanceType === type && styles.segmentLabelActive]}
+                >
+                  {label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+
+          {/* 金額 */}
+          <Text style={styles.label}>金額</Text>
+          <TextInput
+            style={styles.amountInput}
+            value={amountText}
+            onChangeText={(t) => setAmountText(t.replace(/[^0-9]/g, ''))}
+            placeholder="0"
+            placeholderTextColor="rgba(28,20,16,0.3)"
+            keyboardType="number-pad"
+            editable={!createExpense.isPending}
+          />
+
+          {/* カテゴリ */}
+          <Text style={styles.label}>カテゴリ</Text>
+          {categoriesLoading ? (
+            <ActivityIndicator color="#2e7d32" />
+          ) : (
+            <View style={styles.chips}>
+              {(categories ?? []).map((category) => {
+                const selected = categoryId === category.id;
+                return (
+                  <Pressable
+                    key={category.id}
+                    style={[
+                      styles.chip,
+                      { backgroundColor: category.bg },
+                      selected && { borderColor: category.color, borderWidth: 2 },
+                    ]}
+                    onPress={() => setCategoryId(selected ? null : category.id)}
+                    accessibilityRole="button"
+                  >
+                    <Text style={[styles.chipLabel, { color: category.color }]}>
+                      {category.name}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          )}
+
+          {/* 日付（今日 / 昨日） */}
+          <Text style={styles.label}>日付</Text>
+          <View style={styles.segment}>
+            {(
+              [
+                { offset: 0, label: '今日' },
+                { offset: 1, label: '昨日' },
+              ] as const
+            ).map(({ offset, label }) => (
+              <Pressable
+                key={offset}
+                style={[styles.segmentItem, dayOffset === offset && styles.segmentItemActive]}
+                onPress={() => setDayOffset(offset)}
+                accessibilityRole="button"
+              >
+                <Text
+                  style={[styles.segmentLabel, dayOffset === offset && styles.segmentLabelActive]}
+                >
+                  {label}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+
+          {/* メモ */}
+          <Text style={styles.label}>メモ（任意）</Text>
+          <TextInput
+            style={styles.input}
+            value={content}
+            onChangeText={setContent}
+            placeholder="昼食代など"
+            placeholderTextColor="rgba(28,20,16,0.3)"
+            editable={!createExpense.isPending}
+          />
+
+          {errorMessage && <Text style={styles.error}>{errorMessage}</Text>}
+
+          <Pressable
+            style={[styles.submit, !canSubmit && styles.submitDisabled]}
+            onPress={handleSubmit}
+            disabled={!canSubmit}
+            accessibilityRole="button"
+          >
+            {createExpense.isPending ? (
+              <ActivityIndicator color="#ffffff" />
+            ) : (
+              <Text style={styles.submitLabel}>
+                {balanceType === BALANCE_TYPE.expense ? '支出を記録' : '収入を記録'}
+              </Text>
+            )}
+          </Pressable>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#faf6f2',
+  },
+  flex: {
+    flex: 1,
+  },
+  container: {
+    padding: 20,
+    gap: 8,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: '800',
+    color: '#1c1410',
+  },
+  close: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#1c1410',
+    opacity: 0.6,
+  },
+  segment: {
+    flexDirection: 'row',
+    borderRadius: 12,
+    backgroundColor: 'rgba(28,20,16,0.06)',
+    padding: 4,
+    gap: 4,
+  },
+  segmentItem: {
+    flex: 1,
+    borderRadius: 9,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  segmentItemActive: {
+    backgroundColor: '#ffffff',
+  },
+  segmentLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#1c1410',
+    opacity: 0.5,
+  },
+  segmentLabelActive: {
+    opacity: 1,
+  },
+  label: {
+    marginTop: 12,
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#1c1410',
+  },
+  amountInput: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(28,20,16,0.15)',
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 28,
+    fontWeight: '800',
+    color: '#1c1410',
+    textAlign: 'right',
+  },
+  input: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: 'rgba(28,20,16,0.15)',
+    backgroundColor: '#ffffff',
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    fontSize: 16,
+    color: '#1c1410',
+  },
+  chips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderWidth: 2,
+    borderColor: 'transparent',
+  },
+  chipLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  error: {
+    marginTop: 8,
+    fontSize: 13,
+    color: '#c62828',
+  },
+  submit: {
+    marginTop: 20,
+    borderRadius: 12,
+    backgroundColor: '#2e7d32',
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  submitDisabled: {
+    opacity: 0.4,
+  },
+  submitLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#ffffff',
+  },
+});

--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -30,7 +30,11 @@ export default function EntryScreen() {
   const router = useRouter();
   const { userId } = useAuth();
   const [balanceType, setBalanceType] = useState<0 | 1>(BALANCE_TYPE.expense);
-  const { data: categories, isPending: categoriesLoading } = useCategories(balanceType);
+  const {
+    data: categories,
+    isPending: categoriesLoading,
+    isError: isCategoriesError,
+  } = useCategories(balanceType);
   const createExpense = useCreateExpense();
 
   const [amountText, setAmountText] = useState('');
@@ -74,7 +78,11 @@ export default function EntryScreen() {
   };
 
   return (
-    <SafeAreaView style={styles.safeArea} edges={['bottom']}>
+    <SafeAreaView
+      style={styles.safeArea}
+      // iOS のモーダルは OS が上部を自動調整するが Android はされないため top を含める
+      edges={Platform.OS === 'ios' ? ['bottom'] : ['top', 'bottom']}
+    >
       <KeyboardAvoidingView
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
@@ -119,6 +127,7 @@ export default function EntryScreen() {
             placeholder="0"
             placeholderTextColor="rgba(28,20,16,0.3)"
             keyboardType="number-pad"
+            maxLength={9}
             editable={!createExpense.isPending}
           />
 
@@ -126,6 +135,8 @@ export default function EntryScreen() {
           <Text style={styles.label}>カテゴリ</Text>
           {categoriesLoading ? (
             <ActivityIndicator color="#2e7d32" />
+          ) : isCategoriesError ? (
+            <Text style={styles.error}>カテゴリの取得に失敗しました。通信環境を確認してください</Text>
           ) : (
             <View style={styles.chips}>
               {(categories ?? []).map((category) => {
@@ -182,6 +193,7 @@ export default function EntryScreen() {
             onChangeText={setContent}
             placeholder="昼食代など"
             placeholderTextColor="rgba(28,20,16,0.3)"
+            maxLength={255}
             editable={!createExpense.isPending}
           />
 

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -1,4 +1,5 @@
 import { calcSavingsForecast } from '@budget/common';
+import { Link } from 'expo-router';
 import {
   ActivityIndicator,
   Pressable,
@@ -48,6 +49,13 @@ export default function HomeScreen() {
 
         {data && <Dashboard data={data} />}
       </ScrollView>
+
+      {/* クイック記録への導線（#496） */}
+      <Link href="/entry" asChild>
+        <Pressable style={styles.fab} accessibilityRole="button" accessibilityLabel="記録する">
+          <Text style={styles.fabLabel}>＋ 記録</Text>
+        </Pressable>
+      </Link>
     </SafeAreaView>
   );
 }
@@ -270,5 +278,24 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: '#1c1410',
     opacity: 0.5,
+  },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 28,
+    borderRadius: 999,
+    backgroundColor: '#2e7d32',
+    paddingHorizontal: 22,
+    paddingVertical: 14,
+    shadowColor: '#000000',
+    shadowOpacity: 0.2,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
+  fabLabel: {
+    fontSize: 15,
+    fontWeight: '800',
+    color: '#ffffff',
   },
 });

--- a/apps/mobile/src/app/index.tsx
+++ b/apps/mobile/src/app/index.tsx
@@ -148,6 +148,8 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 20,
+    // FAB（＋ 記録）と最終カードが重ならないよう下部に余白を確保する
+    paddingBottom: 100,
     gap: 12,
   },
   header: {

--- a/apps/mobile/src/lib/api/use-categories.ts
+++ b/apps/mobile/src/lib/api/use-categories.ts
@@ -1,0 +1,23 @@
+import { useQuery } from '@tanstack/react-query';
+import type { components } from '@budget/api-client';
+import { apiClient } from './client';
+
+export type CategoryItem = components['schemas']['CategoryItem'];
+
+/** 収支タイプ別のカテゴリ一覧（displayOrder 昇順）を取得する */
+export function useCategories(balanceType: 0 | 1) {
+  return useQuery<CategoryItem[], Error>({
+    queryKey: ['categories', balanceType],
+    queryFn: async () => {
+      const { data, error } = await apiClient.GET('/api/categories', {
+        params: { query: { balanceType: balanceType === 0 ? '0' : '1' } },
+      });
+      if (!data) {
+        throw new Error(error?.message ?? 'カテゴリの取得に失敗しました');
+      }
+      return data;
+    },
+    // カテゴリはマスタデータのため画面遷移ごとの再取得を抑える
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/apps/mobile/src/lib/api/use-create-expense.ts
+++ b/apps/mobile/src/lib/api/use-create-expense.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { components } from '@budget/api-client';
+import { apiClient } from './client';
+
+type NewExpenseData = components['schemas']['CreateExpenseBody']['newData'];
+
+export function useCreateExpense() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (newData: NewExpenseData) => {
+      const { data, error } = await apiClient.POST('/api/expense', {
+        body: { newData },
+      });
+      if (!data) {
+        throw new Error(error?.message ?? '記録の登録に失敗しました');
+      }
+      return data;
+    },
+    onSuccess: () => {
+      // 登録直後にホームの数値へ即時反映させる
+      void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    },
+  });
+}


### PR DESCRIPTION
## 概要

スマホアプリ Phase 3。支出・収入の登録（クイック記録）をモバイルで実装し、記録→評価→行動のフィードバックループをスマホ単体で完結させる（Sprint #33 ゴール）。

## 変更内容

- `src/app/entry.tsx`: 記録画面（モーダル表示）。支出/収入セグメント、金額入力（数値のみ・number-pad）、カテゴリチップ（API の `color` / `bg` でカテゴリカラー表示、再タップで選択解除）、日付（今日/昨日）、メモ（任意）
- `src/lib/api/use-categories.ts`: `GET /api/categories?balanceType=` による収支タイプ別カテゴリ取得（マスタデータのため staleTime 5 分）
- `src/lib/api/use-create-expense.ts`: `POST /api/expense` の useMutation。成功時に `['dashboard']` を invalidate してホームの数値へ即時反映
- `src/app/index.tsx`: FAB「＋ 記録」導線を追加
- `src/app/_layout.tsx`: entry を保護ルート（Stack.Protected 内・presentation: modal）に登録
- 登録成功後に金額・メモ・カテゴリ選択をリセットしてから戻る（Web の #478 と同じ二重登録防止方針）

## 影響範囲

- `apps/mobile` 内で完結。API・Web・共有パッケージへの変更なし

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（balanceType 0=支出 / 1=収入）
- [x] 境界を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（生成は API 側。返却された ULID を確認）
- [x] マジックナンバーを排除し、定数化されているか（BALANCE_TYPE 定数）
- [x] UI/UX 変更がある場合、スクリーンショットを添付しているか（実機確認手順を備考に記載）
- [x] ドキュメント変更に伴う SSOT マップ更新（該当なし）

## Test plan

- `pnpm --filter mobile run type-check` / `eslint src --max-warnings 0` グリーン
- `expo export --platform ios` バンドル生成成功
- 実データ検証（guest ユーザー・ローカル API）: `GET /api/categories?balanceType=0` でカテゴリ・カラー取得 → `POST /api/expense`（amount 500 / 食費）で ULID 取得 → ダッシュボード todayExpense が 0 → 500 に反映 → テストデータ削除で 0 に復帰、まで一連を確認
- 単体テストは #494（jest-expo 基盤整備）で追加予定

## 関連 Issue

- Closes #496
- Sprint: 33

## 備考

- 日付は「今日/昨日」の 2 択（最速入力を優先）。任意日付のカレンダー入力は必要になったら拡張する
- 実機確認: 同一 LAN で `pnpm db:start` + `pnpm dev:api` + `pnpm --filter mobile run start` → ログイン → FAB「＋ 記録」

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q
