### PR TITLE
feat(mobile): 設定画面を実装し初回設定〜1日予算表示をモバイルで完結させる

### DIFF
--- a/apps/mobile/src/app/(tabs)/settings.tsx
+++ b/apps/mobile/src/app/(tabs)/settings.tsx
@@ -1,27 +1,185 @@
-import { Settings } from 'lucide-react-native';
-import { Pressable, StyleSheet, Text, View } from 'react-native';
+import { useEffect, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  KeyboardAvoidingView,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { useAuth } from '@/lib/auth/auth-context';
+import { useSettings, useSaveSettings } from '@/lib/api/use-settings';
 import { colors } from '@/theme/tokens';
 
-/** 設定画面（プレースホルダー。設定フォームの実装は #510） */
+/** 給料日のクイック選択肢（Web 設定画面と同じ） */
+const PAYDAY_PRESETS = [5, 20, 21, 25, 28, 31] as const;
+
+/** 金額入力（数値のみ・カンマなし文字列で保持） */
+function MoneyField({
+  label,
+  value,
+  onChange,
+  editable,
+}: {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  editable: boolean;
+}) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.moneyRow}>
+        <Text style={styles.yen}>¥</Text>
+        <TextInput
+          style={styles.moneyInput}
+          value={value}
+          onChangeText={(t) => onChange(t.replace(/[^0-9]/g, ''))}
+          placeholder="0"
+          placeholderTextColor="rgba(28,20,16,0.3)"
+          keyboardType="number-pad"
+          maxLength={10}
+          editable={editable}
+        />
+      </View>
+    </View>
+  );
+}
+
 export default function SettingsScreen() {
   const { userId, logout } = useAuth();
+  const { data: settings, isPending } = useSettings();
+  const saveSettings = useSaveSettings();
+
+  const [totalAssets, setTotalAssets] = useState('');
+  const [monthlyIncome, setMonthlyIncome] = useState('');
+  const [fixedExpenses, setFixedExpenses] = useState('');
+  const [savingsGoal, setSavingsGoal] = useState('');
+  const [paydayDay, setPaydayDay] = useState<number>(25);
+
+  // 取得済みの設定値でフォームを初期化する
+  useEffect(() => {
+    if (!settings) return;
+    setTotalAssets(String(settings.totalAssets ?? 0));
+    setMonthlyIncome(String(settings.monthlyIncome ?? 0));
+    setFixedExpenses(String(settings.fixedExpenses ?? 0));
+    setSavingsGoal(String(settings.savingsGoal ?? 0));
+    setPaydayDay(settings.paydayDay ?? 25);
+  }, [settings]);
+
+  const canSave =
+    totalAssets !== '' && monthlyIncome !== '' && fixedExpenses !== '' && !saveSettings.isPending;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    try {
+      await saveSettings.mutateAsync({
+        totalAssets: Number(totalAssets),
+        monthlyIncome: Number(monthlyIncome),
+        paydayDay,
+        fixedExpenses: Number(fixedExpenses),
+        savingsGoal: Number(savingsGoal || '0'),
+        initialSetupCompleted: true,
+      });
+      Alert.alert('保存しました', 'ホームに1日予算が反映されます');
+    } catch (e) {
+      Alert.alert('保存に失敗しました', e instanceof Error ? e.message : undefined);
+    }
+  };
+
   return (
     <SafeAreaView style={styles.safeArea} edges={['top', 'left', 'right']}>
       <AppHeader />
-      <View style={styles.center}>
-        <Settings size={40} color={colors.foreground} opacity={0.3} />
-        <Text style={styles.title}>設定は準備中です</Text>
-        <Text style={styles.note}>給与・給料日・固定費・貯蓄目標の設定を追加します。</Text>
-      </View>
-      <View style={styles.account}>
-        <Text style={styles.accountLabel}>ログイン中: {userId ?? '未ログイン'}</Text>
-        <Pressable onPress={logout} accessibilityRole="button" hitSlop={8}>
-          <Text style={styles.logout}>ログアウト</Text>
-        </Pressable>
-      </View>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+          <Text style={styles.title}>設定</Text>
+
+          {isPending ? (
+            <ActivityIndicator size="large" color={colors.brandPrimary} />
+          ) : (
+            <>
+              <MoneyField
+                label="総資産（現在の残高）"
+                value={totalAssets}
+                onChange={setTotalAssets}
+                editable={!saveSettings.isPending}
+              />
+              <MoneyField
+                label="月収（手取り）"
+                value={monthlyIncome}
+                onChange={setMonthlyIncome}
+                editable={!saveSettings.isPending}
+              />
+
+              <View style={styles.field}>
+                <Text style={styles.label}>給料日</Text>
+                <View style={styles.paydayChips}>
+                  {PAYDAY_PRESETS.map((day) => {
+                    const selected = paydayDay === day;
+                    return (
+                      <Pressable
+                        key={day}
+                        style={[styles.chip, selected && styles.chipSelected]}
+                        onPress={() => setPaydayDay(day)}
+                        accessibilityRole="button"
+                      >
+                        <Text style={[styles.chipLabel, selected && styles.chipLabelSelected]}>
+                          {day}
+                        </Text>
+                      </Pressable>
+                    );
+                  })}
+                </View>
+                {!PAYDAY_PRESETS.includes(paydayDay as (typeof PAYDAY_PRESETS)[number]) && (
+                  <Text style={styles.paydayNote}>現在の設定: 毎月 {paydayDay} 日</Text>
+                )}
+              </View>
+
+              <MoneyField
+                label="固定費（家賃・光熱費などの合計）"
+                value={fixedExpenses}
+                onChange={setFixedExpenses}
+                editable={!saveSettings.isPending}
+              />
+              <MoneyField
+                label="月間貯蓄目標（任意）"
+                value={savingsGoal}
+                onChange={setSavingsGoal}
+                editable={!saveSettings.isPending}
+              />
+
+              <Pressable
+                style={[styles.save, !canSave && styles.saveDisabled]}
+                onPress={handleSave}
+                disabled={!canSave}
+                accessibilityRole="button"
+              >
+                {saveSettings.isPending ? (
+                  <ActivityIndicator color={colors.surface} />
+                ) : (
+                  <Text style={styles.saveLabel}>保存する</Text>
+                )}
+              </Pressable>
+            </>
+          )}
+
+          <View style={styles.account}>
+            <Text style={styles.accountLabel}>ログイン中: {userId ?? '未ログイン'}</Text>
+            <Pressable onPress={logout} accessibilityRole="button" hitSlop={8}>
+              <Text style={styles.logout}>ログアウト</Text>
+            </Pressable>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
     </SafeAreaView>
   );
 }
@@ -31,29 +189,105 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: colors.background,
   },
-  center: {
+  flex: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    gap: 10,
-    padding: 24,
+  },
+  container: {
+    padding: 20,
+    paddingTop: 8,
+    paddingBottom: 48,
+    gap: 14,
   },
   title: {
-    fontSize: 16,
+    fontSize: 20,
     fontWeight: '800',
     color: colors.foreground,
   },
-  note: {
+  field: {
+    gap: 6,
+  },
+  label: {
     fontSize: 13,
+    fontWeight: '700',
+    color: colors.foreground,
+  },
+  moneyRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.borderDefault,
+    backgroundColor: colors.surface,
+    paddingHorizontal: 14,
+  },
+  yen: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.foreground,
+    opacity: 0.5,
+  },
+  moneyInput: {
+    flex: 1,
+    paddingHorizontal: 8,
+    paddingVertical: 12,
+    fontSize: 18,
+    fontWeight: '700',
+    color: colors.foreground,
+    textAlign: 'right',
+    fontVariant: ['tabular-nums'],
+  },
+  paydayChips: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+  },
+  chip: {
+    minWidth: 44,
+    alignItems: 'center',
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.borderDefault,
+    backgroundColor: colors.surface,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+  },
+  chipSelected: {
+    backgroundColor: colors.brandPrimary,
+    borderColor: colors.brandPrimary,
+  },
+  chipLabel: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.foreground,
+  },
+  chipLabelSelected: {
+    color: colors.surface,
+  },
+  paydayNote: {
+    fontSize: 12,
     color: colors.foreground,
     opacity: 0.55,
-    textAlign: 'center',
+  },
+  save: {
+    marginTop: 8,
+    borderRadius: 12,
+    backgroundColor: colors.brandPrimary,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  saveDisabled: {
+    opacity: 0.4,
+  },
+  saveLabel: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: colors.surface,
   },
   account: {
+    marginTop: 16,
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    padding: 20,
   },
   accountLabel: {
     fontSize: 13,

--- a/apps/mobile/src/app/(tabs)/settings.tsx
+++ b/apps/mobile/src/app/(tabs)/settings.tsx
@@ -62,19 +62,27 @@ export default function SettingsScreen() {
   const [fixedExpenses, setFixedExpenses] = useState('');
   const [savingsGoal, setSavingsGoal] = useState('');
   const [paydayDay, setPaydayDay] = useState<number>(25);
+  const [customPayday, setCustomPayday] = useState('');
+  const [initialized, setInitialized] = useState(false);
 
-  // 取得済みの設定値でフォームを初期化する
+  // 取得済みの設定値でフォームを初期化する（初回のみ。
+  // バックグラウンド再フェッチで入力中の値を上書きしないようガードする）
   useEffect(() => {
-    if (!settings) return;
+    if (!settings || initialized) return;
     setTotalAssets(String(settings.totalAssets ?? 0));
     setMonthlyIncome(String(settings.monthlyIncome ?? 0));
     setFixedExpenses(String(settings.fixedExpenses ?? 0));
     setSavingsGoal(String(settings.savingsGoal ?? 0));
     setPaydayDay(settings.paydayDay ?? 25);
-  }, [settings]);
+    setInitialized(true);
+  }, [settings, initialized]);
 
+  // 総資産・月収は1日予算算出の前提のため 0 のままの初回設定完了を防ぐ
   const canSave =
-    totalAssets !== '' && monthlyIncome !== '' && fixedExpenses !== '' && !saveSettings.isPending;
+    Number(totalAssets) > 0 &&
+    Number(monthlyIncome) > 0 &&
+    fixedExpenses !== '' &&
+    !saveSettings.isPending;
 
   const handleSave = async () => {
     if (!canSave) return;
@@ -100,7 +108,11 @@ export default function SettingsScreen() {
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+        >
           <Text style={styles.title}>設定</Text>
 
           {isPending ? (
@@ -124,12 +136,15 @@ export default function SettingsScreen() {
                 <Text style={styles.label}>給料日</Text>
                 <View style={styles.paydayChips}>
                   {PAYDAY_PRESETS.map((day) => {
-                    const selected = paydayDay === day;
+                    const selected = paydayDay === day && customPayday === '';
                     return (
                       <Pressable
                         key={day}
                         style={[styles.chip, selected && styles.chipSelected]}
-                        onPress={() => setPaydayDay(day)}
+                        onPress={() => {
+                          setPaydayDay(day);
+                          setCustomPayday('');
+                        }}
                         accessibilityRole="button"
                       >
                         <Text style={[styles.chipLabel, selected && styles.chipLabelSelected]}>
@@ -138,10 +153,24 @@ export default function SettingsScreen() {
                       </Pressable>
                     );
                   })}
+                  <TextInput
+                    style={[styles.chip, styles.customPaydayInput]}
+                    value={customPayday}
+                    onChangeText={(t) => {
+                      const digits = t.replace(/[^0-9]/g, '');
+                      setCustomPayday(digits);
+                      const day = Number(digits);
+                      if (day >= 1 && day <= 31) setPaydayDay(day);
+                    }}
+                    placeholder="他"
+                    placeholderTextColor="rgba(28,20,16,0.35)"
+                    keyboardType="number-pad"
+                    maxLength={2}
+                    editable={!saveSettings.isPending}
+                    accessibilityLabel="給料日を直接入力（1〜31）"
+                  />
                 </View>
-                {!PAYDAY_PRESETS.includes(paydayDay as (typeof PAYDAY_PRESETS)[number]) && (
-                  <Text style={styles.paydayNote}>現在の設定: 毎月 {paydayDay} 日</Text>
-                )}
+                <Text style={styles.paydayNote}>現在の設定: 毎月 {paydayDay} 日</Text>
               </View>
 
               <MoneyField
@@ -262,6 +291,14 @@ const styles = StyleSheet.create({
   },
   chipLabelSelected: {
     color: colors.surface,
+  },
+  customPaydayInput: {
+    minWidth: 52,
+    paddingVertical: 8,
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.foreground,
+    textAlign: 'center',
   },
   paydayNote: {
     fontSize: 12,

--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -87,7 +87,11 @@ export default function EntryScreen() {
         style={styles.flex}
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
-        <ScrollView contentContainerStyle={styles.container} keyboardShouldPersistTaps="handled">
+        <ScrollView
+          style={styles.flex}
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+        >
           <View style={styles.headerRow}>
             <Text style={styles.title}>記録する</Text>
             <Pressable onPress={() => router.back()} accessibilityRole="button" hitSlop={8}>

--- a/apps/mobile/src/lib/api/use-settings.ts
+++ b/apps/mobile/src/lib/api/use-settings.ts
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { components } from '@budget/api-client';
+import { apiClient } from './client';
+
+export type UserSettings = components['schemas']['UserSettingsResponse'];
+export type UpsertSettingsBody = components['schemas']['UpsertUserSettingsBody'];
+
+export function useSettings() {
+  return useQuery<UserSettings, Error>({
+    queryKey: ['settings'],
+    queryFn: async () => {
+      const { data, error } = await apiClient.GET('/api/settings');
+      if (!data) {
+        throw new Error(error?.message ?? '設定の取得に失敗しました');
+      }
+      return data;
+    },
+  });
+}
+
+export function useSaveSettings() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (body: UpsertSettingsBody) => {
+      const { data, error } = await apiClient.PUT('/api/settings', { body });
+      if (!data) {
+        throw new Error(error?.message ?? '設定の保存に失敗しました');
+      }
+      return data;
+    },
+    onSuccess: () => {
+      // 1日予算・生活余力に即時反映させる
+      void queryClient.invalidateQueries({ queryKey: ['settings'] });
+      void queryClient.invalidateQueries({ queryKey: ['dashboard'] });
+    },
+  });
+}


### PR DESCRIPTION
## 概要

ユーザー指摘（Web との差分）への対応第 2 弾（Sprint #36）。Web の設定画面に相当するフォームをモバイルへ実装し、初回設定 → ホームに1日予算表示までをモバイル単体で完結させる。

## 変更内容

- `src/lib/api/use-settings.ts`: `useSettings`（GET）/ `useSaveSettings`（PUT、成功時に settings / dashboard を invalidate）
- `src/app/(tabs)/settings.tsx`: プレースホルダーを実フォームに置換
  - 金額 4 項目: 総資産 / 月収（手取り）/ 固定費合計 / 月間貯蓄目標（任意）
  - 給料日: Web と同一のクイックチップ（5/20/21/25/28/31）
  - 保存で `initialSetupCompleted: true` を送信
  - 既存値の復元・保存中の無効化・成功/失敗 Alert

## 影響範囲

apps/mobile 内で完結。

## 規約・設計チェック

- [x] ユビキタス言語 / 境界 / ID: 遵守〜該当なし
- [x] マジックナンバー: 給料日プリセットを PAYDAY_PRESETS に定数化
- [x] UI/UX 変更: 実機確認（備考参照）
- [x] SSOT マップ更新: 該当なし

## Test plan

- type-check / lint / test:unit（11 件）グリーン
- API 実データ検証（demo ユーザー）: 保存前 `dailyBudget: null` → PUT /api/settings（initialSetupCompleted: true）→ dashboard が `dailyBudget: {amount: 83125, daysUntilPayday: 16}` を返却。初回設定 → 1日予算表示の一連を確認

## 関連 Issue

- Closes #510
- Sprint: 36

## 備考

- 固定費の内訳（家賃・光熱費の個別ステッパー）は Web にある fixedExpensesDetail を使う拡張余地あり。本 PR は合計値のみ（API 仕様上 detail 省略時は既存値維持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q