### PR TITLE
fix(mobile,common): 記録画面のカテゴリタイル・日付選択を Web と同一デザインへ統一する

### DIFF
--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -301,7 +301,7 @@ export default function EntryScreen() {
                           backgroundColor: category.bg,
                           // Web と同一: カテゴリ色の 25% 透過枠（#RRGGBB40）
                           borderColor: `${category.color}40`,
-                          borderWidth: 1.5,
+                          borderWidth: 2,
                         },
                       ]}
                       onPress={() => setCategoryId(category.id)}
@@ -532,9 +532,9 @@ const styles = StyleSheet.create({
     gap: 6,
   },
   categoryTile: {
-    // Web と同一の 4 列グリッド: (100% - gap 3 つ) / 4
-    flexBasis: '23%',
-    flexGrow: 1,
+    // Web と同一の 4 列グリッド: (100% - gap 3 つ) / 4。
+    // flexGrow は使わない（総数が4の倍数でないとき最終行が伸びて崩れるため）
+    flexBasis: '23.5%',
     alignItems: 'center',
     gap: 4,
     paddingVertical: 8,

--- a/apps/mobile/src/app/entry.tsx
+++ b/apps/mobile/src/app/entry.tsx
@@ -18,6 +18,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useAuth } from '@/lib/auth/auth-context';
 import { useCategories } from '@/lib/api/use-categories';
+import { getCategoryIcon } from '@/lib/categoryIcons';
 import { useCreateExpense } from '@/lib/api/use-create-expense';
 import { useReceiptScan } from '@/lib/api/use-receipt-scan';
 import { colors } from '@/theme/tokens';
@@ -169,7 +170,7 @@ export default function EntryScreen() {
         balanceType,
         userId,
         date: toDateString(date),
-        ...(categoryId !== null ? { categoryId } : {}),
+        ...(effectiveCategoryId !== null ? { categoryId: effectiveCategoryId } : {}),
         ...(content ? { content } : {}),
       });
       // 二重登録防止のため入力をリセットしてから戻る（Web #478 と同じ方針）
@@ -187,6 +188,8 @@ export default function EntryScreen() {
   const allCategories = categories ?? [];
   const visibleCategories = showAll ? allCategories : allCategories.slice(0, VISIBLE_COUNT);
   const restCount = Math.max(0, allCategories.length - VISIBLE_COUNT);
+  // Web と同一挙動: 常にいずれか1つ選択（既定は表示順の先頭）・選択解除なし
+  const effectiveCategoryId = categoryId ?? allCategories[0]?.id ?? null;
 
   return (
     <SafeAreaView
@@ -277,7 +280,7 @@ export default function EntryScreen() {
           {/* カテゴリ（表示順 4 件 + もっと見る — Web と同一） */}
           <View style={styles.categoryHeader}>
             <Text style={styles.label}>カテゴリ</Text>
-            <Text style={styles.labelNote}>よく使う順</Text>
+            {!showAll && <Text style={styles.labelNote}>よく使う順</Text>}
           </View>
           {categoriesLoading ? (
             <ActivityIndicator color={colors.brandPrimary} />
@@ -285,22 +288,36 @@ export default function EntryScreen() {
             <Text style={styles.error}>カテゴリの取得に失敗しました。通信環境を確認してください</Text>
           ) : (
             <>
-              <View style={styles.chips}>
+              <View style={styles.categoryGrid}>
                 {visibleCategories.map((category) => {
-                  const selected = categoryId === category.id;
+                  const selected = effectiveCategoryId === category.id;
+                  const Icon = getCategoryIcon(category.key);
                   return (
                     <Pressable
                       key={category.id}
                       style={[
-                        styles.chip,
-                        { backgroundColor: category.bg },
-                        selected && { borderColor: category.color, borderWidth: 2 },
+                        styles.categoryTile,
+                        selected && {
+                          backgroundColor: category.bg,
+                          // Web と同一: カテゴリ色の 25% 透過枠（#RRGGBB40）
+                          borderColor: `${category.color}40`,
+                          borderWidth: 1.5,
+                        },
                       ]}
-                      onPress={() => setCategoryId(selected ? null : category.id)}
+                      onPress={() => setCategoryId(category.id)}
                       disabled={createExpense.isPending}
                       accessibilityRole="button"
                     >
-                      <Text style={[styles.chipLabel, { color: category.color }]}>
+                      <Icon
+                        size={16}
+                        color={selected ? category.color : 'rgba(28,20,16,0.35)'}
+                      />
+                      <Text
+                        style={[
+                          styles.categoryTileLabel,
+                          { color: selected ? category.color : 'rgba(28,20,16,0.55)' },
+                        ]}
+                      >
                         {category.name}
                       </Text>
                     </Pressable>
@@ -314,8 +331,8 @@ export default function EntryScreen() {
                   accessibilityRole="button"
                 >
                   <ChevronDown
-                    size={14}
-                    color={colors.foreground}
+                    size={12}
+                    color="rgba(28,20,16,0.45)"
                     style={showAll ? { transform: [{ rotate: '180deg' }] } : undefined}
                   />
                   <Text style={styles.moreLabel}>
@@ -509,34 +526,43 @@ const styles = StyleSheet.create({
     color: colors.foreground,
     opacity: 0.4,
   },
-  chips: {
+  categoryGrid: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    gap: 8,
+    gap: 6,
   },
-  chip: {
-    borderRadius: 10,
-    paddingHorizontal: 14,
+  categoryTile: {
+    // Web と同一の 4 列グリッド: (100% - gap 3 つ) / 4
+    flexBasis: '23%',
+    flexGrow: 1,
+    alignItems: 'center',
+    gap: 4,
     paddingVertical: 8,
-    borderWidth: 2,
-    borderColor: 'transparent',
+    borderRadius: 10,
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: 'rgba(28,20,16,0.10)',
   },
-  chipLabel: {
-    fontSize: 13,
-    fontWeight: '700',
+  categoryTileLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    textAlign: 'center',
   },
   moreButton: {
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
     gap: 4,
-    paddingVertical: 4,
+    paddingVertical: 6,
+    borderRadius: 10,
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: 'rgba(28,20,16,0.10)',
   },
   moreLabel: {
-    fontSize: 12,
+    fontSize: 10,
     fontWeight: '600',
-    color: colors.foreground,
-    opacity: 0.6,
+    color: 'rgba(28,20,16,0.45)',
   },
   keypad: {
     flexDirection: 'row',
@@ -569,23 +595,24 @@ const styles = StyleSheet.create({
     gap: 8,
   },
   dateChip: {
-    borderRadius: 999,
+    borderRadius: 10,
     paddingHorizontal: 16,
     paddingVertical: 6,
-    backgroundColor: 'rgba(28,20,16,0.06)',
+    backgroundColor: colors.background,
+    borderWidth: 1,
+    borderColor: 'rgba(28,20,16,0.10)',
   },
   dateChipActive: {
-    backgroundColor: colors.foreground,
+    backgroundColor: colors.brandLight,
+    borderColor: colors.brandPrimary,
   },
   dateChipLabel: {
     fontSize: 12,
     fontWeight: '700',
-    color: colors.foreground,
-    opacity: 0.6,
+    color: 'rgba(28,20,16,0.55)',
   },
   dateChipLabelActive: {
-    color: '#ffffff',
-    opacity: 1,
+    color: colors.brandPrimary,
   },
   input: {
     borderRadius: 10,

--- a/apps/mobile/src/lib/__tests__/categoryIcons.test.ts
+++ b/apps/mobile/src/lib/__tests__/categoryIcons.test.ts
@@ -1,0 +1,16 @@
+import { CATEGORY_ICON_NAMES } from '@budget/common';
+import { CATEGORY_ICON_MAP } from '../categoryIcons';
+
+describe('CATEGORY_ICON_MAP', () => {
+  it('common の CATEGORY_ICON_NAMES（SSOT）と key が完全一致する', () => {
+    expect(Object.keys(CATEGORY_ICON_MAP).sort()).toEqual(Object.keys(CATEGORY_ICON_NAMES).sort());
+  });
+
+  it('各 key のアイコンが SSOT のアイコン名と一致する', () => {
+    for (const [key, iconName] of Object.entries(CATEGORY_ICON_NAMES)) {
+      const component = CATEGORY_ICON_MAP[key] as { displayName?: string; name?: string };
+      const actual = component.displayName ?? component.name;
+      expect(`${key}:${actual}`).toBe(`${key}:${iconName}`);
+    }
+  });
+});

--- a/apps/mobile/src/lib/categoryIcons.ts
+++ b/apps/mobile/src/lib/categoryIcons.ts
@@ -1,0 +1,61 @@
+import type { ComponentType } from 'react';
+import {
+  Banknote,
+  Briefcase,
+  Building2,
+  Car,
+  CircleDashed,
+  Gift,
+  GraduationCap,
+  Heart,
+  Landmark,
+  Music,
+  Scissors,
+  Shield,
+  Shirt,
+  ShoppingBag,
+  ShoppingBasket,
+  Smartphone,
+  Tag,
+  TrendingUp,
+  Users,
+  Utensils,
+  Wallet,
+  Zap,
+} from 'lucide-react-native';
+import type { LucideProps } from 'lucide-react-native';
+
+/**
+ * カテゴリ key → アイコンコンポーネント（Web の lib/categoryTokens.ts と同一の対応）。
+ * 対応の SSOT は @budget/common の CATEGORY_ICON_NAMES。
+ * 乖離は __tests__/categoryIcons.test.ts が検出する（#537）。
+ */
+export const CATEGORY_ICON_MAP: Record<string, ComponentType<LucideProps>> = {
+  food: ShoppingBasket,
+  dining: Utensils,
+  transport: Car,
+  utility: Zap,
+  telecom: Smartphone,
+  housing: Building2,
+  tax: Landmark,
+  medical: Heart,
+  insurance: Shield,
+  daily: ShoppingBag,
+  education: GraduationCap,
+  beauty: Scissors,
+  clothing: Shirt,
+  leisure: Music,
+  other: Tag,
+  unclassified: CircleDashed,
+  salary: Banknote,
+  bonus: Gift,
+  sideJob: Briefcase,
+  pension: Users,
+  benefit: Wallet,
+  investment: TrendingUp,
+};
+
+/** カテゴリ key からアイコンを取得する（未知 key は Tag にフォールバック） */
+export function getCategoryIcon(key: string): ComponentType<LucideProps> {
+  return CATEGORY_ICON_MAP[key] ?? Tag;
+}

--- a/apps/web/src/__tests__/lib/categoryTokens.test.ts
+++ b/apps/web/src/__tests__/lib/categoryTokens.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { CATEGORY_ICON_NAMES } from "@budget/common";
+import { getCategoryIcon } from "@/lib/categoryTokens";
+
+describe("getCategoryIcon", () => {
+  it("common の CATEGORY_ICON_NAMES（SSOT）と各 key のアイコンが一致する", () => {
+    for (const [key, iconName] of Object.entries(CATEGORY_ICON_NAMES)) {
+      const component = getCategoryIcon(key) as { displayName?: string; name?: string };
+      const actual = component.displayName ?? component.name;
+      expect(`${key}:${actual}`).toBe(`${key}:${iconName}`);
+    }
+  });
+
+  it("未知の key は Tag にフォールバックする", () => {
+    const component = getCategoryIcon("unknown-key") as { displayName?: string; name?: string };
+    expect(component.displayName ?? component.name).toBe("Tag");
+  });
+});

--- a/packages/common/src/constants/categoryTokens.ts
+++ b/packages/common/src/constants/categoryTokens.ts
@@ -234,3 +234,36 @@ export function getIncomeCategoryToken(name: string): CategoryColorToken {
 	const key = INCOME_NAME_MAP[name] ?? "other";
 	return INCOME_CATEGORY_TOKENS[key] ?? INCOME_CATEGORY_TOKENS.other;
 }
+
+/**
+ * カテゴリ key → lucide アイコン名の対応表（SSOT）。
+ * Web は lucide-react、モバイルは lucide-react-native から同名アイコンを解決し、
+ * 各プラットフォームの単体テストでこの表との一致を強制する（#537）。
+ */
+export const CATEGORY_ICON_NAMES = {
+	food: 'ShoppingBasket',
+	dining: 'Utensils',
+	transport: 'Car',
+	utility: 'Zap',
+	telecom: 'Smartphone',
+	housing: 'Building2',
+	tax: 'Landmark',
+	medical: 'Heart',
+	insurance: 'Shield',
+	daily: 'ShoppingBag',
+	education: 'GraduationCap',
+	beauty: 'Scissors',
+	clothing: 'Shirt',
+	leisure: 'Music',
+	other: 'Tag',
+	unclassified: 'CircleDashed',
+	salary: 'Banknote',
+	bonus: 'Gift',
+	sideJob: 'Briefcase',
+	pension: 'Users',
+	benefit: 'Wallet',
+	investment: 'TrendingUp',
+} as const;
+
+/** アイコン対応表のフォールバックアイコン名（未知のカテゴリ key 用） */
+export const CATEGORY_FALLBACK_ICON_NAME = 'Tag' as const;


### PR DESCRIPTION
## 概要

ユーザー報告（IMG_4052）: カテゴリ UI（アイコンなし色チップ）と今日/昨日（黒チップ）が Web と異なる（Sprint #43）。Web を SSOT としてデザインを統一し、再発をテストで防ぐ。

## 変更内容

- **packages/common**: CATEGORY_ICON_NAMES（カテゴリ key → lucide アイコン名）を SSOT として新設
- **テストによる強制**: Web（vitest）/ モバイル（jest）双方に「ICON_MAP が SSOT と完全一致」テストを追加。今後どちらかが対応表から乖離すると CI が落ちる
- **モバイル記録画面**:
  - カテゴリ: Web と同一の 4 列タイル（アイコン + ラベル / 白地 + 枠線 / 選択時カテゴリ色背景 + 25% 透過枠 / 選択解除なし・先頭を既定選択）
  - もっと見る: 白地ピル（枠線 + シェブロン、10px）
  - 今日/昨日: 黒チップ → 白地 + 枠線 / 選択時 brandLight + brand 枠（Web の意匠体系）

## Test plan

- common ビルド / web test:unit 136 件（アイコン一致テスト含む）/ mobile test:unit 13 件（同）
- mobile type-check / lint グリーン
- 実機: Metro が本ブランチを配信中 — Expo Go リロードで Web と同一のカテゴリタイルを確認（受け入れ条件・Retro #536 Try の適用第1号）

## 規約・設計チェック

- [x] デザイン SSOT は Web QuickEntryDrawer。今回から対応表レベルで機械的に強制
- [x] SSOT マップ更新: 該当なし

## 関連 Issue

- Closes #537
- Sprint: 43

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QpRZ9hSxtdiCt5bYWoi62q