### PR TITLE
feat(web): 設定画面に設定/ガイドタブを追加しガイドタブを実装する

### DIFF
--- a/apps/web/src/__tests__/components/GuideTab.test.tsx
+++ b/apps/web/src/__tests__/components/GuideTab.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GuideTab } from "@/components/settings/GuideTab";
+
+describe("GuideTab", () => {
+  it("使い方ガイドの導線が近日公開プレースホルダとして表示される", () => {
+    render(<GuideTab />);
+    expect(screen.getByText("ホーム画面ガイド")).toBeInTheDocument();
+    expect(screen.getByText("管理設定ガイド")).toBeInTheDocument();
+    expect(screen.getAllByText("近日公開")).toHaveLength(2);
+  });
+
+  it("診断のしくみは初期状態で閉じている", () => {
+    render(<GuideTab />);
+    expect(screen.getByRole("button", { name: /投資余力診断のしくみ/ })).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
+    expect(screen.queryByText("ちなみに、どう計算している？")).not.toBeInTheDocument();
+  });
+
+  it("診断のしくみをタップすると「ちなみに」補足が開閉する", async () => {
+    render(<GuideTab />);
+    const toggle = screen.getByRole("button", { name: /投資余力診断のしくみ/ });
+    fireEvent.click(toggle);
+    expect(await screen.findByText("ちなみに、どう計算している？")).toBeInTheDocument();
+    expect(
+      screen.getByText(/生活費 6 ヶ月分の備え/),
+    ).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/apps/web/src/components/settings/GuideTab.tsx
+++ b/apps/web/src/components/settings/GuideTab.tsx
@@ -95,6 +95,7 @@ function MechanismToggle() {
         type="button"
         onClick={() => setOpen((v) => !v)}
         aria-expanded={open}
+        aria-controls="investment-mechanism-panel"
         className="flex w-full items-center gap-3 px-4 py-3.5 text-left"
       >
         <div
@@ -123,6 +124,7 @@ function MechanismToggle() {
       <AnimatePresence>
         {open && (
           <motion.div
+            id="investment-mechanism-panel"
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
@@ -143,13 +145,13 @@ function MechanismToggle() {
                   ちなみに、どう計算している？
                 </p>
                 <ul
-                  className="mt-2 space-y-1.5 text-[11px] leading-relaxed"
+                  className="mt-2 list-disc space-y-1.5 pl-4 text-[11px] leading-relaxed"
                   style={{ color: "var(--foreground)", opacity: 0.6 }}
                 >
-                  <li>・まず「生活費 6 ヶ月分の備え」を最優先。備えが目標に届くまで、投資はおすすめしません</li>
-                  <li>・上限は毎月の黒字の半分まで。残りの半分は現金で手元に残す想定です</li>
-                  <li>・家計にゆとりがあるほどリスク許容度が上がり、検証ツールで比べられる戦略の幅が広がります</li>
-                  <li>・検証ツールに渡すのは「リスク許容度」と「上限額」の 2 つだけ。名前や記録の中身は渡しません</li>
+                  <li>まず「生活費 6 ヶ月分の備え」を最優先。備えが目標に届くまで、投資はおすすめしません</li>
+                  <li>上限は毎月の黒字の半分まで。残りの半分は現金で手元に残す想定です</li>
+                  <li>家計にゆとりがあるほどリスク許容度が上がり、検証ツールで比べられる戦略の幅が広がります</li>
+                  <li>検証ツールに渡すのは「リスク許容度」と「上限額」の 2 つだけ。名前や記録の中身は渡しません</li>
                 </ul>
               </div>
             </div>

--- a/apps/web/src/components/settings/GuideTab.tsx
+++ b/apps/web/src/components/settings/GuideTab.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { BookOpen, ChevronDown, Lightbulb, Settings, TrendingUp } from "lucide-react";
+import { SPRING } from "@/lib/motion";
+import { SectionCard } from "./SettingsClient";
+
+/**
+ * 設定画面のガイドタブ（#551 / sandbox PersonalSettingsPrototype 承認済みデザイン）
+ * - 使い方ガイドの導線カード（ツアー本体は未実装のため「近日公開」プレースホルダ）
+ * - 「投資余力診断のしくみ」常設トグル（#545 の設計決定。「ちなみに」トーンの補足）
+ */
+export function GuideTab() {
+  return (
+    <motion.div
+      className="flex flex-col gap-4"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={SPRING.smooth}
+    >
+      <SectionCard title="使い方ガイド">
+        <div>
+          <GuideRow
+            icon={BookOpen}
+            title="ホーム画面ガイド"
+            description="ホーム画面の使い方を案内します"
+          />
+          <div className="border-t" style={{ borderColor: "var(--border-default)" }}>
+            <GuideRow
+              icon={Settings}
+              title="管理設定ガイド"
+              description="設定画面の使い方を案内します"
+            />
+          </div>
+        </div>
+      </SectionCard>
+
+      <SectionCard title="診断のしくみ">
+        <MechanismToggle />
+      </SectionCard>
+    </motion.div>
+  );
+}
+
+/** ガイド導線の行（ツアー実装までは近日公開のプレースホルダ） */
+function GuideRow({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex cursor-not-allowed select-none items-center gap-3 px-4 py-3.5 opacity-50">
+      <div
+        className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
+        style={{ background: "var(--color-surface-subtle)" }}
+      >
+        <Icon size={16} style={{ color: "var(--foreground)", opacity: 0.5 }} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-[13px] font-bold" style={{ color: "var(--foreground)" }}>
+          {title}
+        </div>
+        <div className="mt-0.5 text-[11px]" style={{ color: "var(--foreground)", opacity: 0.5 }}>
+          {description}
+        </div>
+      </div>
+      <span
+        className="shrink-0 rounded-full px-2 py-0.5 text-[10px] font-bold"
+        style={{
+          background: "var(--color-surface-subtle)",
+          color: "var(--foreground)",
+          opacity: 0.7,
+        }}
+      >
+        近日公開
+      </span>
+    </div>
+  );
+}
+
+/**
+ * 投資余力診断のしくみ（タップで開閉する「ちなみに」トーンの補足）。
+ * ガイドツアー実装後も、いつでも読み返せる常設導線として残す。
+ */
+function MechanismToggle() {
+  const [open, setOpen] = useState(false);
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center gap-3 px-4 py-3.5 text-left"
+      >
+        <div
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md"
+          style={{ background: "var(--color-surface-subtle)" }}
+        >
+          <TrendingUp size={16} style={{ color: "var(--color-brand-primary)" }} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-[13px] font-bold" style={{ color: "var(--foreground)" }}>
+            投資余力診断のしくみ
+          </div>
+          <div className="mt-0.5 text-[11px]" style={{ color: "var(--foreground)", opacity: 0.5 }}>
+            「今月の上限」がどう決まるかの補足です
+          </div>
+        </div>
+        <motion.span
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={SPRING.quick}
+          style={{ flexShrink: 0 }}
+          aria-hidden
+        >
+          <ChevronDown size={14} style={{ color: "var(--foreground)", opacity: 0.5 }} />
+        </motion.span>
+      </button>
+      <AnimatePresence>
+        {open && (
+          <motion.div
+            initial={{ opacity: 0, height: 0 }}
+            animate={{ opacity: 1, height: "auto" }}
+            exit={{ opacity: 0, height: 0 }}
+            transition={SPRING.quick}
+            className="overflow-hidden"
+          >
+            <div className="px-4 pb-4">
+              {/* 「ちなみに」トーンの補足: 読まなくても困らない、脚注のような佇まい */}
+              <div
+                className="rounded-xl px-3.5 py-3"
+                style={{ background: "rgba(28,20,16,0.04)" }}
+              >
+                <p
+                  className="flex items-center gap-1.5 text-xs font-bold"
+                  style={{ color: "var(--foreground)", opacity: 0.75 }}
+                >
+                  <Lightbulb size={13} style={{ color: "var(--color-brand-primary)" }} aria-hidden />
+                  ちなみに、どう計算している？
+                </p>
+                <ul
+                  className="mt-2 space-y-1.5 text-[11px] leading-relaxed"
+                  style={{ color: "var(--foreground)", opacity: 0.6 }}
+                >
+                  <li>・まず「生活費 6 ヶ月分の備え」を最優先。備えが目標に届くまで、投資はおすすめしません</li>
+                  <li>・上限は毎月の黒字の半分まで。残りの半分は現金で手元に残す想定です</li>
+                  <li>・家計にゆとりがあるほどリスク許容度が上がり、検証ツールで比べられる戦略の幅が広がります</li>
+                  <li>・検証ツールに渡すのは「リスク許容度」と「上限額」の 2 つだけ。名前や記録の中身は渡しません</li>
+                </ul>
+              </div>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsClient.tsx
+++ b/apps/web/src/components/settings/SettingsClient.tsx
@@ -256,6 +256,8 @@ export function SettingsClient({ settings }: Props) {
                     key={item.key}
                     type="button"
                     role="tab"
+                    id={`settings-tab-${item.key}`}
+                    aria-controls={`settings-panel-${item.key}`}
                     aria-selected={active}
                     onClick={() => setActiveMenu(item.key)}
                     className="flex flex-1 items-center justify-center gap-1.5 rounded-[10px] py-2 text-[12px] font-bold transition-colors"
@@ -276,6 +278,12 @@ export function SettingsClient({ settings }: Props) {
               })}
             </div>
 
+            <div
+              role="tabpanel"
+              id={`settings-panel-${activeMenu}`}
+              aria-labelledby={`settings-tab-${activeMenu}`}
+              className="space-y-4"
+            >
             {activeMenu === "guide" ? (
               <GuideTab />
             ) : (
@@ -521,6 +529,7 @@ export function SettingsClient({ settings }: Props) {
             </motion.div>
               </>
             )}
+            </div>
           </div>
         </div>
       </motion.div>

--- a/apps/web/src/components/settings/SettingsClient.tsx
+++ b/apps/web/src/components/settings/SettingsClient.tsx
@@ -7,8 +7,9 @@ import Link from "next/link";
 import {
   TrendingUp, Zap, Car, ShoppingBag,
   Wallet, Heart, Home, PiggyBank, Check,
-  User, ChevronRight,
+  User, ChevronRight, BookOpen, Settings as SettingsIcon,
 } from "lucide-react";
+import { GuideTab } from "./GuideTab";
 import { SPRING, PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
 import { calcDailyBudget } from "@budget/common";
 import type { UserSettingsResponse, FixedExpensesDetail } from "@budget/api-client";
@@ -58,6 +59,8 @@ function getBudgetColor(dailyBudget: number): string {
 }
 
 export function SettingsClient({ settings }: Props) {
+  // 設定 / ガイドのタブ切替（#551 / sandbox PersonalSettingsPrototype 承認済み）
+  const [activeMenu, setActiveMenu] = useState<"settings" | "guide">("settings");
   // 設定フォーム状態
   const [salaryDay, setSalaryDay] = useState(settings.paydayDay);
   const [monthlyIncome, setMonthlyIncome] = useState(settings.monthlyIncome);
@@ -232,8 +235,51 @@ export function SettingsClient({ settings }: Props) {
             />
           </div>
 
-          {/* 右カラム: 設定フォーム */}
+          {/* 右カラム: 設定フォーム / ガイド */}
           <div className="space-y-4 lg:col-start-2 lg:row-start-1">
+            {/* 設定 / ガイドのタブ切替 */}
+            <div
+              className="flex gap-0.5 rounded-xl p-0.5"
+              style={{ background: "rgba(28,20,16,0.05)" }}
+              role="tablist"
+              aria-label="設定メニュー"
+            >
+              {(
+                [
+                  { key: "settings", label: "設定", icon: SettingsIcon },
+                  { key: "guide", label: "ガイド", icon: BookOpen },
+                ] as const
+              ).map((item) => {
+                const active = activeMenu === item.key;
+                return (
+                  <motion.button
+                    key={item.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={active}
+                    onClick={() => setActiveMenu(item.key)}
+                    className="flex flex-1 items-center justify-center gap-1.5 rounded-[10px] py-2 text-[12px] font-bold transition-colors"
+                    style={{
+                      background: active ? "var(--color-surface-default)" : "transparent",
+                      color: active
+                        ? "var(--color-brand-primary)"
+                        : "rgba(28,20,16,0.45)",
+                      boxShadow: active ? "var(--shadow-card)" : "none",
+                    }}
+                    whileTap={{ scale: 0.97 }}
+                    transition={SPRING.snap}
+                  >
+                    <item.icon size={13} strokeWidth={active ? 2.3 : 2} />
+                    {item.label}
+                  </motion.button>
+                );
+              })}
+            </div>
+
+            {activeMenu === "guide" ? (
+              <GuideTab />
+            ) : (
+              <>
             {/* 給与セクション */}
             <motion.div variants={PAGE_ITEM_VARIANTS}>
               <SectionCard title="給与">
@@ -473,6 +519,8 @@ export function SettingsClient({ settings }: Props) {
                 <ChevronRight size={14} style={{ color: "var(--foreground)", opacity: 0.3 }} />
               </Link>
             </motion.div>
+              </>
+            )}
           </div>
         </div>
       </motion.div>
@@ -540,7 +588,8 @@ function FieldRow({
 
 // ─── SectionCard ─────────────────────────────────────────────────────────────
 
-function SectionCard({
+// GuideTab（ガイドタブ）からも同じカードシェルを使うため export する
+export function SectionCard({
   title,
   children,
 }: {


### PR DESCRIPTION
## 概要

sandbox PersonalSettingsPrototype で承認済みの設定画面刷新のうち、本番に未実装だった差分（設定/ガイドのタブ切替 + ガイドタブ）を実装する（Sprint #46）。ベントーグリッド・AmountField・プレビューカード等は #396 リビルドで本番反映済みのため対象外。

## 変更内容

- 設定画面の右カラム上部に **設定 / ガイド** のセグメント型タブを追加（デフォルトは設定タブ = 既存挙動そのまま）
- **ガイドタブ**を新設
  - 使い方ガイドの導線カード: 「ホーム画面ガイド」「管理設定ガイド」（ツアー本体が未実装のため「近日公開」プレースホルダ。実装は別 PBI）
  - **「投資余力診断のしくみ」常設トグル**（#545 の設計決定）: タップで「ちなみに、どう計算している？」の補足（備え6ヶ月分最優先 / 黒字の半分 / 渡すのは2つの数字のみ）を開閉。内部用語は使わない
- `SectionCard` を GuideTab から再利用するため export 化

## 影響範囲

デフォルトタブが「設定」のため既存の設定フォーム・保存フロー・E2E（設定保存）への影響なし。

## 規約・設計チェック

- [x] ユビキタス言語（Expense/Income）を遵守しているか
- [x] 境界を跨ぐ不正な依存はないか
- [x] ID（ulid）の生成・利用箇所は適切か（該当なし）
- [x] マジックナンバーを排除し、定数化されているか（該当なし: スタイル値のみ）
- [x] UI/UX 変更がある場合、スクリーンショット添付（sandbox プロトタイプで承認済みのデザインの移植。実機はデプロイ後確認）
- [x] ドキュメント SSOT マップ更新（該当なし）

## スクリーンショット

| | Before | After |
|---|---|---|
| SP | タブなし（設定フォームのみ） | sandbox PersonalSettingsPrototype のガイドタブと同一デザイン（承認済み） |

## Test plan

- `GuideTab.test.tsx` 新規 3 件（近日公開プレースホルダ表示 / 初期状態は閉 / タップで「ちなみに」補足が開き aria-expanded が切り替わる）
- web 全 146 件パス・type-check パス
- E2E（設定保存フロー）はデフォルトタブの挙動が不変のため影響なし

## 関連 Issue

- Closes #551
- Sprint: 46