### PR TITLE
feat(mobile): ナビゲーションを Web と同一構成にする（4タブ+中央の記録ボタン・ヘッダー）

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,8 +1,24 @@
-import { Tabs } from 'expo-router';
-import { Home, ReceiptText } from 'lucide-react-native';
+import { Link, Tabs } from 'expo-router';
+import { BarChart2, Home, Plus, Receipt, Settings } from 'lucide-react-native';
+import { Pressable, StyleSheet, View } from 'react-native';
 import { colors } from '@/theme/tokens';
 
-/** ホーム / 明細 のタブナビゲーション（Web の BottomNav 相当） */
+/** タブバー中央のオレンジ「+」ボタン（Web BottomNav の中央 FAB 相当） */
+function CenterRecordButton() {
+  return (
+    <View style={styles.centerSlot} pointerEvents="box-none">
+      <Link href="/entry" asChild>
+        <Pressable style={styles.centerButton} accessibilityRole="button" accessibilityLabel="記録する">
+          <Plus size={26} color={colors.surface} strokeWidth={3} />
+        </Pressable>
+      </Link>
+    </View>
+  );
+}
+
+/**
+ * ナビゲーション（Web navItems.ts と同一構成: ホーム / 明細 / [+] / レポート / 設定）
+ */
 export default function TabsLayout() {
   return (
     <Tabs
@@ -24,9 +40,51 @@ export default function TabsLayout() {
         name="records"
         options={{
           title: '明細',
-          tabBarIcon: ({ color, size }) => <ReceiptText color={color} size={size} />,
+          tabBarIcon: ({ color, size }) => <Receipt color={color} size={size} />,
+        }}
+      />
+      <Tabs.Screen
+        name="record-action"
+        options={{
+          title: '',
+          tabBarButton: () => <CenterRecordButton />,
+        }}
+      />
+      <Tabs.Screen
+        name="report"
+        options={{
+          title: 'レポート',
+          tabBarIcon: ({ color, size }) => <BarChart2 color={color} size={size} />,
+        }}
+      />
+      <Tabs.Screen
+        name="settings"
+        options={{
+          title: '設定',
+          tabBarIcon: ({ color, size }) => <Settings color={color} size={size} />,
         }}
       />
     </Tabs>
   );
 }
+
+const styles = StyleSheet.create({
+  centerSlot: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  centerButton: {
+    marginTop: -18,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: colors.brandPrimary,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000000',
+    shadowOpacity: 0.25,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 4 },
+    elevation: 6,
+  },
+});

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,14 +1,71 @@
 import { Link, Tabs } from 'expo-router';
 import { BarChart2, Home, Plus, Receipt, Settings } from 'lucide-react-native';
 import { Pressable, StyleSheet, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { colors } from '@/theme/tokens';
 
-/** タブバー中央のオレンジ「+」ボタン（Web BottomNav の中央 FAB 相当） */
-function CenterRecordButton() {
+/**
+ * ナビゲーション（Web navItems.ts と同一構成: ホーム / 明細 / [+] / レポート / 設定）
+ * 中央の + はタブバーからはみ出すため、親（タブバー）にクリップされないよう
+ * 画面ルートに絶対配置でオーバーレイする（はみ出し部分のタップ不能を防ぐ）。
+ */
+export default function TabsLayout() {
+  const insets = useSafeAreaInsets();
+
   return (
-    <View style={styles.centerSlot} pointerEvents="box-none">
+    <View style={styles.root}>
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarActiveTintColor: colors.brandPrimary,
+          tabBarInactiveTintColor: 'rgba(28,20,16,0.4)',
+          tabBarStyle: { backgroundColor: colors.surface },
+        }}
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: 'ホーム',
+            tabBarIcon: ({ color, size }) => <Home color={color} size={size} />,
+          }}
+        />
+        <Tabs.Screen
+          name="records"
+          options={{
+            title: '明細',
+            tabBarIcon: ({ color, size }) => <Receipt color={color} size={size} />,
+          }}
+        />
+        <Tabs.Screen
+          name="record-action"
+          options={{
+            title: '',
+            // 中央スロットの場所取り（実ボタンは下のオーバーレイ）
+            tabBarButton: () => <View style={styles.centerSpacer} />,
+          }}
+        />
+        <Tabs.Screen
+          name="report"
+          options={{
+            title: 'レポート',
+            tabBarIcon: ({ color, size }) => <BarChart2 color={color} size={size} />,
+          }}
+        />
+        <Tabs.Screen
+          name="settings"
+          options={{
+            title: '設定',
+            tabBarIcon: ({ color, size }) => <Settings color={color} size={size} />,
+          }}
+        />
+      </Tabs>
+
       <Link href="/entry" asChild>
-        <Pressable style={styles.centerButton} accessibilityRole="button" accessibilityLabel="記録する">
+        <Pressable
+          style={[styles.centerButton, { bottom: insets.bottom + 22 }]}
+          accessibilityRole="button"
+          accessibilityLabel="記録する"
+        >
           <Plus size={26} color={colors.surface} strokeWidth={3} />
         </Pressable>
       </Link>
@@ -16,65 +73,16 @@ function CenterRecordButton() {
   );
 }
 
-/**
- * ナビゲーション（Web navItems.ts と同一構成: ホーム / 明細 / [+] / レポート / 設定）
- */
-export default function TabsLayout() {
-  return (
-    <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: colors.brandPrimary,
-        tabBarInactiveTintColor: 'rgba(28,20,16,0.4)',
-        tabBarStyle: { backgroundColor: colors.surface },
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'ホーム',
-          tabBarIcon: ({ color, size }) => <Home color={color} size={size} />,
-        }}
-      />
-      <Tabs.Screen
-        name="records"
-        options={{
-          title: '明細',
-          tabBarIcon: ({ color, size }) => <Receipt color={color} size={size} />,
-        }}
-      />
-      <Tabs.Screen
-        name="record-action"
-        options={{
-          title: '',
-          tabBarButton: () => <CenterRecordButton />,
-        }}
-      />
-      <Tabs.Screen
-        name="report"
-        options={{
-          title: 'レポート',
-          tabBarIcon: ({ color, size }) => <BarChart2 color={color} size={size} />,
-        }}
-      />
-      <Tabs.Screen
-        name="settings"
-        options={{
-          title: '設定',
-          tabBarIcon: ({ color, size }) => <Settings color={color} size={size} />,
-        }}
-      />
-    </Tabs>
-  );
-}
-
 const styles = StyleSheet.create({
-  centerSlot: {
+  root: {
     flex: 1,
-    alignItems: 'center',
+  },
+  centerSpacer: {
+    flex: 1,
   },
   centerButton: {
-    marginTop: -18,
+    position: 'absolute',
+    alignSelf: 'center',
     width: 56,
     height: 56,
     borderRadius: 28,

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -1,4 +1,3 @@
-import { Link } from 'expo-router';
 import {
   ActivityIndicator,
   Pressable,
@@ -9,8 +8,8 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useAuth } from '@/lib/auth/auth-context';
 import { useDashboard, type DashboardData } from '@/lib/api/use-dashboard';
+import { AppHeader } from '@/components/layout/AppHeader';
 import { LivingMarginCard } from '@/components/dashboard/LivingMarginCard';
 import { MonthlySummaryCard } from '@/components/dashboard/MonthlySummaryCard';
 import { TodayStatusCard } from '@/components/dashboard/TodayStatusCard';
@@ -18,25 +17,18 @@ import { WeeklyStreak } from '@/components/dashboard/WeeklyStreak';
 import { colors } from '@/theme/tokens';
 
 export default function HomeScreen() {
-  const { userId, logout } = useAuth();
   const { data, isPending, isError, error, refetch, isRefetching } = useDashboard();
 
   return (
     // 下部セーフエリアはタブバーが処理するため除外（二重パディング防止）
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
+      <AppHeader />
       <ScrollView
         contentContainerStyle={styles.container}
         refreshControl={
           <RefreshControl refreshing={isRefetching} onRefresh={() => refetch()} />
         }
       >
-        <View style={styles.header}>
-          <Text style={styles.userId}>{userId}</Text>
-          <Pressable onPress={logout} accessibilityRole="button" hitSlop={8}>
-            <Text style={styles.logout}>ログアウト</Text>
-          </Pressable>
-        </View>
-
         {isPending && (
           <View style={styles.center}>
             <ActivityIndicator size="large" color={colors.income} />
@@ -54,13 +46,6 @@ export default function HomeScreen() {
 
         {data && <Dashboard data={data} today={new Date()} />}
       </ScrollView>
-
-      {/* クイック記録への導線（#496） */}
-      <Link href="/entry" asChild>
-        <Pressable style={styles.fab} accessibilityRole="button" accessibilityLabel="記録する">
-          <Text style={styles.fabLabel}>＋ 記録</Text>
-        </Pressable>
-      </Link>
     </SafeAreaView>
   );
 }
@@ -123,26 +108,10 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 20,
-    // FAB（＋ 記録）と最終カードが重ならないよう下部に余白を確保する
-    paddingBottom: 100,
+    paddingTop: 8,
+    // タブ中央の + ボタンと最終カードが重ならないよう下部に余白を確保する
+    paddingBottom: 48,
     gap: 12,
-  },
-  header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  userId: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: colors.foreground,
-    opacity: 0.7,
-  },
-  logout: {
-    fontSize: 13,
-    fontWeight: '700',
-    color: '#c62828',
   },
   center: {
     paddingVertical: 64,
@@ -218,24 +187,5 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: colors.foreground,
     opacity: 0.5,
-  },
-  fab: {
-    position: 'absolute',
-    right: 20,
-    bottom: 28,
-    borderRadius: 999,
-    backgroundColor: colors.income,
-    paddingHorizontal: 22,
-    paddingVertical: 14,
-    shadowColor: '#000000',
-    shadowOpacity: 0.2,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 6,
-  },
-  fabLabel: {
-    fontSize: 15,
-    fontWeight: '800',
-    color: colors.surface,
   },
 });

--- a/apps/mobile/src/app/(tabs)/record-action.tsx
+++ b/apps/mobile/src/app/(tabs)/record-action.tsx
@@ -1,0 +1,4 @@
+/** タブ中央の「+」ボタン用ダミールート（tabBarButton で置換されるため画面としては描画されない） */
+export default function RecordActionPlaceholder() {
+  return null;
+}

--- a/apps/mobile/src/app/(tabs)/report.tsx
+++ b/apps/mobile/src/app/(tabs)/report.tsx
@@ -1,0 +1,44 @@
+import { BarChart2 } from 'lucide-react-native';
+import { StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { AppHeader } from '@/components/layout/AppHeader';
+import { colors } from '@/theme/tokens';
+
+/** レポート画面（プレースホルダー。グラフ実装は次スプリント） */
+export default function ReportScreen() {
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
+      <AppHeader />
+      <View style={styles.center}>
+        <BarChart2 size={40} color={colors.foreground} opacity={0.3} />
+        <Text style={styles.title}>レポートは準備中です</Text>
+        <Text style={styles.note}>支出の内訳グラフ・月次推移を順次追加します。</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    padding: 24,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: colors.foreground,
+  },
+  note: {
+    fontSize: 13,
+    color: colors.foreground,
+    opacity: 0.55,
+    textAlign: 'center',
+  },
+});

--- a/apps/mobile/src/app/(tabs)/settings.tsx
+++ b/apps/mobile/src/app/(tabs)/settings.tsx
@@ -1,0 +1,68 @@
+import { Settings } from 'lucide-react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { AppHeader } from '@/components/layout/AppHeader';
+import { useAuth } from '@/lib/auth/auth-context';
+import { colors } from '@/theme/tokens';
+
+/** 設定画面（プレースホルダー。設定フォームの実装は #510） */
+export default function SettingsScreen() {
+  const { userId, logout } = useAuth();
+  return (
+    <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
+      <AppHeader />
+      <View style={styles.center}>
+        <Settings size={40} color={colors.foreground} opacity={0.3} />
+        <Text style={styles.title}>設定は準備中です</Text>
+        <Text style={styles.note}>給与・給料日・固定費・貯蓄目標の設定を追加します。</Text>
+      </View>
+      <View style={styles.account}>
+        <Text style={styles.accountLabel}>ログイン中: {userId}</Text>
+        <Pressable onPress={logout} accessibilityRole="button" hitSlop={8}>
+          <Text style={styles.logout}>ログアウト</Text>
+        </Pressable>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  center: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+    padding: 24,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '800',
+    color: colors.foreground,
+  },
+  note: {
+    fontSize: 13,
+    color: colors.foreground,
+    opacity: 0.55,
+    textAlign: 'center',
+  },
+  account: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    padding: 20,
+  },
+  accountLabel: {
+    fontSize: 13,
+    color: colors.foreground,
+    opacity: 0.6,
+  },
+  logout: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: '#c62828',
+  },
+});

--- a/apps/mobile/src/app/(tabs)/settings.tsx
+++ b/apps/mobile/src/app/(tabs)/settings.tsx
@@ -17,7 +17,7 @@ export default function SettingsScreen() {
         <Text style={styles.note}>給与・給料日・固定費・貯蓄目標の設定を追加します。</Text>
       </View>
       <View style={styles.account}>
-        <Text style={styles.accountLabel}>ログイン中: {userId}</Text>
+        <Text style={styles.accountLabel}>ログイン中: {userId ?? '未ログイン'}</Text>
         <Pressable onPress={logout} accessibilityRole="button" hitSlop={8}>
           <Text style={styles.logout}>ログアウト</Text>
         </Pressable>

--- a/apps/mobile/src/components/layout/AppHeader.tsx
+++ b/apps/mobile/src/components/layout/AppHeader.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'expo-router';
+import { NotebookPen } from 'lucide-react-native';
+import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/tokens';
+
+/** アプリ共通ヘッダー（Web Header 相当: アプリ名 + 記録するボタン） */
+export function AppHeader() {
+  return (
+    <View style={styles.header}>
+      <Text style={styles.title}>家計かんり</Text>
+      <Link href="/entry" asChild>
+        <Pressable style={styles.recordButton} accessibilityRole="button">
+          <NotebookPen size={14} color={colors.surface} />
+          <Text style={styles.recordLabel}>記録する</Text>
+        </Pressable>
+      </Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  title: {
+    fontSize: 17,
+    fontWeight: '800',
+    color: colors.foreground,
+  },
+  recordButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    borderRadius: 999,
+    backgroundColor: colors.brandPrimary,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+  },
+  recordLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.surface,
+  },
+});


### PR DESCRIPTION
## 概要

ユーザー指摘（モバイルと Web の見た目が大きく違う）への対応第 1 弾（Sprint #36）。ナビゲーションを Web と同一構成に揃える。

## 変更内容

- タブを **ホーム / 明細 / レポート / 設定** の 4 つに拡張（Web `navItems.ts` と同一のラベル・lucide アイコン: Home/Receipt/BarChart2/Settings）
- **タブバー中央にオレンジの + ボタン**（Web BottomNav の中央 FAB 相当）→ 記録モーダル。ホームの緑 FAB は廃止
- **AppHeader**（家計かんり + 記録するボタン、Web Header 相当）を全タブ画面に追加
- レポート / 設定は準備中画面（設定フォームは #510 で実装。ログアウト導線は設定画面へ移設）

## 影響範囲

apps/mobile 内で完結。

## 規約・設計チェック

- [x] ユビキタス言語 / 境界 / ID / 定数化: 該当なし〜遵守
- [x] UI/UX 変更: 実機で Web スクリーンショット（ユーザー提供）と見比べて確認
- [x] SSOT マップ更新: 該当なし

## Test plan

- type-check / lint / test:unit（11 件）/ expo export すべてグリーン

## 関連 Issue

- Closes #509
- Sprint: 36

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q