### PR TITLE
feat(web,sandbox): クイック記録にレシート読取（撮影/選択 → 自動プリフィル）を実装する

### DIFF
--- a/apps/sandbox/src/main.tsx
+++ b/apps/sandbox/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import './index.css'
 import { Gallery } from './pages/Gallery'
+import { ReceiptScanPrototype } from './pages/ReceiptScanPrototype'
 import { SandboxNav } from './components/SandboxNav'
 import { HomePrototype } from './pages/HomePrototype'
 import { CategoryTopABPrototype } from './pages/CategoryTopABPrototype'
@@ -33,6 +34,7 @@ createRoot(document.getElementById('root')!).render(
         <Route path="/savings-forecast-palette" element={<SavingsForecastPalettePrototype />} />
         <Route path="/today-status-palette" element={<TodayStatusPalettePrototype />} />
         <Route path="/category-color-palette" element={<CategoryColorPalettePrototype />} />
+        <Route path="/receipt-scan" element={<ReceiptScanPrototype />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/apps/sandbox/src/pages/Gallery.tsx
+++ b/apps/sandbox/src/pages/Gallery.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom'
-import { ArrowRight, LayoutDashboard, PieChart, Settings, CircleUser, Wand2, BarChart2, Receipt, Layers, PiggyBank, SunMedium, Shapes } from 'lucide-react'
+import { ArrowRight, LayoutDashboard, PieChart, Settings, CircleUser, Wand2, BarChart2, Receipt, Layers, PiggyBank, SunMedium, Shapes, Camera } from 'lucide-react'
 
 type PrototypeCard = {
   path: string
@@ -81,6 +81,14 @@ const prototypes: PrototypeCard[] = [
     description: '超好調/好調/注意/危険の4状態。バー・バッジ・インサイトのカラー設計を横並び比較。',
     icon: PiggyBank,
     issue: 'sandbox',
+    status: 'wip' as const,
+  },
+  {
+    path: '/receipt-scan',
+    title: 'レシート読取 — クイック記録組み込み',
+    description: 'QuickEntryDrawer へのレシート読取導線。解析中表示・成功/失敗トースト・プリフィルの挙動デモ（モバイル #515 検証済みパターンの Web 移植）。',
+    icon: Camera,
+    issue: '#521',
     status: 'wip' as const,
   },
   {

--- a/apps/sandbox/src/pages/ReceiptScanPrototype.tsx
+++ b/apps/sandbox/src/pages/ReceiptScanPrototype.tsx
@@ -1,0 +1,190 @@
+/**
+ * ReceiptScanPrototype — クイック記録のレシート読取（#521）
+ *
+ * Web 版 QuickEntryDrawer に追加する「レシート読取」導線のプロトタイプ。
+ * モバイルアプリ（#515/#518）で実機検証済みのパターンを Web の UI 言語へ移植する:
+ * - 金額入力の上に読取ボタン（ブランドカラーの淡色ピル）
+ * - 解析中はスピナー + 所要時間の目安
+ * - 結果は必ずトースト通知（成功: 読取内容 / 失敗: 理由 + 手入力の案内）
+ * - プリフィルのみで自動登録はしない
+ */
+
+import { useState } from 'react'
+import { Camera, Loader2, CheckCircle2, XCircle } from 'lucide-react'
+
+const D = {
+  bg: '#fffdf5',
+  card: '#ffffff',
+  text: '#1c1410',
+  muted: 'rgba(28,20,16,0.42)',
+  border: 'rgba(28,20,16,0.08)',
+  brand: '#f18840',
+  brandLight: '#fff6ee',
+} as const
+
+type Phase = 'idle' | 'scanning' | 'success' | 'failure'
+
+const MOCK_RESULT = { amount: 702, date: '2026-07-09', content: 'ローソン 品川店' }
+
+export function ReceiptScanPrototype() {
+  const [phase, setPhase] = useState<Phase>('idle')
+  const [amount, setAmount] = useState('')
+  const [memo, setMemo] = useState('')
+
+  const runScan = (outcome: 'success' | 'failure') => {
+    setPhase('scanning')
+    setAmount('')
+    setMemo('')
+    setTimeout(() => {
+      if (outcome === 'success') {
+        setAmount(String(MOCK_RESULT.amount))
+        setMemo(MOCK_RESULT.content)
+      }
+      setPhase(outcome)
+    }, 1500)
+  }
+
+  return (
+    <div style={{ minHeight: '100vh', background: D.bg, padding: 24, color: D.text }}>
+      <h1 style={{ fontSize: 18, fontWeight: 800 }}>レシート読取 — クイック記録への組み込み</h1>
+      <p style={{ fontSize: 12, color: D.muted, marginTop: 4 }}>
+        モバイル実機検証済みパターンの Web 移植。ボタンでシナリオを再生できます。
+      </p>
+
+      <div style={{ display: 'flex', gap: 8, margin: '16px 0' }}>
+        <button
+          onClick={() => runScan('success')}
+          style={{ padding: '8px 14px', borderRadius: 10, border: `1px solid ${D.border}`, background: D.card, fontWeight: 700, fontSize: 12 }}
+        >
+          ▶ 成功シナリオ
+        </button>
+        <button
+          onClick={() => runScan('failure')}
+          style={{ padding: '8px 14px', borderRadius: 10, border: `1px solid ${D.border}`, background: D.card, fontWeight: 700, fontSize: 12 }}
+        >
+          ▶ 失敗シナリオ
+        </button>
+      </div>
+
+      {/* ドロワーのモック */}
+      <div
+        style={{
+          maxWidth: 420,
+          background: D.card,
+          borderRadius: 20,
+          border: `1px solid ${D.border}`,
+          boxShadow: '0 8px 32px rgba(28,20,16,0.12)',
+          padding: 20,
+        }}
+      >
+        <div style={{ fontSize: 14, fontWeight: 800, marginBottom: 12 }}>クイック記録</div>
+
+        {/* レシート読取ボタン（追加箇所） */}
+        <button
+          disabled={phase === 'scanning'}
+          onClick={() => runScan('success')}
+          style={{
+            width: '100%',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            padding: '10px 0',
+            borderRadius: 12,
+            border: `1px solid ${D.brand}`,
+            background: D.brandLight,
+            color: D.brand,
+            fontWeight: 700,
+            fontSize: 13,
+            marginBottom: 12,
+            opacity: phase === 'scanning' ? 0.7 : 1,
+          }}
+        >
+          {phase === 'scanning' ? (
+            <>
+              <Loader2 size={15} style={{ animation: 'spin 1s linear infinite' }} />
+              レシートを解析中…（最大2分ほどかかります）
+            </>
+          ) : (
+            <>
+              <Camera size={15} />
+              レシートを読み取って自動入力
+            </>
+          )}
+        </button>
+
+        {/* 金額（プリフィル先） */}
+        <div style={{ fontSize: 11, color: D.muted, fontWeight: 700 }}>支出金額</div>
+        <div
+          style={{
+            fontSize: 32,
+            fontWeight: 800,
+            color: D.brand,
+            background: D.brandLight,
+            borderRadius: 12,
+            padding: '10px 14px',
+            textAlign: 'right',
+            margin: '4px 0 12px',
+          }}
+        >
+          ¥{amount === '' ? '0' : Number(amount).toLocaleString()}
+        </div>
+
+        {/* メモ（プリフィル先） */}
+        <div style={{ fontSize: 11, color: D.muted, fontWeight: 700 }}>メモ（任意）</div>
+        <div
+          style={{
+            borderRadius: 10,
+            border: `1px solid ${D.border}`,
+            padding: '10px 12px',
+            fontSize: 13,
+            color: memo ? D.text : D.muted,
+            marginTop: 4,
+          }}
+        >
+          {memo || '店名・用途など'}
+        </div>
+      </div>
+
+      {/* トースト通知のモック */}
+      {phase === 'success' && (
+        <div style={toastStyle('#ecfaf8', '#35b5a2')}>
+          <CheckCircle2 size={16} color="#35b5a2" />
+          <div>
+            <div style={{ fontWeight: 800, fontSize: 13 }}>レシートを読み取りました</div>
+            <div style={{ fontSize: 12, color: D.muted, whiteSpace: 'pre-line' }}>
+              {`金額: ¥${MOCK_RESULT.amount.toLocaleString()} / 日付: ${MOCK_RESULT.date} / 店名: ${MOCK_RESULT.content}\n内容を確認して登録してください。`}
+            </div>
+          </div>
+        </div>
+      )}
+      {phase === 'failure' && (
+        <div style={toastStyle('#fff1f2', '#f43f5e')}>
+          <XCircle size={16} color="#f43f5e" />
+          <div>
+            <div style={{ fontWeight: 800, fontSize: 13 }}>レシートを解析できませんでした</div>
+            <div style={{ fontSize: 12, color: D.muted }}>
+              明るい場所で撮り直すか、手入力で登録できます。
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style>{`@keyframes spin { from { transform: rotate(0deg) } to { transform: rotate(360deg) } }`}</style>
+    </div>
+  )
+}
+
+function toastStyle(bg: string, border: string): React.CSSProperties {
+  return {
+    display: 'flex',
+    gap: 10,
+    alignItems: 'flex-start',
+    maxWidth: 420,
+    marginTop: 16,
+    padding: '12px 14px',
+    borderRadius: 12,
+    background: bg,
+    border: `1px solid ${border}`,
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,13 @@ const nextConfig: NextConfig = {
   // コンテナデプロイ用: standalone モードで最小ランタイムを出力
   output: "standalone",
 
+  experimental: {
+    serverActions: {
+      // レシート画像（最大約7MB）を Server Action で受けるため既定の 1MB から拡大（#521）
+      bodySizeLimit: "8mb",
+    },
+  },
+
   // ─── Layer 3: セキュリティヘッダー ─────────────────────────────────────────
   async headers() {
     return [

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -1,13 +1,15 @@
 "use client";
 
-import { useActionState, useState, useEffect, useCallback } from "react";
+import { useActionState, useState, useEffect, useCallback, useRef, useTransition } from "react";
 import {
-  Delete, PenLine, ChevronDown, Receipt, Check,
+  Delete, PenLine, ChevronDown, Receipt, Check, Camera, Loader2,
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Drawer, DrawerContent, DrawerTitle } from "@/components/ui/drawer";
 import { formatLivingMarginImpact } from "@budget/common";
+import { toast } from "sonner";
 import { createExpenseAction } from "@/lib/actions/expense";
+import { scanReceiptAction } from "@/lib/actions/receipt";
 import type { ExpenseActionState } from "@/lib/actions/expense";
 import type { DailyBudgetSnapshot } from "@/components/providers/LivingMarginProvider";
 import type { CategoryItem } from "@/lib/api/types";
@@ -50,6 +52,40 @@ export function QuickEntryDrawer({
   const [memo, setMemo] = useState("");
   const [date] = useState<string>(() => new Date().toISOString().slice(0, 10));
   const [state, formAction, isPending] = useActionState(createExpenseAction, initialState);
+
+  // レシート読取（#521）: 解析結果はプリフィルのみ。登録は必ずユーザーが確認する
+  const receiptInputRef = useRef<HTMLInputElement>(null);
+  const [isScanning, startScanTransition] = useTransition();
+
+  const handleReceiptFile = (file: File) => {
+    startScanTransition(async () => {
+      const formData = new FormData();
+      formData.append("receipt", file);
+      const result = await scanReceiptAction(formData);
+
+      if (result.status === "error") {
+        // 失敗しても手入力はそのまま継続できる
+        toast.error("レシートを解析できませんでした", { description: result.message });
+        return;
+      }
+
+      if (result.amount != null) {
+        setAmountStr(String(Math.min(result.amount, MAX_AMOUNT)));
+      }
+      if (result.content != null) {
+        setMemo(result.content);
+      }
+      const dateNote =
+        result.date != null && result.date !== date ? `（日付 ${result.date} は本日扱いになります）` : "";
+      const summary = [
+        result.amount != null ? `金額: ¥${result.amount.toLocaleString()}` : "金額: 読み取れず",
+        result.content != null ? `店名: ${result.content}` : "店名: 読み取れず",
+      ].join(" / ");
+      toast.success("レシートを読み取りました", {
+        description: `${summary}${dateNote} — 内容を確認して登録してください`,
+      });
+    });
+  };
 
   // 登録成功後の一時的な成功フィードバック（✓ 記録しました！）表示中フラグ
   const [justSubmitted, setJustSubmitted] = useState(false);
@@ -204,6 +240,46 @@ export function QuickEntryDrawer({
               </motion.button>
             ))}
           </div>
+
+          {/* レシート読取（#521） */}
+          <button
+            type="button"
+            onClick={() => receiptInputRef.current?.click()}
+            disabled={isScanning || isPending}
+            className="flex shrink-0 items-center justify-center gap-2 py-2.5 text-[13px] font-bold"
+            style={{
+              borderRadius: "12px",
+              border: "1px solid var(--color-brand-primary)",
+              background: "var(--color-brand-light)",
+              color: "var(--color-brand-primary)",
+              opacity: isScanning ? 0.7 : 1,
+            }}
+          >
+            {isScanning ? (
+              <>
+                <Loader2 size={15} className="animate-spin" />
+                レシートを解析中…（最大2分ほどかかります）
+              </>
+            ) : (
+              <>
+                <Camera size={15} />
+                レシートを読み取って自動入力
+              </>
+            )}
+          </button>
+          <input
+            ref={receiptInputRef}
+            type="file"
+            accept="image/jpeg,image/png"
+            capture="environment"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              // 同じファイルを再選択できるよう毎回リセットする
+              e.target.value = "";
+              if (file) handleReceiptFile(file);
+            }}
+          />
 
           {/* 金額表示パネル */}
           <div

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -69,7 +69,8 @@ export function QuickEntryDrawer({
         return;
       }
 
-      if (result.amount != null) {
+      // API 側で整数・正数に正規化済みだが、キーパッドが整数前提のため防衛的に検証する
+      if (result.amount != null && Number.isInteger(result.amount) && result.amount > 0) {
         setAmountStr(String(Math.min(result.amount, MAX_AMOUNT)));
       }
       if (result.content != null) {

--- a/apps/web/src/lib/actions/receipt.ts
+++ b/apps/web/src/lib/actions/receipt.ts
@@ -1,0 +1,52 @@
+"use server";
+
+import { serverFetch, ApiError } from "../api/client";
+
+export type ReceiptScanActionResult =
+  | {
+      status: "success";
+      amount: number | null;
+      date: string | null;
+      content: string | null;
+      source: "claude-cli" | "claude-api" | "ocr";
+    }
+  | { status: "error"; message: string };
+
+const ALLOWED_MIME_TYPES = ["image/jpeg", "image/png"] as const;
+/** API 側の受領上限（base64 で約10M文字 ≒ 元画像 約7MB）に合わせる */
+const MAX_FILE_BYTES = 7 * 1024 * 1024;
+
+type ReceiptScanResponse = {
+  amount: number | null;
+  date: string | null;
+  content: string | null;
+  source: "claude-cli" | "claude-api" | "ocr";
+};
+
+/** レシート画像を解析 API へ転送する（結果はプリフィル用。登録はしない） */
+export async function scanReceiptAction(formData: FormData): Promise<ReceiptScanActionResult> {
+  const file = formData.get("receipt");
+  if (!(file instanceof File) || file.size === 0) {
+    return { status: "error", message: "画像が選択されていません" };
+  }
+  if (!ALLOWED_MIME_TYPES.includes(file.type as (typeof ALLOWED_MIME_TYPES)[number])) {
+    return { status: "error", message: "JPEG または PNG 画像を選択してください" };
+  }
+  if (file.size > MAX_FILE_BYTES) {
+    return { status: "error", message: "画像サイズが大きすぎます（7MB 以下にしてください）" };
+  }
+
+  const imageBase64 = Buffer.from(await file.arrayBuffer()).toString("base64");
+
+  try {
+    const result = await serverFetch<ReceiptScanResponse>("/api/receipt-scan", {
+      method: "POST",
+      body: JSON.stringify({ image: imageBase64, mimeType: file.type }),
+    });
+    return { status: "success", ...result };
+  } catch (e) {
+    const message =
+      e instanceof ApiError ? e.message : "レシートの解析に失敗しました。時間をおいて再試行してください";
+    return { status: "error", message };
+  }
+}


### PR DESCRIPTION
## 概要

モバイル（#515/#518）で実機検証済みのレシート読取を Web のクイック記録へ展開する（Sprint #38・ユーザー要望）。API（POST /api/receipt-scan #514）は実装済みのため、フロントエンドのみの変更。

## 変更内容

- **サンドボックス**: `/receipt-scan` プロトタイプを追加（ボタン・解析中・成功/失敗トーストの挙動デモ）。ユーザー承認により本実装まで一括実施
- **QuickEntryDrawer**: セグメント直下に「レシートを読み取って自動入力」ボタン。`input[type=file] accept=image/* capture` — スマホブラウザはカメラ直起動、PC はファイル選択（Permissions-Policy `camera=()` は getUserMedia のみ対象のため影響なし）
- **scanReceiptAction**（Server Action）: File → base64 → serverFetch で API へ転送（Cookie JWT の認証をそのまま利用）。MIME/サイズ（7MB）検証
- **通知**: sonner トーストで成功（読取内容 + 確認案内）/ 失敗（理由）を必ず表示。金額・メモをプリフィル、日付はドロワー仕様上本日固定のため差異があれば注記。**自動登録はしない**
- **next.config**: Server Actions `bodySizeLimit: 8mb`（既定 1MB では写真が超過）

## 環境ごとの解析経路（#514 のフォールバックがそのまま適用）

ローカル開発 = claude CLI（課金ゼロ）/ 本番（キー未設定）= OCR（課金ゼロ）/ キー設定時 = Claude API（制限つき）

## 影響範囲

- QuickEntryDrawer の既存の登録フロー・キーパッド操作は不変（追加ボタンのみ）
- sandbox の TypeScript 既存エラー 4 件（MeisaiPrototype）は本 PR と無関係の pre-existing

## 規約・設計チェック

- [x] UI/UX 変更: 規約どおり apps/sandbox にプロトタイプを追加（/receipt-scan）。ユーザーの事前承認により本実装まで一括
- [x] ユビキタス言語 / 境界 / ID / マジックナンバー: 遵守（上限は定数化）
- [x] SSOT マップ更新: 該当なし

## Test plan

- web: type-check / eslint / test:unit 134 件 / next build（standalone）すべてグリーン
- sandbox: 追加 3 ファイルは tsc エラーなし（既存 4 エラーは main 由来）
- API 経路は #516 で実画像検証済み（トンネル経由 11〜12 秒で正確抽出）

## 関連 Issue

- Closes #521
- Sprint: 38

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q