### PR TITLE
fix(web): レシート読取で写真ライブラリからの画像選択を可能にする

### DIFF
--- a/apps/web/src/components/expense/QuickEntryDrawer.tsx
+++ b/apps/web/src/components/expense/QuickEntryDrawer.tsx
@@ -276,7 +276,6 @@ export function QuickEntryDrawer({
             ref={receiptInputRef}
             type="file"
             accept="image/jpeg,image/png"
-            capture="environment"
             className="hidden"
             onChange={(e) => {
               const file = e.target.files?.[0];


### PR DESCRIPTION
## 概要

実機確認でのユーザー要望（Sprint #41）。capture=environment がカメラを強制起動するため、撮影済みレシート（写真ライブラリ）を選択できなかった。

## 変更内容

- input[type=file] の capture 属性を削除（1 行）。スマホブラウザでは OS の選択メニュー（写真ライブラリ / 写真を撮る / ファイルを選択）が表示され、カメラ撮影も引き続き可能
- デスクトップは従来どおりファイル選択ダイアログ

## Test plan

- web: type-check / eslint / test:unit 134 件グリーン
- 実機: デプロイ後にライブラリ選択 → 解析 → プリフィルをユーザー確認

## 影響範囲

レシート読取ボタンの画像取得方法のみ。解析・プリフィル・通知は不変。

## 規約・設計チェック

- [x] UI/UX 変更: OS ネイティブメニューへの委譲のみ（新規デザインなし・サンドボックス対象外）

## 関連 Issue

- Closes #531
- Sprint: 41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q