### PR TITLE
fix(mobile): レシート解析の結果を成功/失敗ともに必ずメッセージで通知する

### DIFF
--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -60,16 +60,20 @@ export default function EntryScreen() {
 
   const receiptScan = useReceiptScan();
 
-  /** 撮影/選択した画像を解析し、結果をフォームへプリフィルする（登録はしない） */
+  /**
+   * 撮影/選択した画像の解析結果をフォームへプリフィルし、
+   * 読み取り内容のサマリーを返す（登録はしない）
+   */
   const applyScanResult = (result: {
     amount: number | null;
     date: string | null;
     content: string | null;
-  }) => {
+  }): string => {
     // != null で null と undefined の両方を防ぐ（防衛的チェック）
     if (result.amount != null) setAmountText(String(result.amount));
     if (result.content != null) setContent(result.content);
 
+    let dateNote = '';
     // 記録フォームの日付は今日/昨日のみのため、それ以外の日付は反映せず通知する
     if (result.date != null) {
       // 日付境界のレースを避けるため now は1回だけ取得する
@@ -82,12 +86,15 @@ export default function EntryScreen() {
       } else if (result.date === toDateString(yesterday)) {
         setDayOffset(1);
       } else {
-        Alert.alert(
-          'レシートの日付は反映されません',
-          `レシートの日付は ${result.date} でした。このフォームでは今日または昨日のみ選択できます。`,
-        );
+        dateNote = '（今日/昨日以外のため日付は未反映）';
       }
     }
+
+    return [
+      result.amount != null ? `金額: ¥${result.amount.toLocaleString()}` : '金額: 読み取れず',
+      result.date != null ? `日付: ${result.date}${dateNote}` : '日付: 読み取れず',
+      result.content != null ? `店名: ${result.content}` : '店名: 読み取れず',
+    ].join('\n');
   };
 
   const handleReceiptScan = async (useCamera: boolean) => {
@@ -119,10 +126,14 @@ export default function EntryScreen() {
         imageBase64: asset.base64,
         mimeType: asset.mimeType === 'image/png' ? 'image/png' : 'image/jpeg',
       });
-      applyScanResult(result);
+      // 成功時は読み取り結果を必ずメッセージで明示する（全項目 null でも通知される）
+      const summary = applyScanResult(result);
+      Alert.alert('レシートを読み取りました', `${summary}\n\n内容を確認して登録してください。`);
     } catch (e) {
-      // 解析失敗でも手入力は継続できる
-      setErrorMessage(e instanceof Error ? e.message : 'レシートの解析に失敗しました');
+      const message = e instanceof Error ? e.message : 'レシートの解析に失敗しました';
+      // 失敗時もメッセージで明示する（手入力はそのまま継続できる）
+      setErrorMessage(message);
+      Alert.alert('レシートを解析できませんでした', `${message}\n\n手入力で登録できます。`);
     }
   };
 

--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -201,7 +201,7 @@ export default function EntryScreen() {
             {receiptScan.isPending ? (
               <>
                 <ActivityIndicator size="small" color={colors.brandPrimary} />
-                <Text style={styles.scanLabel}>レシートを解析中…（最大1分ほどかかります）</Text>
+                <Text style={styles.scanLabel}>レシートを解析中…（最大2分ほどかかります）</Text>
               </>
             ) : (
               <>

--- a/apps/mobile/src/lib/api/use-receipt-scan.ts
+++ b/apps/mobile/src/lib/api/use-receipt-scan.ts
@@ -4,16 +4,32 @@ import { apiClient } from './client';
 
 export type ReceiptScanResult = components['schemas']['ReceiptScanResponse'];
 
+/** 解析の待ち上限。CLI 経路（最大90秒）+ OCR フォールバックを見込む */
+const SCAN_TIMEOUT_MS = 120_000;
+
 export function useReceiptScan() {
   return useMutation({
     mutationFn: async (params: { imageBase64: string; mimeType: 'image/jpeg' | 'image/png' }) => {
-      const { data, error } = await apiClient.POST('/api/receipt-scan', {
-        body: { image: params.imageBase64, mimeType: params.mimeType },
-      });
-      if (!data) {
-        throw new Error(error?.message ?? 'レシートの解析に失敗しました');
+      // スピナーが無限に続かないようクライアント側でも打ち切る
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), SCAN_TIMEOUT_MS);
+      try {
+        const { data, error } = await apiClient.POST('/api/receipt-scan', {
+          body: { image: params.imageBase64, mimeType: params.mimeType },
+          signal: controller.signal,
+        });
+        if (!data) {
+          throw new Error(error?.message ?? 'レシートの解析に失敗しました');
+        }
+        return data;
+      } catch (e) {
+        if (controller.signal.aborted) {
+          throw new Error('解析がタイムアウトしました（2分）。通信環境を確認して再試行してください');
+        }
+        throw e;
+      } finally {
+        clearTimeout(timer);
       }
-      return data;
     },
   });
 }


### PR DESCRIPTION
## 概要

実機テストのフィードバック対応（Sprint #37）。解析が完了しても結果の通知がなく「解析中…」のまま成否が分からない事象を修正する。

## 変更内容

- **成功時**: 読み取り結果を Alert で明示（金額・日付・店名。読み取れなかった項目は「読み取れず」と表示）→ 全項目 null でプリフィルが起きないケースでも必ず通知される
- **失敗時**: エラー内容を Alert で表示（手入力はそのまま継続可能）
- **タイムアウト**: クライアント側 120 秒（AbortController）を追加し、スピナーが無限に続かないようにする
- 今日/昨日以外の日付の通知を結果メッセージへ統合（Alert の二重表示を解消）

## 影響範囲

apps/mobile の記録画面のみ。

## Test plan

- type-check / lint / test:unit（11 件）グリーン
- 実機（Expo Go）で撮影 → 結果 Alert の表示をユーザー確認予定

## 関連 Issue

- Closes #518
- Sprint: 37

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q