### PR TITLE
feat(web,mobile,common): 投資余力カードをホームへ本番実装しディープリンク CTA を追加する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,13 @@ JWT_PUBLIC_KEY=-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----
 # Next.js から公開鍵を参照するための変数（NEXT_PUBLIC_ でなくよい — サーバー専用）
 # apps/web/.env.local にも同じ JWT_PUBLIC_KEY を設定すること
 
+# 投資戦略検証ツール（investment-analysis-tool）のベース URL — 投資余力カードの CTA 用
+# 未設定の場合、カードの「戦略の過去検証を見る」リンクは表示されない
+# Web: apps/web/.env.local に NEXT_PUBLIC_INVESTMENT_TOOL_URL を設定
+# モバイル: apps/mobile/.env に EXPO_PUBLIC_INVESTMENT_TOOL_URL を設定
+NEXT_PUBLIC_INVESTMENT_TOOL_URL=
+EXPO_PUBLIC_INVESTMENT_TOOL_URL=
+
 # Claude API（Anthropic SDK）— AI 機能全般に使用
 ANTHROPIC_API_KEY=sk-ant-...
 LLM_MODEL=claude-haiku-4-5-20251001

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -10,6 +10,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { useDashboard, type DashboardData } from '@/lib/api/use-dashboard';
 import { AppHeader } from '@/components/layout/AppHeader';
+import { InvestmentCapacityCard } from '@/components/dashboard/InvestmentCapacityCard';
 import { LivingMarginCard } from '@/components/dashboard/LivingMarginCard';
 import { MonthlySummaryCard } from '@/components/dashboard/MonthlySummaryCard';
 import { TodayStatusCard } from '@/components/dashboard/TodayStatusCard';
@@ -72,6 +73,8 @@ function Dashboard({ data, today }: { data: DashboardData; today?: Date }) {
         lastMonthExpense={data.lastMonthExpense}
         today={today}
       />
+      {/* 投資余力（#543 / #545）。Web と同じく MonthlySummary の後・算出不能時は非表示 */}
+      <InvestmentCapacityCard livingMargin={data.livingMargin} />
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>最近の記録</Text>

--- a/apps/mobile/src/components/dashboard/InvestmentCapacityCard.tsx
+++ b/apps/mobile/src/components/dashboard/InvestmentCapacityCard.tsx
@@ -1,5 +1,5 @@
 import {
-  buildInvestmentDeepLinkQuery,
+  buildInvestmentToolCtaUrl,
   calculateInvestmentCapacity,
   emergencyFundDisplay,
   formatCapacityHoldReason,
@@ -27,11 +27,8 @@ export function InvestmentCapacityCard({ livingMargin }: { livingMargin: LivingM
 
   const fund = emergencyFundDisplay(result.emergencyFundRatio);
   const holdReason = formatCapacityHoldReason(result);
-  const deepLinkQuery = buildInvestmentDeepLinkQuery(result);
-  const ctaUrl =
-    deepLinkQuery && INVESTMENT_TOOL_URL
-      ? `${INVESTMENT_TOOL_URL.replace(/\/$/, '')}/?${deepLinkQuery}`
-      : null;
+  // URL のスキーム検証（http/https 以外は CTA 非表示）・送客可否は common に集約
+  const ctaUrl = buildInvestmentToolCtaUrl(INVESTMENT_TOOL_URL, result);
 
   return (
     <View style={styles.card} testID="investment-capacity-card">
@@ -75,7 +72,7 @@ export function InvestmentCapacityCard({ livingMargin }: { livingMargin: LivingM
 
       {ctaUrl && (
         <Pressable
-          style={styles.cta}
+          style={({ pressed }) => [styles.cta, pressed && styles.ctaPressed]}
           accessibilityRole="link"
           onPress={() => {
             // 端末外ブラウザで検証ツールを開く（失敗しても静かに握りつぶさずログへ）
@@ -179,6 +176,9 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
     paddingVertical: 10,
     alignItems: 'center',
+  },
+  ctaPressed: {
+    opacity: 0.6,
   },
   ctaLabel: {
     fontSize: 12,

--- a/apps/mobile/src/components/dashboard/InvestmentCapacityCard.tsx
+++ b/apps/mobile/src/components/dashboard/InvestmentCapacityCard.tsx
@@ -1,0 +1,195 @@
+import {
+  buildInvestmentDeepLinkQuery,
+  calculateInvestmentCapacity,
+  emergencyFundDisplay,
+  formatCapacityHoldReason,
+  formatYen,
+  INVESTMENT_CAPACITY_TEXT,
+  RISK_TOLERANCE_LABELS,
+  type LivingMarginInputs,
+} from '@budget/common';
+import { Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { colors } from '@/theme/tokens';
+
+/** 検証ツール（investment-analysis-tool）のベース URL。未設定時は CTA を表示しない */
+const INVESTMENT_TOOL_URL = process.env.EXPO_PUBLIC_INVESTMENT_TOOL_URL;
+
+/**
+ * 投資余力カード（Web InvestmentCapacityCard と同一ロジック・同一文言。SSOT は @budget/common）
+ * 「今月は投資を控える月」も正しい結果として肯定形で表示する。
+ * 算出不能のときは何も描画しない（生活余力カード側が案内する）。
+ */
+export function InvestmentCapacityCard({ livingMargin }: { livingMargin: LivingMarginInputs }) {
+  const result = calculateInvestmentCapacity(livingMargin);
+  if (result.status !== 'ok') {
+    return null;
+  }
+
+  const fund = emergencyFundDisplay(result.emergencyFundRatio);
+  const holdReason = formatCapacityHoldReason(result);
+  const deepLinkQuery = buildInvestmentDeepLinkQuery(result);
+  const ctaUrl =
+    deepLinkQuery && INVESTMENT_TOOL_URL
+      ? `${INVESTMENT_TOOL_URL.replace(/\/$/, '')}/?${deepLinkQuery}`
+      : null;
+
+  return (
+    <View style={styles.card} testID="investment-capacity-card">
+      <Text style={styles.title}>{INVESTMENT_CAPACITY_TEXT.title}</Text>
+
+      {result.shouldHold ? (
+        <>
+          <Text style={styles.holdTitle}>{INVESTMENT_CAPACITY_TEXT.holdTitle}</Text>
+          <Text style={styles.note}>{holdReason}</Text>
+        </>
+      ) : (
+        <>
+          <View style={styles.valueRow}>
+            <Text style={styles.valueLabel}>{INVESTMENT_CAPACITY_TEXT.limitLabel}</Text>
+            <Text style={styles.value}>{formatYen(result.monthlyLimitJpy)}</Text>
+          </View>
+          <Text style={styles.tolerance}>
+            リスク許容度: {RISK_TOLERANCE_LABELS[result.riskTolerance]}
+          </Text>
+        </>
+      )}
+
+      {/* 生活防衛資金の充足バー（事実のみ。良好=income / 未充足=caution） */}
+      <View style={styles.fundSection}>
+        <View style={styles.fundLabelRow}>
+          <Text style={styles.fundLabel}>{INVESTMENT_CAPACITY_TEXT.fundLabel}</Text>
+          <Text style={styles.fundPercent}>{fund.percent}%</Text>
+        </View>
+        <View style={styles.barTrack}>
+          <View
+            style={[
+              styles.barFill,
+              {
+                width: `${fund.barPercent}%`,
+                backgroundColor: result.emergencyFundRatio >= 1.0 ? colors.income : colors.caution,
+              },
+            ]}
+          />
+        </View>
+      </View>
+
+      {ctaUrl && (
+        <Pressable
+          style={styles.cta}
+          accessibilityRole="link"
+          onPress={() => {
+            // 端末外ブラウザで検証ツールを開く（失敗しても静かに握りつぶさずログへ）
+            Linking.openURL(ctaUrl).catch((error: unknown) => {
+              console.warn('検証ツールのリンクを開けませんでした', error);
+            });
+          }}
+        >
+          <Text style={styles.ctaLabel}>{INVESTMENT_CAPACITY_TEXT.ctaLabel}</Text>
+        </Pressable>
+      )}
+
+      <Text style={styles.disclaimer}>{INVESTMENT_CAPACITY_TEXT.disclaimer}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.borderDefault,
+    padding: 16,
+    gap: 6,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.foreground,
+  },
+  holdTitle: {
+    fontSize: 18,
+    fontWeight: '800',
+    color: colors.foreground,
+  },
+  note: {
+    fontSize: 12,
+    lineHeight: 18,
+    color: colors.foreground,
+    opacity: 0.55,
+  },
+  valueRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 6,
+  },
+  valueLabel: {
+    fontSize: 13,
+    fontWeight: '700',
+    color: colors.foreground,
+    opacity: 0.6,
+    marginBottom: 5,
+  },
+  value: {
+    fontSize: 30,
+    fontWeight: '800',
+    color: colors.foreground,
+    fontVariant: ['tabular-nums'],
+  },
+  tolerance: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: colors.income,
+  },
+  fundSection: {
+    marginTop: 6,
+    gap: 4,
+  },
+  fundLabelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  fundLabel: {
+    fontSize: 11,
+    color: colors.foreground,
+    opacity: 0.5,
+  },
+  fundPercent: {
+    fontSize: 11,
+    color: colors.foreground,
+    opacity: 0.5,
+    fontVariant: ['tabular-nums'],
+  },
+  barTrack: {
+    height: 6,
+    borderRadius: 9999,
+    backgroundColor: colors.borderDefault,
+    overflow: 'hidden',
+  },
+  barFill: {
+    height: '100%',
+    borderRadius: 9999,
+  },
+  cta: {
+    marginTop: 6,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: colors.borderDefault,
+    backgroundColor: colors.background,
+    paddingVertical: 10,
+    alignItems: 'center',
+  },
+  ctaLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: colors.foreground,
+  },
+  disclaimer: {
+    marginTop: 4,
+    fontSize: 10,
+    lineHeight: 15,
+    color: colors.foreground,
+    opacity: 0.5,
+  },
+});

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -24,6 +24,7 @@ export const colors = {
   expenseLight: v('--color-expense-light'),
   income: v('--color-income'),
   incomeLight: v('--color-income-light'),
+  caution: v('--color-caution'),
 } as const;
 
 /** カード全体の3トーン配色（--color-status-*） */

--- a/apps/web/src/__tests__/components/InvestmentCapacityCard.test.tsx
+++ b/apps/web/src/__tests__/components/InvestmentCapacityCard.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InvestmentCapacityCard } from "@/components/dashboard/InvestmentCapacityCard";
+
+describe("InvestmentCapacityCard", () => {
+  // E_m = 240,000 円/月・防衛資金目標 1,440,000 円
+  const okInputs = {
+    totalAssets: 2_880_000, // 充足率 200%
+    avgDailyExpense: 8_000,
+    monthlyIncome: 300_000, // 黒字 60,000 円/月 → 上限 30,000 円
+    recordedDays: 30,
+  };
+
+  it("投資可能なとき、今月の上限とリスク許容度が表示される", () => {
+    render(<InvestmentCapacityCard livingMargin={okInputs} />);
+    expect(screen.getByText("投資余力")).toBeInTheDocument();
+    expect(screen.getByText("¥30,000")).toBeInTheDocument();
+    expect(screen.getByText("リスク許容度: 中（バランス）")).toBeInTheDocument();
+    expect(screen.getByText("200%")).toBeInTheDocument();
+  });
+
+  it("防衛資金が未充足のとき、「今月は投資を控える月」と理由が表示される", () => {
+    render(<InvestmentCapacityCard livingMargin={{ ...okInputs, totalAssets: 1_200_000 }} />);
+    expect(screen.getByText("今月は投資を控える月")).toBeInTheDocument();
+    expect(
+      screen.getByText("生活の備え（目標 ¥1,440,000）が 83% です。まずは備えを整える段階です。")
+    ).toBeInTheDocument();
+  });
+
+  it("月次赤字のとき、家計の立て直しを優先する理由が表示される", () => {
+    render(<InvestmentCapacityCard livingMargin={{ ...okInputs, monthlyIncome: 200_000 }} />);
+    expect(screen.getByText("今月は投資を控える月")).toBeInTheDocument();
+    expect(
+      screen.getByText("今月は支出が収入を上回るペースです。投資より家計の立て直しが先の段階です。")
+    ).toBeInTheDocument();
+  });
+
+  it("投資を控える月は検証ツールへのリンクを表示しない", () => {
+    render(<InvestmentCapacityCard livingMargin={{ ...okInputs, totalAssets: 1_200_000 }} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("算出不能（総資産未設定）のとき、何も描画しない", () => {
+    render(<InvestmentCapacityCard livingMargin={{ ...okInputs, totalAssets: null }} />);
+    expect(screen.queryByTestId("investment-capacity-card")).not.toBeInTheDocument();
+  });
+
+  it("免責文言が常に表示される", () => {
+    render(<InvestmentCapacityCard livingMargin={okInputs} />);
+    expect(screen.getByText(/投資成果を保証するものではありません/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -6,6 +6,7 @@ import { calculateLivingMargin } from "@budget/common";
 import { PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
 import type { DashboardResponse, CategoryItem } from "@/lib/api/types";
 import { DailyBudgetHero } from "./DailyBudgetHero";
+import { InvestmentCapacityCard } from "./InvestmentCapacityCard";
 import { LivingMarginCard } from "./LivingMarginCard";
 import { useLivingMargin } from "@/components/providers/LivingMarginProvider";
 import { MonthlySummaryCard } from "./MonthlySummaryCard";
@@ -109,6 +110,11 @@ export function HomeClient({
               monthSummary={dashboard.monthSummary}
               lastMonthExpense={dashboard.lastMonthExpense}
             />
+          </motion.div>
+
+          {/* InvestmentCapacityCard — 投資余力（#543 / #545）。算出不能時は非表示 */}
+          <motion.div variants={PAGE_ITEM_VARIANTS}>
+            <InvestmentCapacityCard livingMargin={dashboard.livingMargin} />
           </motion.div>
         </div>
 

--- a/apps/web/src/components/dashboard/InvestmentCapacityCard.stories.tsx
+++ b/apps/web/src/components/dashboard/InvestmentCapacityCard.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite'
+import { InvestmentCapacityCard } from './InvestmentCapacityCard'
+
+/**
+ * ホームの「投資余力」カード（#543 / #545 / investment-business-basics.md MVP スコープ 1）。
+ * 「今月投資に回してよい上限」を数字主役・事実のみのトーンで表示する。
+ * 「今月は投資を控える月」も正しい結果として肯定形で表示する（急かさない・煽らない）。
+ * 診断は @budget/common の calculateInvestmentCapacity に委譲している。
+ * 算出不能（総資産未設定・記録不足）のときは何も描画しない（生活余力カード側が案内する）。
+ */
+const meta: Meta<typeof InvestmentCapacityCard> = {
+  title: 'Dashboard/InvestmentCapacityCard',
+  component: InvestmentCapacityCard,
+  parameters: { layout: 'padded' },
+  tags: ['autodocs'],
+}
+
+export default meta
+type Story = StoryObj<typeof InvestmentCapacityCard>
+
+/** 防衛資金充足（200%）・月次黒字 → 上限 3 万円・リスク許容度 中 */
+export const Investable: Story = {
+  args: {
+    livingMargin: {
+      totalAssets: 2_880_000,
+      avgDailyExpense: 8_000,
+      monthlyIncome: 300_000,
+      recordedDays: 30,
+    },
+  },
+}
+
+/** 防衛資金が未充足（83%）→ 黒字があっても「今月は投資を控える月」 */
+export const HoldInsufficientFund: Story = {
+  args: {
+    livingMargin: {
+      totalAssets: 1_200_000,
+      avgDailyExpense: 8_000,
+      monthlyIncome: 300_000,
+      recordedDays: 30,
+    },
+  },
+}
+
+/** 備えは十分だが月次赤字 → 「今月は投資を控える月」 */
+export const HoldMonthlyDeficit: Story = {
+  args: {
+    livingMargin: {
+      totalAssets: 2_880_000,
+      avgDailyExpense: 8_000,
+      monthlyIncome: 200_000,
+      recordedDays: 30,
+    },
+  },
+}
+
+/** 算出不能（総資産未設定）→ 何も描画しない */
+export const HiddenNoAssets: Story = {
+  args: {
+    livingMargin: {
+      totalAssets: null,
+      avgDailyExpense: 8_000,
+      monthlyIncome: 300_000,
+      recordedDays: 30,
+    },
+  },
+}

--- a/apps/web/src/components/dashboard/InvestmentCapacityCard.tsx
+++ b/apps/web/src/components/dashboard/InvestmentCapacityCard.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { motion } from "framer-motion";
 import { ExternalLink, TrendingUp } from "lucide-react";
 import {
-  buildInvestmentDeepLinkQuery,
+  buildInvestmentToolCtaUrl,
   calculateInvestmentCapacity,
   emergencyFundDisplay,
   formatCapacityHoldReason,
@@ -12,7 +11,6 @@ import {
   RISK_TOLERANCE_LABELS,
   type LivingMarginInputs,
 } from "@budget/common";
-import { SPRING } from "@/lib/motion";
 
 type Props = {
   livingMargin: LivingMarginInputs;
@@ -35,14 +33,12 @@ export function InvestmentCapacityCard({ livingMargin }: Props) {
 
   const fund = emergencyFundDisplay(result.emergencyFundRatio);
   const holdReason = formatCapacityHoldReason(result);
-  const deepLinkQuery = buildInvestmentDeepLinkQuery(result);
-  const ctaHref =
-    deepLinkQuery && INVESTMENT_TOOL_URL
-      ? `${INVESTMENT_TOOL_URL.replace(/\/$/, "")}/?${deepLinkQuery}`
-      : null;
+  // URL のスキーム検証・送客可否は common に集約。アニメーションは HomeClient 側の
+  // PAGE_ITEM_VARIANTS に一任するため、ここはプレーンな div にする
+  const ctaHref = buildInvestmentToolCtaUrl(INVESTMENT_TOOL_URL, result);
 
   return (
-    <motion.div
+    <div
       data-testid="investment-capacity-card"
       className="overflow-hidden rounded-2xl border p-4"
       style={{
@@ -50,9 +46,6 @@ export function InvestmentCapacityCard({ livingMargin }: Props) {
         borderColor: "var(--border-default)",
         boxShadow: "var(--shadow-card)",
       }}
-      initial={{ opacity: 0, y: 22 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={SPRING.smooth}
     >
       <div className="mb-1 flex items-center justify-between">
         <span className="text-[13px] font-bold" style={{ color: "var(--foreground)" }}>
@@ -144,6 +137,6 @@ export function InvestmentCapacityCard({ livingMargin }: Props) {
       >
         {INVESTMENT_CAPACITY_TEXT.disclaimer}
       </p>
-    </motion.div>
+    </div>
   );
 }

--- a/apps/web/src/components/dashboard/InvestmentCapacityCard.tsx
+++ b/apps/web/src/components/dashboard/InvestmentCapacityCard.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { ExternalLink, TrendingUp } from "lucide-react";
+import {
+  buildInvestmentDeepLinkQuery,
+  calculateInvestmentCapacity,
+  emergencyFundDisplay,
+  formatCapacityHoldReason,
+  formatYen,
+  INVESTMENT_CAPACITY_TEXT,
+  RISK_TOLERANCE_LABELS,
+  type LivingMarginInputs,
+} from "@budget/common";
+import { SPRING } from "@/lib/motion";
+
+type Props = {
+  livingMargin: LivingMarginInputs;
+};
+
+/** 検証ツール（investment-analysis-tool）のベース URL。未設定時は CTA を表示しない */
+const INVESTMENT_TOOL_URL = process.env.NEXT_PUBLIC_INVESTMENT_TOOL_URL;
+
+/**
+ * 投資余力カード（spec: investment-business-basics.md MVP スコープ 1 / #543 #545）
+ * 「今月投資に回してよい上限」を数字主役・事実のみのトーンで表示する。
+ * 「今月は投資を控える月」も正しい結果として肯定形で表示する（急かさない・煽らない）。
+ * 算出不能（総資産未設定・記録不足）のときは生活余力カード側が案内するため何も表示しない。
+ */
+export function InvestmentCapacityCard({ livingMargin }: Props) {
+  const result = calculateInvestmentCapacity(livingMargin);
+  if (result.status !== "ok") {
+    return null;
+  }
+
+  const fund = emergencyFundDisplay(result.emergencyFundRatio);
+  const holdReason = formatCapacityHoldReason(result);
+  const deepLinkQuery = buildInvestmentDeepLinkQuery(result);
+  const ctaHref =
+    deepLinkQuery && INVESTMENT_TOOL_URL
+      ? `${INVESTMENT_TOOL_URL.replace(/\/$/, "")}/?${deepLinkQuery}`
+      : null;
+
+  return (
+    <motion.div
+      data-testid="investment-capacity-card"
+      className="overflow-hidden rounded-2xl border p-4"
+      style={{
+        background: "var(--color-surface-default)",
+        borderColor: "var(--border-default)",
+        boxShadow: "var(--shadow-card)",
+      }}
+      initial={{ opacity: 0, y: 22 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={SPRING.smooth}
+    >
+      <div className="mb-1 flex items-center justify-between">
+        <span className="text-[13px] font-bold" style={{ color: "var(--foreground)" }}>
+          {INVESTMENT_CAPACITY_TEXT.title}
+        </span>
+        <TrendingUp size={14} aria-hidden style={{ color: "var(--foreground)", opacity: 0.42 }} />
+      </div>
+
+      {result.shouldHold ? (
+        <>
+          <p className="text-lg font-black" style={{ color: "var(--foreground)" }}>
+            {INVESTMENT_CAPACITY_TEXT.holdTitle}
+          </p>
+          <p
+            className="mt-1.5 text-xs leading-relaxed"
+            style={{ color: "var(--foreground)", opacity: 0.6 }}
+          >
+            {holdReason}
+          </p>
+        </>
+      ) : (
+        <>
+          <div className="flex items-baseline gap-1.5">
+            <span
+              className="text-sm font-semibold"
+              style={{ color: "var(--foreground)", opacity: 0.6 }}
+            >
+              {INVESTMENT_CAPACITY_TEXT.limitLabel}
+            </span>
+            <span
+              className="text-3xl font-black tabular-nums"
+              style={{ color: "var(--foreground)", letterSpacing: "-0.02em" }}
+            >
+              {formatYen(result.monthlyLimitJpy)}
+            </span>
+          </div>
+          <p className="mt-1.5 text-xs font-semibold" style={{ color: "var(--color-income)" }}>
+            リスク許容度: {RISK_TOLERANCE_LABELS[result.riskTolerance]}
+          </p>
+        </>
+      )}
+
+      {/* 生活防衛資金の充足バー（事実のみ。良好=income / 未充足=caution） */}
+      <div className="mt-3">
+        <div
+          className="flex items-center justify-between text-[11px]"
+          style={{ color: "var(--foreground)", opacity: 0.5 }}
+        >
+          <span>{INVESTMENT_CAPACITY_TEXT.fundLabel}</span>
+          <span className="tabular-nums">{fund.percent}%</span>
+        </div>
+        <div
+          className="mt-1 h-1.5 overflow-hidden rounded-full"
+          style={{ background: "var(--border-default)" }}
+        >
+          <div
+            className="h-full rounded-full"
+            style={{
+              width: `${fund.barPercent}%`,
+              background:
+                result.emergencyFundRatio >= 1.0
+                  ? "var(--color-income)"
+                  : "var(--color-caution)",
+            }}
+          />
+        </div>
+      </div>
+
+      {ctaHref && (
+        <a
+          href={ctaHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="mt-3 inline-flex items-center gap-1.5 rounded-xl border px-3 py-2 text-xs font-bold"
+          style={{
+            borderColor: "var(--border-default)",
+            color: "var(--foreground)",
+            background: "var(--color-surface-subtle)",
+          }}
+        >
+          <ExternalLink size={12} aria-hidden />
+          {INVESTMENT_CAPACITY_TEXT.ctaLabel}
+        </a>
+      )}
+
+      <p
+        className="mt-3 text-[10px] leading-relaxed"
+        style={{ color: "var(--foreground)", opacity: 0.5 }}
+      >
+        {INVESTMENT_CAPACITY_TEXT.disclaimer}
+      </p>
+    </motion.div>
+  );
+}

--- a/packages/common/src/__tests__/utils/investmentCapacity.test.ts
+++ b/packages/common/src/__tests__/utils/investmentCapacity.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
     buildInvestmentDeepLinkQuery,
     calculateInvestmentCapacity,
+    emergencyFundDisplay,
+    formatCapacityHoldReason,
     EMERGENCY_FUND_TARGET_MONTHS,
     INVESTMENT_RATIO_OF_SURPLUS,
 } from '../../utils/investmentCapacity'
@@ -102,5 +104,49 @@ describe('buildInvestmentDeepLinkQuery', () => {
     it('算出不能のとき、null を返す', () => {
         const result = calculateInvestmentCapacity({ ...baseInputs, totalAssets: null })
         expect(buildInvestmentDeepLinkQuery(result)).toBeNull()
+    })
+})
+
+describe('formatCapacityHoldReason', () => {
+    const baseInputs = {
+        totalAssets: 2_880_000,
+        avgDailyExpense: 8_000,
+        monthlyIncome: 300_000,
+        recordedDays: 30,
+    }
+
+    it('防衛資金未充足のとき、目標額と充足率を含む理由文を返す', () => {
+        const result = calculateInvestmentCapacity({ ...baseInputs, totalAssets: 1_200_000 })
+        // 目標 1,440,000 円・充足率 83%
+        expect(formatCapacityHoldReason(result)).toBe(
+            '生活の備え（目標 ¥1,440,000）が 83% です。まずは備えを整える段階です。'
+        )
+    })
+
+    it('月次赤字のとき、家計の立て直しを優先する理由文を返す', () => {
+        const result = calculateInvestmentCapacity({ ...baseInputs, monthlyIncome: 200_000 })
+        expect(formatCapacityHoldReason(result)).toBe(
+            '今月は支出が収入を上回るペースです。投資より家計の立て直しが先の段階です。'
+        )
+    })
+
+    it('投資可能なとき・算出不能のとき、null を返す', () => {
+        expect(formatCapacityHoldReason(calculateInvestmentCapacity(baseInputs))).toBeNull()
+        expect(
+            formatCapacityHoldReason(
+                calculateInvestmentCapacity({ ...baseInputs, totalAssets: null })
+            )
+        ).toBeNull()
+    })
+})
+
+describe('emergencyFundDisplay', () => {
+    it('充足率をパーセント表示とバー幅（100 上限）に変換する', () => {
+        expect(emergencyFundDisplay(2.0)).toEqual({ percent: 200, barPercent: 100 })
+        expect(emergencyFundDisplay(0.83)).toEqual({ percent: 83, barPercent: 83 })
+    })
+
+    it('負の充足率（負債超過など）は 0 にクランプする', () => {
+        expect(emergencyFundDisplay(-0.5)).toEqual({ percent: 0, barPercent: 0 })
     })
 })

--- a/packages/common/src/__tests__/utils/investmentCapacity.test.ts
+++ b/packages/common/src/__tests__/utils/investmentCapacity.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
     buildInvestmentDeepLinkQuery,
+    buildInvestmentToolCtaUrl,
     calculateInvestmentCapacity,
     emergencyFundDisplay,
     formatCapacityHoldReason,
@@ -137,6 +138,41 @@ describe('formatCapacityHoldReason', () => {
                 calculateInvestmentCapacity({ ...baseInputs, totalAssets: null })
             )
         ).toBeNull()
+    })
+})
+
+describe('buildInvestmentToolCtaUrl', () => {
+    const investable = calculateInvestmentCapacity({
+        totalAssets: 2_880_000,
+        avgDailyExpense: 8_000,
+        monthlyIncome: 300_000,
+        recordedDays: 30,
+    })
+
+    it('http(s) のベース URL のとき、末尾スラッシュを整えた CTA URL を返す', () => {
+        expect(buildInvestmentToolCtaUrl('https://example.com/', investable)).toBe(
+            'https://example.com/?risk_tolerance=mid&monthly_limit=30000'
+        )
+        expect(buildInvestmentToolCtaUrl('http://localhost:3000', investable)).toBe(
+            'http://localhost:3000/?risk_tolerance=mid&monthly_limit=30000'
+        )
+    })
+
+    it('未設定・http(s) 以外のベース URL は null（設定ミスで相対遷移させない）', () => {
+        expect(buildInvestmentToolCtaUrl(undefined, investable)).toBeNull()
+        expect(buildInvestmentToolCtaUrl('', investable)).toBeNull()
+        expect(buildInvestmentToolCtaUrl('example.com', investable)).toBeNull()
+        expect(buildInvestmentToolCtaUrl('javascript:alert(1)', investable)).toBeNull()
+    })
+
+    it('投資を控える月は null（送客しない）', () => {
+        const hold = calculateInvestmentCapacity({
+            totalAssets: 1_200_000,
+            avgDailyExpense: 8_000,
+            monthlyIncome: 300_000,
+            recordedDays: 30,
+        })
+        expect(buildInvestmentToolCtaUrl('https://example.com', hold)).toBeNull()
     })
 })
 

--- a/packages/common/src/utils/investmentCapacity.ts
+++ b/packages/common/src/utils/investmentCapacity.ts
@@ -28,6 +28,25 @@ const MONTHLY_LIMIT_ROUNDING_JPY = 1000;
 /** 家計状態から導出するリスク許容度（連携契約 InvestmentCapacity.risk_tolerance と同値） */
 export type RiskTolerance = 'low' | 'mid' | 'high';
 
+/** リスク許容度の表示ラベル（Web / モバイル共通。表記ゆれ防止のため common が SSOT） */
+export const RISK_TOLERANCE_LABELS: Record<RiskTolerance, string> = {
+    low: '低（安定重視）',
+    mid: '中（バランス）',
+    high: '高（変動を許容）',
+};
+
+/** 投資余力カードの表示文言（Web / モバイル共通 SSOT。断定・煽り表現を使わない） */
+export const INVESTMENT_CAPACITY_TEXT = {
+    title: '投資余力',
+    limitLabel: '今月の上限',
+    holdTitle: '今月は投資を控える月',
+    fundLabel: `生活の備え（生活費 ${EMERGENCY_FUND_TARGET_MONTHS} ヶ月分が目安）`,
+    ctaLabel: 'この条件で戦略の過去検証を見る',
+    disclaimer:
+        '診断は家計の記録に基づく目安であり、投資成果を保証するものではありません。' +
+        '投資判断はご自身の責任で行ってください。',
+} as const;
+
 export type InvestmentCapacityResult =
     | {
           status: 'ok';
@@ -99,6 +118,38 @@ export function calculateInvestmentCapacity(
         emergencyFundTargetJpy,
         shouldHold: monthlyLimitJpy <= 0,
     };
+}
+
+/**
+ * 「投資を控える月」の理由文（事実のみのトーン。Web / モバイル共通 SSOT）。
+ * 控える判断でない場合は null を返す。
+ */
+export function formatCapacityHoldReason(
+    result: InvestmentCapacityResult
+): string | null {
+    if (result.status !== 'ok' || !result.shouldHold) {
+        return null;
+    }
+    if (result.emergencyFundRatio < 1.0) {
+        const target = `¥${Math.round(result.emergencyFundTargetJpy).toLocaleString('ja-JP')}`;
+        const percent = Math.max(0, Math.round(result.emergencyFundRatio * 100));
+        return `生活の備え（目標 ${target}）が ${percent}% です。まずは備えを整える段階です。`;
+    }
+    return '今月は支出が収入を上回るペースです。投資より家計の立て直しが先の段階です。';
+}
+
+/**
+ * 生活防衛資金の充足バー表示値（Web / モバイル共通）。
+ * 負の総資産などで充足率が負になっても表示が壊れないよう 0 以上にクランプする。
+ */
+export function emergencyFundDisplay(emergencyFundRatio: number): {
+    /** 表示用パーセント（0 以上・整数） */
+    percent: number;
+    /** バー幅パーセント（0〜100） */
+    barPercent: number;
+} {
+    const percent = Math.max(0, Math.round(emergencyFundRatio * 100));
+    return { percent, barPercent: Math.min(percent, 100) };
 }
 
 /**

--- a/packages/common/src/utils/investmentCapacity.ts
+++ b/packages/common/src/utils/investmentCapacity.ts
@@ -166,3 +166,22 @@ export function buildInvestmentDeepLinkQuery(
     // 値は列挙型と整数のみのため URL エンコード不要（DOM 非依存のまま組み立てる）
     return `risk_tolerance=${result.riskTolerance}&monthly_limit=${result.monthlyLimitJpy}`;
 }
+
+/**
+ * 検証ツールへの CTA URL を組み立てる（Web / モバイル共通）。
+ * ベース URL が未設定・http(s) 以外（相対パス等の設定ミス）、または送客しない診断結果の
+ * 場合は null を返し、呼び出し側は CTA を表示しない。
+ */
+export function buildInvestmentToolCtaUrl(
+    baseUrl: string | undefined,
+    result: InvestmentCapacityResult
+): string | null {
+    if (!baseUrl || !/^https?:\/\//.test(baseUrl)) {
+        return null;
+    }
+    const query = buildInvestmentDeepLinkQuery(result);
+    if (query === null) {
+        return null;
+    }
+    return `${baseUrl.replace(/\/$/, '')}/?${query}`;
+}


### PR DESCRIPTION
## 概要

投資余力診断（#543 で承認済みのプロトタイプ・PR #544）を Web / モバイルのホーム画面へ本番実装する。investment-analysis-tool へのステートレス・ディープリンク CTA（シナジーPRD Phase 1.75 の budget 側）を含む。

## 変更内容

- **packages/common**（表示 SSOT の追加。PR #544 の Gemini レビュー指摘への対応を含む）
  - `RISK_TOLERANCE_LABELS` / `INVESTMENT_CAPACITY_TEXT`: リスク許容度ラベル・カード文言を共通化（Web/モバイルの表記ゆれ防止）
  - `formatCapacityHoldReason`: 「投資を控える月」の理由文（防衛資金未充足 / 月次赤字）を事実のみのトーンで生成
  - `emergencyFundDisplay`: 充足バーの表示値。負の総資産でも表示が壊れないよう 0 にクランプ（レビュー指摘対応）
- **apps/web**: `InvestmentCapacityCard` を新規追加し `HomeClient` のカードグリッド（MonthlySummary の後）へ配置
  - 診断結果に応じて「今月の上限 + リスク許容度」または「今月は投資を控える月 + 理由」を表示
  - `NEXT_PUBLIC_INVESTMENT_TOOL_URL` 設定時のみ「この条件で戦略の過去検証を見る」CTA を表示（`?risk_tolerance=&monthly_limit=` のみ付与・PII なし・控える月は非表示）
  - 算出不能（総資産未設定・記録不足）は非表示（案内は生活余力カードに集約し重複させない）
  - Storybook ストーリー 4 状態（投資可 / 防衛資金未達 / 月次赤字 / 非表示）
- **apps/mobile**: 同一ロジック・同一文言（common SSOT）の RN 版カードをホームへ追加。`EXPO_PUBLIC_INVESTMENT_TOOL_URL` 設定時のみ `Linking.openURL` で CTA を開く。theme tokens に `caution` 色を追加（`--color-caution` 由来）
- `.env.example` に CTA 用 URL 変数 2 件を追記

## 影響範囲

既存カード・ダッシュボード API への変更なし（診断入力は既存の `dashboard.livingMargin` を再利用）。環境変数未設定の場合、カードは CTA なしで表示される（外部送客は発生しない）。

**プロトタイプで承認された SP カルーセル・使い方ガイド・ガイドタブへの配置について**: 本番ホームにはカルーセル・ガイド UI がまだ存在しない（sandbox HomePrototype = ホーム刷新案の一部）ため、本 PR は現行ホームの既存グリッドへの追加とし、承認済みの配置デザインはホーム刷新の本実装時に適用する。

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界（Domain/Application/Infrastructure/Presentation）を跨ぐ不正な依存はないか（common は純粋関数のみ・DOM/RN 非依存）
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（文言・ラベル・閾値はすべて common の定数）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（プロトタイプ承認済み #543。Storybook に 4 状態を追加）
- [x] ドキュメントを追加・移動・削除した場合、SSOT マップを更新したか（該当なし）

## スクリーンショット

| | Before | After |
|---|---|---|
| SP（390px） | 投資余力カードなし | sandbox プロトタイプで承認済み（#543 のセッション内共有）。Storybook `Dashboard/InvestmentCapacityCard` で 4 状態を確認可能 |

## Test plan

- common: `formatCapacityHoldReason`（未充足 / 赤字 / null）・`emergencyFundDisplay`（クランプ）の 5 件追加 → 全 162 件パス
- web: `InvestmentCapacityCard` の 6 件追加（上限表示 / 控える 2 パターン / リンク非表示 / 非表示 / 免責常設）→ 全 143 件パス
- mobile: jest 全 14 件パス（既存回帰なし）
- `pnpm -w run type-check` / `pnpm -w run lint` パス

## 関連 Issue

- Closes #545
- Sprint: 45