### PR TITLE
fix(web,ci): E2E フレーキー（#437）を恒久対応する（revalidatePath 撤去 + standalone 起動）

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -607,11 +607,21 @@ jobs:
           DATABASE_URL: "mysql://Admin:password@127.0.0.1:3307/budgetdb_test"
         run: pnpm --filter web run build
 
-      - name: Start Next.js (production)
+      # output: standalone 構成では `next start` が非対応（Next 16 が明示警告）で、
+      # Server Action 応答の不安定化 = E2E フレーキー（#437）の温床になるため、
+      # 本番と同じ standalone server.js で起動する。
+      # standalone は .env.local を読まないため gen:keys の出力を明示的に環境へ載せる。
+      - name: Start Next.js (production, standalone)
         env:
           DATABASE_URL: "mysql://Admin:password@127.0.0.1:3307/budgetdb_test"
           INTERNAL_API_URL: "http://localhost:5000"
-        run: pnpm --filter web run start &
+          PORT: "3000"
+        run: |
+          cp -r apps/web/public apps/web/.next/standalone/apps/web/
+          mkdir -p apps/web/.next/standalone/apps/web/.next
+          cp -r apps/web/.next/static apps/web/.next/standalone/apps/web/.next/
+          set -a; source apps/web/.env.local; set +a
+          node apps/web/.next/standalone/apps/web/server.js &
 
       - name: Wait for Next.js
         run: npx wait-on tcp:3000 --timeout 60000

--- a/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
@@ -4,7 +4,8 @@ import * as React from 'react'
 import { ExpenseCreateForm } from '../../components/expense/ExpenseCreateForm'
 import type { CategoryItem } from '@/lib/api/types'
 
-const routerRefresh = vi.fn();
+// vi.mock はホイストされるため、参照する変数は vi.hoisted で先に初期化する
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
 }));

--- a/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseCreateForm.test.tsx
@@ -4,6 +4,12 @@ import * as React from 'react'
 import { ExpenseCreateForm } from '../../components/expense/ExpenseCreateForm'
 import type { CategoryItem } from '@/lib/api/types'
 
+const routerRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
+}));
+
+
 // Server Actionをモック
 vi.mock('@/lib/actions/expense', () => ({
     createExpenseAction: vi.fn(),

--- a/apps/web/src/__tests__/components/ExpenseEditModal.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseEditModal.test.tsx
@@ -4,6 +4,12 @@ import * as React from 'react'
 import { ExpenseEditModal } from '../../components/expense/ExpenseEditModal'
 import type { ExpenseResponse, CategoryItem } from '@/lib/api/types'
 
+const routerRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
+}));
+
+
 // Server Action をモック
 vi.mock('@/lib/actions/expense', () => ({
     updateExpenseAction: vi.fn(),

--- a/apps/web/src/__tests__/components/ExpenseEditModal.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseEditModal.test.tsx
@@ -4,7 +4,8 @@ import * as React from 'react'
 import { ExpenseEditModal } from '../../components/expense/ExpenseEditModal'
 import type { ExpenseResponse, CategoryItem } from '@/lib/api/types'
 
-const routerRefresh = vi.fn();
+// vi.mock はホイストされるため、参照する変数は vi.hoisted で先に初期化する
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
 }));

--- a/apps/web/src/__tests__/components/ExpenseInputModal.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseInputModal.test.tsx
@@ -2,6 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ExpenseInputModal } from '../../components/input/ExpenseInputModal'
 
+const routerRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
+}));
+
+
 const mockCreateExpenseAction = vi.fn().mockResolvedValue({ error: null, success: true })
 vi.mock('@/lib/actions/expense', () => ({
     createExpenseAction: (...args: unknown[]) => mockCreateExpenseAction(...args),

--- a/apps/web/src/__tests__/components/ExpenseInputModal.test.tsx
+++ b/apps/web/src/__tests__/components/ExpenseInputModal.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ExpenseInputModal } from '../../components/input/ExpenseInputModal'
 
-const routerRefresh = vi.fn();
+// vi.mock はホイストされるため、参照する変数は vi.hoisted で先に初期化する
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
 }));

--- a/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
@@ -3,6 +3,12 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QuickEntryDrawer } from "@/components/expense/QuickEntryDrawer";
 import type { CategoryItem } from "@/lib/api/types";
 
+const routerRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
+}));
+
+
 // vaul の Drawer はポータルを使うため、テスト環境では DOM への描画を確認する
 vi.mock("@/lib/actions/expense", () => ({
   createExpenseAction: vi.fn().mockResolvedValue({ error: null, success: false }),

--- a/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
+++ b/apps/web/src/__tests__/components/QuickEntryDrawer.test.tsx
@@ -3,7 +3,8 @@ import { render, screen, fireEvent, act } from "@testing-library/react";
 import { QuickEntryDrawer } from "@/components/expense/QuickEntryDrawer";
 import type { CategoryItem } from "@/lib/api/types";
 
-const routerRefresh = vi.fn();
+// vi.mock はホイストされるため、参照する変数は vi.hoisted で先に初期化する
+const { routerRefresh } = vi.hoisted(() => ({ routerRefresh: vi.fn() }));
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn(), refresh: routerRefresh }),
 }));

--- a/apps/web/src/components/expense/ExpenseCreateForm.tsx
+++ b/apps/web/src/components/expense/ExpenseCreateForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useActionState, useState } from "react";
+import { useActionState, useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import { ChevronDown } from "lucide-react";
 import { createExpenseAction } from "@/lib/actions/expense";
 import type { ExpenseActionState } from "@/lib/actions/expense";
@@ -36,6 +37,12 @@ export function ExpenseCreateForm({ userId, defaultDate, defaultBalanceType = 0,
     createExpenseAction,
     initialState,
   );
+  const router = useRouter();
+
+  // 登録成功後に一覧・ホームのサーバーデータを更新する（action 内 revalidatePath は #437 のため禁止）
+  useEffect(() => {
+    if (state.success) router.refresh();
+  }, [state, router]);
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;
 
   // 種別に応じたアクセントカラー

--- a/apps/web/src/components/expense/ExpenseCreateForm.tsx
+++ b/apps/web/src/components/expense/ExpenseCreateForm.tsx
@@ -42,6 +42,9 @@ export function ExpenseCreateForm({ userId, defaultDate, defaultBalanceType = 0,
   // 登録成功後に一覧・ホームのサーバーデータを更新する（action 内 revalidatePath は #437 のため禁止）
   useEffect(() => {
     if (state.success) router.refresh();
+    // 依存は state（オブジェクト identity）であることが重要:
+    // 連続登録では success が true のまま新しい state が返るため、
+    // state.success を依存にすると 2 回目以降の登録で refresh されない
   }, [state, router]);
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;
 

--- a/apps/web/src/components/expense/ExpenseEditModal.tsx
+++ b/apps/web/src/components/expense/ExpenseEditModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { updateExpenseAction } from "@/lib/actions/expense";
 import type { UpdateExpenseActionState } from "@/lib/actions/expense";
 import type { ExpenseResponse, CategoryItem } from "@/lib/api/types";
@@ -28,6 +29,7 @@ type Props = {
 const initialState: UpdateExpenseActionState = { error: null, success: false };
 
 export function ExpenseEditModal({ expense, onClose, expenseCategories, incomeCategories }: Props) {
+  const router = useRouter();
   const boundAction = updateExpenseAction.bind(null, expense.id);
   const [state, formAction, isPending] = useActionState(boundAction, initialState);
   const [balanceType, setBalanceType] = useState<0 | 1>(expense.balanceType);
@@ -37,9 +39,11 @@ export function ExpenseEditModal({ expense, onClose, expenseCategories, incomeCa
   // 更新成功時にモーダルを閉じる
   useEffect(() => {
     if (state.success) {
+      // action 内 revalidatePath は #437 のため禁止。ここでサーバーデータを更新する
+      router.refresh();
       onClose();
     }
-  }, [state.success, onClose]);
+  }, [state.success, onClose, router]);
 
   return (
     <Dialog open={true} onOpenChange={(open) => !open && onClose()}>

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -131,6 +131,9 @@ export function QuickEntryDrawer({
   // 成功フィードバック表示とは独立にここで refresh する
   useEffect(() => {
     if (state.success) router.refresh();
+    // 依存は state（オブジェクト identity）であることが重要:
+    // 連続登録では success が true のまま新しい state が返るため、
+    // state.success を依存にすると 2 回目以降の登録で refresh されない
   }, [state, router]);
 
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;

--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useActionState, useState, useEffect, useCallback, useRef, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import {
   Delete, PenLine, ChevronDown, Receipt, Check, Camera, Loader2,
 } from "lucide-react";
@@ -45,6 +46,7 @@ export function QuickEntryDrawer({
   effectiveDailyExpense = null,
   dailyBudget = null,
 }: Props) {
+  const router = useRouter();
   const [balanceType, setBalanceType] = useState<0 | 1>(0);
   const [categoryId, setCategoryId] = useState<number>(expenseCategories[0]?.id ?? 0);
   const [amountStr, setAmountStr] = useState("");
@@ -123,6 +125,13 @@ export function QuickEntryDrawer({
     const timer = setTimeout(() => setJustSubmitted(false), SUCCESS_FEEDBACK_MS);
     return () => clearTimeout(timer);
   }, [justSubmitted]);
+
+  // 登録成功後にホームの数値（サーバーコンポーネント由来）を更新する。
+  // action 内の revalidatePath は isPending ハングの原因になるため（#437）、
+  // 成功フィードバック表示とは独立にここで refresh する
+  useEffect(() => {
+    if (state.success) router.refresh();
+  }, [state, router]);
 
   const categories = balanceType === 0 ? expenseCategories : incomeCategories;
   const visible = showAll ? categories : categories.slice(0, VISIBLE_COUNT);

--- a/apps/web/src/components/input/ExpenseInputModal.tsx
+++ b/apps/web/src/components/input/ExpenseInputModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { motion, AnimatePresence } from "framer-motion";
 import { calcExpenseImpact } from "@budget/common";
+import { useRouter } from "next/navigation";
 import { createExpenseAction } from "@/lib/actions/expense";
 import type { ExpenseActionState } from "@/lib/actions/expense";
 import { SPRING } from "@/lib/motion";
@@ -47,6 +48,7 @@ interface Props {
 }
 
 export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
+  const router = useRouter();
   const [balanceType, setBalanceType] = useState<0 | 1>(0);
   const [amountStr, setAmountStr] = useState("");
   const [categoryId, setCategoryId] = useState(EXPENSE_CATS[0].id);
@@ -100,6 +102,8 @@ export function ExpenseInputModal({ userId, minutesPerYen, onClose }: Props) {
     startTransition(async () => {
       const result = await createExpenseAction(INITIAL_STATE, fd);
       if (result.success) {
+        // action 内 revalidatePath は #437 のため禁止。ここでサーバーデータを更新する
+        router.refresh();
         setSubmitted(true);
         setTimeout(() => {
           setSubmitted(false);

--- a/apps/web/src/lib/actions/expense.ts
+++ b/apps/web/src/lib/actions/expense.ts
@@ -1,6 +1,5 @@
 "use server";
 
-import { revalidatePath } from "next/cache";
 import { serverFetch, ApiError } from "../api/client";
 import { createExpenseSchema, updateExpenseSchema } from "@budget/common";
 import type { GetExpenseResponse } from "../api/types";
@@ -57,8 +56,10 @@ export async function createExpenseAction(
     return { error: "支出の登録に失敗しました", success: false };
   }
 
-  revalidatePath("/");
-  revalidatePath("/expenses");
+  // 注意: ここで revalidatePath を呼んではならない（#437）。
+  // action 応答に RSC 再レンダーが同梱されると、遅い環境で useActionState の
+  // isPending が解除されないクライアント側ハングが発生する。
+  // 画面データの更新は呼び出し側が成功後に router.refresh() で行う。
   return {
     error: null,
     success: true,
@@ -117,14 +118,11 @@ export async function updateExpenseAction(
     return { error: "支出の更新に失敗しました", success: false };
   }
 
-  revalidatePath("/");
-  revalidatePath("/expenses");
+  // revalidatePath は使わない（#437: isPending ハングの原因）。呼び出し側で router.refresh() する
   return { error: null, success: true };
 }
 
-/** 支出を削除する Server Action */
+/** 支出を削除する Server Action（呼び出し側で成功後に router.refresh() すること。#437） */
 export async function deleteExpenseAction(id: string): Promise<void> {
   await serverFetch(`/api/expense/${id}`, { method: "DELETE" });
-  revalidatePath("/");
-  revalidatePath("/expenses");
 }


### PR DESCRIPTION
## 概要

9 スプリント持ち越し・本日だけで 6 run の rerun を発生させた E2E フレーキー（#437）の恒久対応（Sprint #39）。2 層の原因に同時対処する。

## 原因と対応

### ① クライアント側ハング（CI トレースで確認済みの直接原因）

Server Action の POST は 200/50ms で完了しデータも作成されるのに、`useActionState` の isPending が解除されず「登録中…」のまま 30 秒超固まる（遅い CI ランナーで顕在化）。action 内の `revalidatePath` により応答へ RSC 再レンダーが同梱されることが引き金。

→ **expense 系 action から revalidatePath を撤去**し、4 コンシューマーで成功後に `router.refresh()` を実行。成功フィードバックの表示がデータ再取得から独立し、ハングが構造的に発生しなくなる。

### ② 非対応構成の排除（不安定化の温床）

CI の E2E は `next start` で web を起動しているが、**`output: standalone` 構成では next start が非対応**（Next 16 が明示警告）。

→ **本番と同じ standalone server.js 起動へ変更**（アセットコピー + gen:keys の鍵を source）。E2E 環境と本番の起動方式も統一される。

## Test plan

- クリーンな CI 同等環境（DROP → migrate deploy → seed で再構築した test DB + standalone server.js）で、フレーキーだった 3 spec（budget-flow / expense / living-margin）× 5 回 = **51/51 パス（43 秒・リトライなし）**
- web 単体テスト 134 件パス（next/navigation モック追加込み）/ type-check / lint / next build グリーン
- 検証過程で判明したローカル再現の落とし穴（残置プロセス・standalone の .env 非読込・db push 由来のゼロ日付）は自動メモリに記録済み

## 影響範囲

- 画面挙動: 登録成功後のデータ更新が revalidatePath → router.refresh() に変わる（ユーザー体感は同等。成功表示はむしろ早くなる）
- CI: E2E の web 起動方式のみ変更（テスト内容は不変）

## 規約・設計チェック

- [x] UI/UX 変更なし（内部機構のみ）/ ユビキタス言語・境界・ID: 該当なし
- [x] SSOT マップ更新: 該当なし

## 関連 Issue

- Closes #437
- Sprint: 39

## 備考

- 本 PR 以降の CI で E2E rerun が必要になった場合は、#437 を再オープンして新しい証拠を記録する運用とする

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q
