### PR TITLE
fix(mobile): タブ中央の「＋（記録）」ボタンが左下に未スタイルで表示される問題を修正する

### DIFF
--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -63,7 +63,8 @@ export default function TabsLayout() {
 
       <Pressable
         style={[styles.centerButton, { bottom: insets.bottom + 22 }]}
-        onPress={() => router.push('/entry')}
+        // navigate は同一ルートの重複プッシュを抑止する（連打対策）
+        onPress={() => router.navigate('/entry')}
         accessibilityRole="button"
         accessibilityLabel="記録する"
       >

--- a/apps/mobile/src/app/(tabs)/_layout.tsx
+++ b/apps/mobile/src/app/(tabs)/_layout.tsx
@@ -1,4 +1,4 @@
-import { Link, Tabs } from 'expo-router';
+import { Tabs, useRouter } from 'expo-router';
 import { BarChart2, Home, Plus, Receipt, Settings } from 'lucide-react-native';
 import { Pressable, StyleSheet, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -11,6 +11,7 @@ import { colors } from '@/theme/tokens';
  */
 export default function TabsLayout() {
   const insets = useSafeAreaInsets();
+  const router = useRouter();
 
   return (
     <View style={styles.root}>
@@ -60,15 +61,14 @@ export default function TabsLayout() {
         />
       </Tabs>
 
-      <Link href="/entry" asChild>
-        <Pressable
-          style={[styles.centerButton, { bottom: insets.bottom + 22 }]}
-          accessibilityRole="button"
-          accessibilityLabel="記録する"
-        >
-          <Plus size={26} color={colors.surface} strokeWidth={3} />
-        </Pressable>
-      </Link>
+      <Pressable
+        style={[styles.centerButton, { bottom: insets.bottom + 22 }]}
+        onPress={() => router.push('/entry')}
+        accessibilityRole="button"
+        accessibilityLabel="記録する"
+      >
+        <Plus size={26} color={colors.surface} strokeWidth={3} />
+      </Pressable>
     </View>
   );
 }
@@ -82,7 +82,10 @@ const styles = StyleSheet.create({
   },
   centerButton: {
     position: 'absolute',
-    alignSelf: 'center',
+    // alignSelf: center は絶対配置との組み合わせで実機の挙動が不安定なため、
+    // left 50% + 幅の半分のマージン補正で決定的にセンタリングする（#534）
+    left: '50%',
+    marginLeft: -28,
     width: 56,
     height: 56,
     borderRadius: 28,


### PR DESCRIPTION
## 概要

実機報告（IMG_4051）: タブバー中央の「＋（記録）」ボタンが表示されず、画面左下隅に小さな + が未スタイルのまま表示される（Sprint #42・P0）。

## 原因

画面ルートへの絶対配置オーバーレイ（#511 のはみ出しタップ不能対策）で、水平センタリングに `position: absolute` + `alignSelf: 'center'` を使用していた。この組み合わせは RN/Yoga のバージョンにより絶対配置要素への適用挙動が変わり、実機（Expo Go / RN 0.81）では位置がリセットされ左下に落ちる。Link asChild 経由の style 伝播も要因になり得るため排除した。

## 変更内容

- センタリングを `left: '50%'` + `marginLeft: -28`（幅の半分）の決定的な指定へ変更
- `Link asChild` → `Pressable` + `router.push('/entry')` に単純化

## Test plan

- mobile: type-check / lint / test:unit 11 件グリーン
- 実機: Metro が本ブランチを配信中 — Expo Go リロードで中央ボタンの表示・タップを確認（ユーザー確認待ち）

## 関連 Issue

- Closes #534
- Sprint: 42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q