### PR TITLE
fix(web): 固定費カードの合計行がカードの角丸を突き破る見た目を修正する

### DIFF
--- a/apps/web/src/components/settings/SettingsClient.tsx
+++ b/apps/web/src/components/settings/SettingsClient.tsx
@@ -276,9 +276,10 @@ export function SettingsClient({ settings }: Props) {
                   ))}
                 </div>
                 {/* SectionCard は overflow-visible のため、背景付きフッターは角丸を自前で
-                    合わせる（角丸を突き破って下角が欠けて見える問題の修正 #554） */}
+                    合わせる（角丸を突き破って下角が欠けて見える問題の修正 #554）。
+                    親の radius 16px から border 1px を引いた 15px で内接させる */}
                 <div
-                  className="flex items-center justify-between rounded-b-2xl border-t px-4 py-2.5"
+                  className="flex items-center justify-between rounded-b-[15px] border-t px-4 py-2.5"
                   style={{
                     background: "var(--color-surface-subtle)",
                     borderColor: "var(--border-default)",

--- a/apps/web/src/components/settings/SettingsClient.tsx
+++ b/apps/web/src/components/settings/SettingsClient.tsx
@@ -275,8 +275,10 @@ export function SettingsClient({ settings }: Props) {
                     </div>
                   ))}
                 </div>
+                {/* SectionCard は overflow-visible のため、背景付きフッターは角丸を自前で
+                    合わせる（角丸を突き破って下角が欠けて見える問題の修正 #554） */}
                 <div
-                  className="flex items-center justify-between border-t px-4 py-2.5"
+                  className="flex items-center justify-between rounded-b-2xl border-t px-4 py-2.5"
                   style={{
                     background: "var(--color-surface-subtle)",
                     borderColor: "var(--border-default)",


### PR DESCRIPTION
## 概要

設定画面の固定費カード下部（合計行）の左右の角が四角く欠けて見える問題（ユーザー報告・SP スクリーンショット）を修正する。

## 変更内容

- 合計フッター行（背景色付き）に `rounded-b-2xl` を付与し、カードの角丸に沿わせる

## 原因

`SectionCard` のカード要素が `overflow-visible` のため、フッター行の四角い背景（`--color-surface-subtle`）が `rounded-2xl` の角丸を突き破って描画されていた。残高カード等は背景付きフッター行を持たないため発生しない。プレーンHTMLで再現・修正効果を確認済み。`overflow-visible` 自体は他要素（SalaryDayPicker 等）への影響が不明なため変更しない最小修正とした。

## 影響範囲

固定費カードの合計行のみ。ロジック変更なし。

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか（該当なし）
- [x] 境界を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（該当なし）
- [x] UI/UX 変更がある場合、スクリーンショット（Before/After）を添付しているか（下記）
- [x] ドキュメント SSOT マップ更新（該当なし）

## スクリーンショット

| | Before | After |
|---|---|---|
| SP | ユーザー報告のスクリーンショット（合計行の角が四角く欠ける） | 再現HTMLで修正効果確認済み（角丸維持）。デプロイ後に実機確認をお願いします |

## Test plan

- 見た目のみの変更（`pnpm run type-check` パス）。プレーンHTML再現で before/after を目視確認
- 既存ユニットテスト・E2E への影響なし（クラス追加のみ）

## 関連 Issue

- Closes #554
- Sprint: 46