### PR TITLE
feat(web): SPホームをスワイプカルーセル化する

### DIFF
--- a/apps/web/src/__tests__/components/DashboardCarousel.test.tsx
+++ b/apps/web/src/__tests__/components/DashboardCarousel.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DashboardCarousel, type CarouselSlide } from "@/components/dashboard/DashboardCarousel";
+
+const slides: CarouselSlide[] = [
+  { key: "a", label: "スライドA", node: <div>コンテンツA</div> },
+  { key: "b", label: "スライドB", node: <div>コンテンツB</div> },
+  { key: "c", label: "スライドC", node: <div>コンテンツC</div> },
+];
+
+describe("DashboardCarousel", () => {
+  it("初期表示: 先頭スライドのみが表示され、ドットが枚数ぶん描画される", () => {
+    render(<DashboardCarousel slides={slides} />);
+    expect(screen.getByText("コンテンツA")).toBeInTheDocument();
+    expect(screen.queryByText("コンテンツB")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "スライドA" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "スライドC" })).toBeInTheDocument();
+  });
+
+  it("ドットをタップすると該当スライドに切り替わる", async () => {
+    render(<DashboardCarousel slides={slides} />);
+    fireEvent.click(screen.getByRole("button", { name: "スライドB" }));
+    // AnimatePresence(mode=wait) の退場アニメーション完了後に次スライドがマウントされる
+    expect(await screen.findByText("コンテンツB")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "スライドB" })).toHaveAttribute(
+      "aria-current",
+      "true",
+    );
+  });
+
+  it("＞で次へ、＜で前へ切り替わる", async () => {
+    render(<DashboardCarousel slides={slides} />);
+    fireEvent.click(screen.getByRole("button", { name: "次のカード" }));
+    expect(await screen.findByText("コンテンツB")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "前のカード" }));
+    expect(await screen.findByText("コンテンツA")).toBeInTheDocument();
+  });
+
+  it("先頭で＜が、末尾で＞が disabled になる", () => {
+    render(<DashboardCarousel slides={slides} />);
+    expect(screen.getByRole("button", { name: "前のカード" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "スライドC" }));
+    expect(screen.getByRole("button", { name: "次のカード" })).toBeDisabled();
+  });
+
+  it("スライドが空のとき、何も描画しない", () => {
+    render(<DashboardCarousel slides={[]} />);
+    expect(screen.queryByTestId("dashboard-carousel")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/dashboard/DashboardCarousel.tsx
+++ b/apps/web/src/components/dashboard/DashboardCarousel.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { useState } from "react";
+import { AnimatePresence, motion, type PanInfo } from "framer-motion";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { SPRING } from "@/lib/motion";
+
+/** スワイプ判定のしきい値（px）。これ未満のドラッグはスライドを切り替えない */
+const SWIPE_THRESHOLD_PX = 40;
+
+export type CarouselSlide = {
+  key: string;
+  /** インジケーターの aria-label に使う名称 */
+  label: string;
+  node: React.ReactNode;
+};
+
+/** スライドの出入りアニメーション（sandbox HomePrototype と同パターン） */
+const SLIDE_VARIANTS = {
+  enter: (dir: number) => ({ x: dir > 0 ? "100%" : "-100%", opacity: 0 }),
+  center: {
+    x: 0,
+    opacity: 1,
+    transition: { type: "spring" as const, stiffness: 320, damping: 30 },
+  },
+  exit: (dir: number) => ({
+    x: dir > 0 ? "-100%" : "100%",
+    opacity: 0,
+    transition: { duration: 0.14 },
+  }),
+};
+
+/**
+ * SP ホームのスワイプカルーセル（#550 / sandbox HomePrototype 承認済みデザイン）
+ * ドラッグスワイプとインジケーター（＜ ドット ＞）でスライドを切り替える。
+ * スライドの中身は既存のダッシュボードカードをそのまま受け取る（DOM順 = 表示順）。
+ */
+export function DashboardCarousel({ slides }: { slides: CarouselSlide[] }) {
+  const [index, setIndex] = useState(0);
+  const [direction, setDirection] = useState<1 | -1>(1);
+
+  const go = (next: number) => {
+    if (next < 0 || next >= slides.length || next === index) return;
+    setDirection(next > index ? 1 : -1);
+    setIndex(next);
+  };
+
+  const handleDragEnd = (_: unknown, info: PanInfo) => {
+    if (info.offset.x < -SWIPE_THRESHOLD_PX) go(index + 1);
+    else if (info.offset.x > SWIPE_THRESHOLD_PX) go(index - 1);
+  };
+
+  if (slides.length === 0) return null;
+
+  return (
+    <div data-testid="dashboard-carousel">
+      {/* スワイプ可能エリア。横方向の入れ替えアニメーションのためはみ出しを隠す */}
+      <motion.div
+        className="overflow-hidden"
+        drag="x"
+        dragConstraints={{ left: 0, right: 0 }}
+        dragElastic={0.04}
+        onDragEnd={handleDragEnd}
+        style={{ touchAction: "pan-y" }}
+      >
+        <AnimatePresence mode="wait" custom={direction} initial={false}>
+          <motion.div
+            key={slides[index].key}
+            custom={direction}
+            variants={SLIDE_VARIANTS}
+            initial="enter"
+            animate="center"
+            exit="exit"
+          >
+            {slides[index].node}
+          </motion.div>
+        </AnimatePresence>
+      </motion.div>
+
+      {/* インジケーター行: ＜ ドット ＞ */}
+      <div className="flex items-center justify-center gap-2 px-4 py-2">
+        <motion.button
+          type="button"
+          onClick={() => go(index - 1)}
+          disabled={index === 0}
+          whileTap={{ scale: 0.85 }}
+          transition={SPRING.snap}
+          className="flex h-7 w-7 items-center justify-center rounded-full transition-opacity disabled:opacity-25"
+          style={{ color: "var(--color-brand-primary)" }}
+          aria-label="前のカード"
+        >
+          <ChevronLeft size={15} strokeWidth={2.5} />
+        </motion.button>
+        {slides.map((slide, i) => (
+          <motion.button
+            key={slide.key}
+            type="button"
+            onClick={() => go(i)}
+            aria-label={slide.label}
+            aria-current={i === index ? "true" : undefined}
+            animate={{
+              width: i === index ? 20 : 6,
+              background:
+                i === index ? "var(--color-brand-primary)" : "rgba(28,20,16,0.18)",
+            }}
+            transition={SPRING.quick}
+            style={{ height: 6, borderRadius: 9999 }}
+          />
+        ))}
+        <motion.button
+          type="button"
+          onClick={() => go(index + 1)}
+          disabled={index === slides.length - 1}
+          whileTap={{ scale: 0.85 }}
+          transition={SPRING.snap}
+          className="flex h-7 w-7 items-center justify-center rounded-full transition-opacity disabled:opacity-25"
+          style={{ color: "var(--color-brand-primary)" }}
+          aria-label="次のカード"
+        >
+          <ChevronRight size={15} strokeWidth={2.5} />
+        </motion.button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/DashboardCarousel.tsx
+++ b/apps/web/src/components/dashboard/DashboardCarousel.tsx
@@ -36,8 +36,11 @@ const SLIDE_VARIANTS = {
  * スライドの中身は既存のダッシュボードカードをそのまま受け取る（DOM順 = 表示順）。
  */
 export function DashboardCarousel({ slides }: { slides: CarouselSlide[] }) {
-  const [index, setIndex] = useState(0);
+  const [rawIndex, setIndex] = useState(0);
   const [direction, setDirection] = useState<1 | -1>(1);
+  // データ更新でスライド数が減った場合（例: 投資余力が算出不能になった）に
+  // 範囲外参照でクラッシュしないよう末尾へクランプする
+  const index = Math.min(rawIndex, Math.max(0, slides.length - 1));
 
   const go = (next: number) => {
     if (next < 0 || next >= slides.length || next === index) return;

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { calculateInvestmentCapacity, calculateLivingMargin } from "@budget/common";
 import { PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
@@ -85,6 +85,9 @@ export function HomeClient({
 }: Props) {
   const [drawerOpen, setDrawerOpen] = useState(false);
 
+  // スライド配列の再生成による不要な再レンダリングを避ける（レビュー指摘対応）
+  const carouselSlides = useMemo(() => buildCarouselSlides(dashboard), [dashboard]);
+
   // 生活余力（#418）。登録直後の即時フィードバック用に実効日次支出 E も導出する
   const livingMarginResult = calculateLivingMargin(dashboard.livingMargin);
   const effectiveDailyExpense =
@@ -135,9 +138,7 @@ export function HomeClient({
 
         {/* SP: スワイプカルーセル（#550 / sandbox 承認済みデザイン。DOM順 = 表示順） */}
         <motion.div variants={PAGE_ITEM_VARIANTS} className="lg:hidden">
-          <DashboardCarousel
-            slides={buildCarouselSlides(dashboard)}
-          />
+          <DashboardCarousel slides={carouselSlides} />
         </motion.div>
 
         {/* PC: 2カラムグリッド */}

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -2,10 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { motion } from "framer-motion";
-import { calculateLivingMargin } from "@budget/common";
+import { calculateInvestmentCapacity, calculateLivingMargin } from "@budget/common";
 import { PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
 import type { DashboardResponse, CategoryItem } from "@/lib/api/types";
 import { DailyBudgetHero } from "./DailyBudgetHero";
+import { DashboardCarousel, type CarouselSlide } from "./DashboardCarousel";
 import { InvestmentCapacityCard } from "./InvestmentCapacityCard";
 import { LivingMarginCard } from "./LivingMarginCard";
 import { useLivingMargin } from "@/components/providers/LivingMarginProvider";
@@ -22,6 +23,58 @@ type Props = {
   incomeCategories: CategoryItem[];
   allCategories: CategoryItem[];
 };
+
+/**
+ * SP カルーセルのスライド構成（sandbox HomePrototype 準拠）。
+ * ① 生活余力 + 今週の記録 ② 今月の貯蓄予測 ③ 今月のサマリー ④ 投資余力。
+ * 投資余力は算出不能（総資産未設定・記録不足）のときスライドごと出さない。
+ */
+function buildCarouselSlides(dashboard: DashboardResponse): CarouselSlide[] {
+  const slides: CarouselSlide[] = [
+    {
+      key: "margin-streak",
+      label: "生活余力・今週の記録",
+      node: (
+        <div className="flex flex-col gap-3">
+          <LivingMarginCard livingMargin={dashboard.livingMargin} />
+          <WeeklyStreak
+            weeklyRecord={dashboard.weeklyRecord}
+            dailyBudget={dashboard.dailyBudget?.amount ?? null}
+          />
+        </div>
+      ),
+    },
+    {
+      key: "savings-forecast",
+      label: "今月の貯蓄予測",
+      node: (
+        <SavingsForecastCard
+          monthSummary={dashboard.monthSummary}
+          todayExpense={dashboard.todayExpense}
+          savingsGoal={dashboard.savingsGoal}
+        />
+      ),
+    },
+    {
+      key: "monthly-summary",
+      label: "今月のサマリー",
+      node: (
+        <MonthlySummaryCard
+          monthSummary={dashboard.monthSummary}
+          lastMonthExpense={dashboard.lastMonthExpense}
+        />
+      ),
+    },
+  ];
+  if (calculateInvestmentCapacity(dashboard.livingMargin).status === "ok") {
+    slides.push({
+      key: "investment-capacity",
+      label: "投資余力",
+      node: <InvestmentCapacityCard livingMargin={dashboard.livingMargin} />,
+    });
+  }
+  return slides;
+}
 
 export function HomeClient({
   userId,
@@ -80,8 +133,15 @@ export function HomeClient({
           />
         </motion.div>
 
-        {/* PC: 2カラム / SP: 1カラム */}
-        <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+        {/* SP: スワイプカルーセル（#550 / sandbox 承認済みデザイン。DOM順 = 表示順） */}
+        <motion.div variants={PAGE_ITEM_VARIANTS} className="lg:hidden">
+          <DashboardCarousel
+            slides={buildCarouselSlides(dashboard)}
+          />
+        </motion.div>
+
+        {/* PC: 2カラムグリッド */}
+        <div className="hidden grid-cols-2 gap-3 lg:grid">
           {/* LivingMarginCard — 生活余力（#418） */}
           <motion.div variants={PAGE_ITEM_VARIANTS}>
             <LivingMarginCard livingMargin={dashboard.livingMargin} />

--- a/e2e/living-margin.spec.ts
+++ b/e2e/living-margin.spec.ts
@@ -41,7 +41,8 @@ test.describe('生活余力（US-402）', () => {
         const home = new HomePage(page)
         await home.goto()
 
-        const card = page.getByTestId('living-margin-card')
+        // #550: カードは SP カルーセルと PC グリッドの両方に DOM 存在するため可視要素に絞る
+        const card = page.locator('[data-testid="living-margin-card"]:visible')
         await expect(card).toBeVisible()
         await expect(card.getByText('生活余力')).toBeVisible()
     })
@@ -100,7 +101,8 @@ test.describe('生活余力（US-402）', () => {
 
             // ホーム再読み込み → 生活余力（◯ヶ月分）が表示される
             await page.reload()
-            const card = page.getByTestId('living-margin-card')
+            // #550: カードは SP カルーセルと PC グリッドの両方に DOM 存在するため可視要素に絞る
+        const card = page.locator('[data-testid="living-margin-card"]:visible')
             await expect(card).toBeVisible()
             await expect(card.getByText('ヶ月分', { exact: true })).toBeVisible({ timeout: 30000 })
 


### PR DESCRIPTION
## 概要

sandbox HomePrototype で承認済みの SP スワイプカルーセルを本実装する（Sprint #46・#545 から持ち越した投資余力のカルーセル配置も実現）。

## 変更内容

- `DashboardCarousel` を新規追加
  - ドラッグスワイプ（しきい値 40px）+ インジケーター（＜ ドット ＞）で切替
  - スライドの出入りは HomePrototype と同じスプリングアニメーション
  - 中身は既存カードコンポーネントをそのまま受け取る（ロジック重複なし）
- SP（lg 未満）のダッシュボードカードを 4 枚カルーセルへ:
  ① 生活余力 + 今週の記録 / ② 今月の貯蓄予測 / ③ 今月のサマリー / ④ 投資余力
- 投資余力が算出不能（総資産未設定・記録不足）のときはスライドごと非表示（ドット数も連動）
- PC（lg 以上）は従来の 2 カラムグリッドを維持

## 影響範囲

SP のホーム表示のみ。各カードのロジック・API・PC 表示への変更なし。DailyBudgetHero・最近の記録は従来どおりカルーセル外。

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（スワイプしきい値を定数化）
- [x] UI/UX 変更がある場合、スクリーンショット添付（sandbox プロトタイプで承認済み #543/#545 レビュー。実機はデプロイ後確認）
- [x] ドキュメント SSOT マップ更新（該当なし）

## スクリーンショット

| | Before | After |
|---|---|---|
| SP | カード縦積み | sandbox HomePrototype と同一デザイン（承認済み） |

## Test plan

- `DashboardCarousel.test.tsx` 新規 5 件（初期表示・ドット切替・＜＞切替・端での disabled・空スライド）
- web 全 148 件パス・type-check パス

## 関連 Issue

- Closes #550
- Sprint: 46