### PR TITLE
feat(api): 取り込みセッション API を追加する（解析 → 候補列 / 一括登録）

### DIFF
--- a/apps/api/src/__tests__/unit/use-cases/AnalyzeImportUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/AnalyzeImportUseCase.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ImportCandidate } from '@budget/common';
+import { AnalyzeImportUseCase } from '../../../application/use-cases/import/AnalyzeImportUseCase';
+import type { StatementScanService } from '../../../application/services/import/StatementScanService';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import type { Expense } from '../../../domain/models/Expense';
+
+const candidate: ImportCandidate = {
+    date: '2026-06-29',
+    amount: 17504,
+    balanceType: 0,
+    content: 'ニホンガクセイシエンキ',
+    categoryId: 6,
+    confidence: 'high',
+    raw: '29日 ニホンガクセイシエンキ -¥17,504',
+};
+
+function expense(over: Partial<{ date: string; amount: number; balanceType: number; deletedDate: Date | null }>): Expense {
+    return {
+        id: 'ulid-1',
+        amount: over.amount ?? 17504,
+        balanceType: over.balanceType ?? 0,
+        userId: 'user-1',
+        categoryId: 6,
+        content: '既存明細',
+        date: over.date ?? '2026-06-29',
+        createdDate: new Date(),
+        updatedDate: new Date(),
+        deletedDate: over.deletedDate ?? null,
+    } as unknown as Expense;
+}
+
+function makeUseCase(candidates: ImportCandidate[], expenses: Expense[]) {
+    const scanService = {
+        scan: vi.fn().mockResolvedValue({ candidates, skippedRows: 1, source: 'claude-api' }),
+    } as unknown as StatementScanService;
+    const expenseRepository: IExpenseRepository = {
+        findAll: vi.fn(),
+        findByUserId: vi.fn().mockResolvedValue(expenses),
+        findById: vi.fn(),
+        save: vi.fn(),
+        remove: vi.fn(),
+    };
+    return new AnalyzeImportUseCase(scanService, expenseRepository);
+}
+
+const input = { userId: 'user-1', imageBase64: 'aW1n', mimeType: 'image/png' };
+
+describe('AnalyzeImportUseCase', () => {
+    it('既存明細と同日・同額・同収支の候補に重複疑いを付ける', async () => {
+        const useCase = makeUseCase([candidate], [expense({})]);
+        const result = await useCase.execute(input);
+        expect(result.candidates[0].duplicateSuspect).toBe(true);
+        expect(result.skippedRows).toBe(1);
+        expect(result.source).toBe('claude-api');
+    });
+
+    it('日付・金額・収支のいずれかが異なれば重複疑いにしない', async () => {
+        const useCase = makeUseCase(
+            [candidate],
+            [expense({ date: '2026-06-28' }), expense({ amount: 999 }), expense({ balanceType: 1 })]
+        );
+        const result = await useCase.execute(input);
+        expect(result.candidates[0].duplicateSuspect).toBe(false);
+    });
+
+    it('削除済みの既存明細は重複判定の対象にしない', async () => {
+        const useCase = makeUseCase([candidate], [expense({ deletedDate: new Date() })]);
+        const result = await useCase.execute(input);
+        expect(result.candidates[0].duplicateSuspect).toBe(false);
+    });
+});

--- a/apps/api/src/__tests__/unit/use-cases/AnalyzeImportUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/AnalyzeImportUseCase.test.ts
@@ -39,6 +39,7 @@ function makeUseCase(candidates: ImportCandidate[], expenses: Expense[]) {
         findByUserId: vi.fn().mockResolvedValue(expenses),
         findById: vi.fn(),
         save: vi.fn(),
+        saveMany: vi.fn(),
         remove: vi.fn(),
     };
     return new AnalyzeImportUseCase(scanService, expenseRepository);
@@ -62,6 +63,24 @@ describe('AnalyzeImportUseCase', () => {
         );
         const result = await useCase.execute(input);
         expect(result.candidates[0].duplicateSuspect).toBe(false);
+    });
+
+    it('候補ゼロのときは既存明細を照会せず早期リターンする', async () => {
+        const scanService = {
+            scan: vi.fn().mockResolvedValue({ candidates: [], skippedRows: 2, source: 'claude-cli' }),
+        } as unknown as StatementScanService;
+        const expenseRepository: IExpenseRepository = {
+            findAll: vi.fn(),
+            findByUserId: vi.fn(),
+            findById: vi.fn(),
+            save: vi.fn(),
+            saveMany: vi.fn(),
+            remove: vi.fn(),
+        };
+        const result = await new AnalyzeImportUseCase(scanService, expenseRepository).execute(input);
+        expect(result.candidates).toEqual([]);
+        expect(result.skippedRows).toBe(2);
+        expect(expenseRepository.findByUserId).not.toHaveBeenCalled();
     });
 
     it('削除済みの既存明細は重複判定の対象にしない', async () => {

--- a/apps/api/src/__tests__/unit/use-cases/CommitImportUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/CommitImportUseCase.test.ts
@@ -18,6 +18,7 @@ function makeDeps(userExists = true) {
         findByUserId: vi.fn(),
         findById: vi.fn(),
         save: vi.fn().mockImplementation(async (e) => e),
+        saveMany: vi.fn().mockResolvedValue(undefined),
         remove: vi.fn(),
     };
     const userRepository = {
@@ -35,7 +36,9 @@ describe('CommitImportUseCase', () => {
 
         expect(result.ok).toBe(true);
         if (result.ok) expect(result.value.registered).toBe(2);
-        expect(expenseRepository.save).toHaveBeenCalledTimes(2);
+        // 原子的な一括登録（saveMany 1回・個別 save は使わない）
+        expect(expenseRepository.saveMany).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(expenseRepository.saveMany).mock.calls[0][0]).toHaveLength(2);
     });
 
     it('ユーザーが存在しないとき NotFoundError を返す', async () => {
@@ -72,6 +75,6 @@ describe('CommitImportUseCase', () => {
         });
 
         expect(result.ok).toBe(false);
-        expect(expenseRepository.save).not.toHaveBeenCalled();
+        expect(expenseRepository.saveMany).not.toHaveBeenCalled();
     });
 });

--- a/apps/api/src/__tests__/unit/use-cases/CommitImportUseCase.test.ts
+++ b/apps/api/src/__tests__/unit/use-cases/CommitImportUseCase.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+import { CommitImportUseCase, type CommitImportRow } from '../../../application/use-cases/import/CommitImportUseCase';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import type { IUserRepository } from '../../../domain/repositories/IUserRepository';
+import { NotFoundError, ValidationError } from '../../../shared/errors/DomainException';
+
+const row: CommitImportRow = {
+    date: '2026-06-29',
+    amount: 17504,
+    balanceType: 0,
+    categoryId: 6,
+    content: 'ニホンガクセイシエンキ（取り込み）',
+};
+
+function makeDeps(userExists = true) {
+    const expenseRepository: IExpenseRepository = {
+        findAll: vi.fn(),
+        findByUserId: vi.fn(),
+        findById: vi.fn(),
+        save: vi.fn().mockImplementation(async (e) => e),
+        remove: vi.fn(),
+    };
+    const userRepository = {
+        findById: vi.fn().mockResolvedValue(userExists ? { userId: 'user-1' } : null),
+    } as unknown as IUserRepository;
+    return { expenseRepository, userRepository };
+}
+
+describe('CommitImportUseCase', () => {
+    it('選択済みの行を明細として一括登録し件数を返す', async () => {
+        const { expenseRepository, userRepository } = makeDeps();
+        const useCase = new CommitImportUseCase(expenseRepository, userRepository);
+
+        const result = await useCase.execute({ userId: 'user-1', rows: [row, { ...row, amount: 900 }] });
+
+        expect(result.ok).toBe(true);
+        if (result.ok) expect(result.value.registered).toBe(2);
+        expect(expenseRepository.save).toHaveBeenCalledTimes(2);
+    });
+
+    it('ユーザーが存在しないとき NotFoundError を返す', async () => {
+        const { expenseRepository, userRepository } = makeDeps(false);
+        const useCase = new CommitImportUseCase(expenseRepository, userRepository);
+
+        const result = await useCase.execute({ userId: 'ghost', rows: [row] });
+
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toBeInstanceOf(NotFoundError);
+    });
+
+    it('0 件・上限超過は ValidationError を返す', async () => {
+        const { expenseRepository, userRepository } = makeDeps();
+        const useCase = new CommitImportUseCase(expenseRepository, userRepository);
+
+        const empty = await useCase.execute({ userId: 'user-1', rows: [] });
+        expect(!empty.ok && empty.error).toBeInstanceOf(ValidationError);
+
+        const tooMany = await useCase.execute({
+            userId: 'user-1',
+            rows: Array.from({ length: 101 }, () => row),
+        });
+        expect(!tooMany.ok && tooMany.error).toBeInstanceOf(ValidationError);
+    });
+
+    it('1 行でも不正（金額0以下）があれば全体を登録せず失敗させる', async () => {
+        const { expenseRepository, userRepository } = makeDeps();
+        const useCase = new CommitImportUseCase(expenseRepository, userRepository);
+
+        const result = await useCase.execute({
+            userId: 'user-1',
+            rows: [row, { ...row, amount: 0 }],
+        });
+
+        expect(result.ok).toBe(false);
+        expect(expenseRepository.save).not.toHaveBeenCalled();
+    });
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -22,6 +22,8 @@ import type { GetUserSettingsUseCase } from './application/use-cases/settings/Ge
 import type { UpsertUserSettingsUseCase } from './application/use-cases/settings/UpsertUserSettingsUseCase';
 import type { GetDashboardUseCase } from './application/use-cases/dashboard/GetDashboardUseCase';
 import type { RegisterAutoFixedExpensesUseCase } from './application/use-cases/dashboard/RegisterAutoFixedExpensesUseCase';
+import type { AnalyzeImportUseCase } from './application/use-cases/import/AnalyzeImportUseCase';
+import type { CommitImportUseCase } from './application/use-cases/import/CommitImportUseCase';
 import type { ReceiptScanService } from './application/services/receipt/ReceiptScanService';
 import { buildServices } from './container';
 import type { ICategoryRepository } from './domain/repositories/ICategoryRepository';
@@ -35,6 +37,7 @@ import type { IUserRepository } from './domain/repositories/IUserRepository';
 import { createCategoryRoutes } from './presentation/routes/category';
 import { createDashboardRoutes } from './presentation/routes/dashboard';
 import { createReceiptRoutes } from './presentation/routes/receipt';
+import { createImportRoutes } from './presentation/routes/imports';
 import { createAuthRoutes } from './presentation/routes/auth';
 import { createSettingsRoutes } from './presentation/routes/settings';
 import { createBudgetRoutes } from './presentation/routes/budget';
@@ -94,6 +97,9 @@ export type RouteServices = {
     registerAutoFixedExpensesUseCase: RegisterAutoFixedExpensesUseCase;
     // Receipt（#514）
     receiptScanService: ReceiptScanService;
+    // Import（#564）
+    analyzeImportUseCase: AnalyzeImportUseCase;
+    commitImportUseCase: CommitImportUseCase;
 };
 
 /** Hono context の型変数定義（認証済みルートで userId を参照するために使用） */
@@ -137,6 +143,7 @@ export function createApp(deps: AppDeps) {
     app.route('/api', createExportRoutes(services));
     app.route('/api', createSettingsRoutes(services));
     app.route('/api', createReceiptRoutes(services));
+    app.route('/api', createImportRoutes(services));
 
     app.onError((err, c) => {
         if (err instanceof DomainException) {

--- a/apps/api/src/application/use-cases/import/AnalyzeImportUseCase.ts
+++ b/apps/api/src/application/use-cases/import/AnalyzeImportUseCase.ts
@@ -1,0 +1,59 @@
+import type { ImportCandidate } from '@budget/common';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import type { StatementScanService } from '../../services/import/StatementScanService';
+import type { StatementAnalyzerSource } from '../../services/import/StatementAnalyzer';
+
+/** 確認画面へ返す候補（既存明細との重複疑いを付与） */
+export type AnalyzedCandidate = ImportCandidate & {
+    /** 既存明細（手動・固定費自動登録を含む）と同日・同額・同収支のとき true */
+    duplicateSuspect: boolean;
+};
+
+export type AnalyzeImportResult = {
+    candidates: AnalyzedCandidate[];
+    skippedRows: number;
+    source: StatementAnalyzerSource;
+};
+
+export type AnalyzeImportInput = {
+    userId: string;
+    imageBase64: string;
+    mimeType: string;
+};
+
+/**
+ * スクショ一括取り込みの解析（#564 / #559 シナリオ1・3）。
+ * 解析エンジン（#563）の候補列に、既存明細との重複疑いを付けて返す。
+ * 重複疑いは除外ではなくマークに留め、含め直しはユーザーの判断に委ねる。
+ */
+export class AnalyzeImportUseCase {
+    constructor(
+        private readonly statementScanService: StatementScanService,
+        private readonly expenseRepository: IExpenseRepository
+    ) {}
+
+    async execute(input: AnalyzeImportInput): Promise<AnalyzeImportResult> {
+        const scan = await this.statementScanService.scan({
+            imageBase64: input.imageBase64,
+            mimeType: input.mimeType,
+            userId: input.userId,
+        });
+
+        // 既存明細（未削除）と同日・同額・同収支なら重複疑い
+        const expenses = await this.expenseRepository.findByUserId(input.userId);
+        const existingKeys = new Set(
+            expenses
+                .filter((e) => !e.deletedDate)
+                .map((e) => `${e.date}:${e.amount}:${e.balanceType}`)
+        );
+
+        const candidates = scan.candidates.map((candidate) => ({
+            ...candidate,
+            duplicateSuspect: existingKeys.has(
+                `${candidate.date}:${candidate.amount}:${candidate.balanceType}`
+            ),
+        }));
+
+        return { candidates, skippedRows: scan.skippedRows, source: scan.source };
+    }
+}

--- a/apps/api/src/application/use-cases/import/AnalyzeImportUseCase.ts
+++ b/apps/api/src/application/use-cases/import/AnalyzeImportUseCase.ts
@@ -39,6 +39,11 @@ export class AnalyzeImportUseCase {
             userId: input.userId,
         });
 
+        // 候補ゼロなら重複判定のクエリを省略して早期リターン（レビュー指摘対応）
+        if (scan.candidates.length === 0) {
+            return { candidates: [], skippedRows: scan.skippedRows, source: scan.source };
+        }
+
         // 既存明細（未削除）と同日・同額・同収支なら重複疑い
         const expenses = await this.expenseRepository.findByUserId(input.userId);
         const existingKeys = new Set(

--- a/apps/api/src/application/use-cases/import/CommitImportUseCase.ts
+++ b/apps/api/src/application/use-cases/import/CommitImportUseCase.ts
@@ -67,9 +67,8 @@ export class CommitImportUseCase {
             );
         }
 
-        for (const expense of expenses) {
-            await this.expenseRepository.save(expense);
-        }
+        // 原子的な一括登録（部分登録を防ぐ・レビュー指摘対応）
+        await this.expenseRepository.saveMany(expenses);
         return ok({ registered: expenses.length });
     }
 }

--- a/apps/api/src/application/use-cases/import/CommitImportUseCase.ts
+++ b/apps/api/src/application/use-cases/import/CommitImportUseCase.ts
@@ -1,0 +1,75 @@
+import { Expense } from '../../../domain/models/Expense';
+import type { IExpenseRepository } from '../../../domain/repositories/IExpenseRepository';
+import type { IUserRepository } from '../../../domain/repositories/IUserRepository';
+import { NotFoundError, ValidationError } from '../../../shared/errors/DomainException';
+import { type Result, err, ok } from '../../../shared/types/result';
+
+/** 確認画面で選択・編集された登録対象行 */
+export type CommitImportRow = {
+    date: string;
+    amount: number;
+    balanceType: 0 | 1;
+    categoryId: number;
+    content: string;
+};
+
+export type CommitImportInput = {
+    userId: string;
+    rows: CommitImportRow[];
+};
+
+/** 一括登録の上限（1回のスクショ由来として妥当な範囲に制限する） */
+const MAX_ROWS_PER_COMMIT = 100;
+
+/**
+ * 選択済みの取り込み候補を明細へ一括登録する（#564 / #559 シナリオ4）。
+ * バリデーションは Expense.create（ドメイン規則）に委譲し、
+ * 1 行でも不正があれば登録前に全体を失敗させる（部分登録による混乱を防ぐ）。
+ */
+export class CommitImportUseCase {
+    constructor(
+        private readonly expenseRepository: IExpenseRepository,
+        private readonly userRepository: IUserRepository
+    ) {}
+
+    async execute(
+        input: CommitImportInput
+    ): Promise<Result<{ registered: number }, NotFoundError | ValidationError>> {
+        const user = await this.userRepository.findById(input.userId);
+        if (!user) {
+            return err(new NotFoundError(`ユーザーが見つかりません: ${input.userId}`));
+        }
+        if (input.rows.length === 0) {
+            return err(new ValidationError('登録対象の明細が選択されていません'));
+        }
+        if (input.rows.length > MAX_ROWS_PER_COMMIT) {
+            return err(new ValidationError(`一度に登録できるのは ${MAX_ROWS_PER_COMMIT} 件までです`));
+        }
+
+        // 先に全行をドメイン規則で検証してから保存する（途中失敗の防止）
+        let expenses: Expense[];
+        try {
+            expenses = input.rows.map((row) =>
+                Expense.create({
+                    amount: row.amount,
+                    balanceType: row.balanceType,
+                    userId: input.userId,
+                    categoryId: row.categoryId,
+                    content: row.content,
+                    date: row.date,
+                })
+            );
+        } catch (error) {
+            return err(
+                new ValidationError(
+                    error instanceof Error ? error.message : '明細の内容が不正です'
+                )
+            );
+        }
+
+        for (const expense of expenses) {
+            await this.expenseRepository.save(expense);
+        }
+        return ok({ registered: expenses.length });
+    }
+}

--- a/apps/api/src/container.ts
+++ b/apps/api/src/container.ts
@@ -9,6 +9,11 @@ import { GetCategoriesUseCase } from './application/use-cases/category/GetCatego
 import { CreateExpenseUseCase } from './application/use-cases/CreateExpenseUseCase';
 import { GetDashboardUseCase } from './application/use-cases/dashboard/GetDashboardUseCase';
 import { RegisterAutoFixedExpensesUseCase } from './application/use-cases/dashboard/RegisterAutoFixedExpensesUseCase';
+import { AnalyzeImportUseCase } from './application/use-cases/import/AnalyzeImportUseCase';
+import { CommitImportUseCase } from './application/use-cases/import/CommitImportUseCase';
+import { ClaudeApiStatementAnalyzer } from './application/services/import/ClaudeApiStatementAnalyzer';
+import { ClaudeCliStatementAnalyzer } from './application/services/import/ClaudeCliStatementAnalyzer';
+import { StatementScanService } from './application/services/import/StatementScanService';
 import { ExportUserDataUseCase } from './application/use-cases/export/ExportUserDataUseCase';
 import { ParseExpenseUseCase, RuleBasedExpenseParser } from './application/use-cases/parse/ParseExpenseUseCase';
 import { UpdateExpenseUseCase } from './application/use-cases/UpdateExpenseUseCase';
@@ -100,6 +105,15 @@ export function buildServices(deps: AppDeps, tokenService: TokenService): RouteS
             deps.autoFixedRegistrar
         ),
         // Receipt（#514）: claude CLI（ローカル・課金ゼロ）→ Claude API（キー設定時）→ OCR の順にフォールバック
+        // Import（#564）: 明細一覧スクショ → 候補抽出 → 一括登録
+        analyzeImportUseCase: new AnalyzeImportUseCase(
+            new StatementScanService([
+                new ClaudeCliStatementAnalyzer(),
+                new ClaudeApiStatementAnalyzer(new LlmClient(), new LlmUsageGuard(new PrismaLlmUsageRepository(prisma))),
+            ]),
+            deps.expenseRepository
+        ),
+        commitImportUseCase: new CommitImportUseCase(deps.expenseRepository, deps.userRepository),
         receiptScanService: new ReceiptScanService([
             new ClaudeCliReceiptAnalyzer(),
             new ClaudeApiReceiptAnalyzer(new LlmClient(), new LlmUsageGuard(new PrismaLlmUsageRepository(prisma))),

--- a/apps/api/src/domain/repositories/IExpenseRepository.ts
+++ b/apps/api/src/domain/repositories/IExpenseRepository.ts
@@ -5,5 +5,7 @@ export interface IExpenseRepository {
     findByUserId(userId: string): Promise<Expense[]>;
     findById(id: string): Promise<Expense | null>;
     save(expense: Expense): Promise<Expense>;
+    /** 複数明細を原子的に一括登録する（全件成功 or 全件失敗。#564 の一括取り込みで使用） */
+    saveMany(expenses: Expense[]): Promise<void>;
     remove(id: string): Promise<void>;
 }

--- a/apps/api/src/infrastructure/persistence/PrismaExpenseRepository.ts
+++ b/apps/api/src/infrastructure/persistence/PrismaExpenseRepository.ts
@@ -44,6 +44,21 @@ export class PrismaExpenseRepository implements IExpenseRepository {
         return record ? toDomain(record) : null;
     }
 
+    async saveMany(expenses: Expense[]): Promise<void> {
+        // createMany は単一ステートメントのため原子的（途中失敗による部分登録が起きない）
+        await this.prisma.budgetList.createMany({
+            data: expenses.map((expense) => ({
+                id: expense.id,
+                amount: expense.amount,
+                balanceType: expense.balanceType,
+                userId: expense.userId,
+                categoryId: expense.categoryId,
+                content: expense.content,
+                date: expense.date,
+            })),
+        });
+    }
+
     async save(expense: Expense): Promise<Expense> {
         const record = await this.prisma.budgetList.upsert({
             where: { id: expense.id },

--- a/apps/api/src/openapi/schemas.ts
+++ b/apps/api/src/openapi/schemas.ts
@@ -569,6 +569,81 @@ export const DashboardResponseSchema = z
 
 // ── レシート読取（#514） ─────────────────────────────────────────
 
+// ─── スクショ一括取り込み（#564）─────────────────────────────────
+
+export const ImportAnalyzeBodySchema = z
+    .object({
+        image: z
+            .string()
+            .min(1)
+            .max(10_000_000)
+            .openapi({ description: 'base64 エンコード済み画像（data: プレフィックスなし・最大約7MB）' }),
+        mimeType: z.enum(['image/jpeg', 'image/png']).openapi({ description: '画像の MIME タイプ' }),
+    })
+    .openapi('ImportAnalyzeBody');
+
+export const ImportCandidateSchema = z
+    .object({
+        date: z.string().openapi({ description: 'YYYY-MM-DD', example: '2026-06-29' }),
+        amount: z.number().int().min(1).openapi({ description: '金額（正の整数・円）', example: 17504 }),
+        balanceType: z
+            .union([z.literal(0), z.literal(1)])
+            .openapi({ description: '0=支出, 1=収入', example: 0 }),
+        content: z.string().openapi({ description: '摘要（店名・振込元など）' }),
+        categoryId: z.number().int().min(0).openapi({ description: '推定カテゴリ ID（0=その他）' }),
+        confidence: z.enum(['high', 'low']).openapi({ description: '解析の確からしさ。low は要確認' }),
+        raw: z.string().openapi({ description: '読み取った元の行テキスト（監査用）' }),
+        duplicateSuspect: z
+            .boolean()
+            .openapi({ description: '既存明細と同日・同額・同収支のとき true（登録済みの可能性）' }),
+    })
+    .openapi('ImportCandidate');
+
+export const ImportAnalyzeResponseSchema = z
+    .object({
+        candidates: z.array(ImportCandidateSchema),
+        skippedRows: z
+            .number()
+            .int()
+            .min(0)
+            .openapi({ description: '解析器が出力したが検証で弾かれた行数（部分成功の明示）' }),
+        source: z.enum(['claude-cli', 'claude-api']).openapi({ description: '使用された解析手段' }),
+    })
+    .openapi('ImportAnalyzeResponse');
+
+export const ImportCommitBodySchema = z
+    .object({
+        rows: z
+            .array(
+                z.object({
+                    date: z
+                        .string()
+                        .regex(/^\d{4}-\d{2}-\d{2}$/, '日付は YYYY-MM-DD 形式で入力してください')
+                        .openapi({ description: 'YYYY-MM-DD' }),
+                    amount: z
+                        .number({ invalid_type_error: '金額は数値で入力してください' })
+                        .int()
+                        .min(1, '金額は1以上の値を入力してください')
+                        .openapi({ description: '金額（円）' }),
+                    balanceType: z
+                        .union([z.literal(0), z.literal(1)])
+                        .openapi({ description: '0=支出, 1=収入' }),
+                    categoryId: z.number().int().min(0).openapi({ description: 'カテゴリ ID' }),
+                    content: z.string().max(255).openapi({ description: '摘要' }),
+                })
+            )
+            .min(1, '登録対象の明細が選択されていません')
+            .max(100, '一度に登録できるのは 100 件までです')
+            .openapi({ description: '確認画面で選択・編集済みの登録対象行' }),
+    })
+    .openapi('ImportCommitBody');
+
+export const ImportCommitResponseSchema = z
+    .object({
+        registered: z.number().int().min(0).openapi({ description: '登録した明細数', example: 6 }),
+    })
+    .openapi('ImportCommitResponse');
+
 export const ReceiptScanBodySchema = z
     .object({
         image: z

--- a/apps/api/src/presentation/routes/imports.ts
+++ b/apps/api/src/presentation/routes/imports.ts
@@ -1,0 +1,118 @@
+import { createRoute } from '@hono/zod-openapi';
+import type { RouteServices } from '../../app';
+import { createOpenAPIApp } from '../../lib/openapi-app';
+import {
+    ErrorResponseSchema,
+    ImportAnalyzeBodySchema,
+    ImportAnalyzeResponseSchema,
+    ImportCommitBodySchema,
+    ImportCommitResponseSchema,
+} from '../../openapi/schemas';
+import { createAuthMiddleware } from '../middleware/auth';
+
+const analyzeImportRoute = createRoute({
+    method: 'post',
+    path: '/imports/analyze',
+    tags: ['Import'],
+    summary: '明細一覧スクショの解析（取り込み候補の抽出）',
+    description:
+        'マネーツリー等の明細一覧スクショから取り込み候補を抽出し、既存明細との重複疑いを付けて返す。画像は解析後に破棄され保存されない。',
+    security: [{ bearerAuth: [] }],
+    request: {
+        body: {
+            required: true,
+            content: { 'application/json': { schema: ImportAnalyzeBodySchema } },
+        },
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: ImportAnalyzeResponseSchema } },
+            description: '取り込み候補列（skippedRows で部分成功を明示）',
+        },
+        400: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'バリデーションエラー・全手段で解析失敗',
+        },
+        401: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: '未認証',
+        },
+        429: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'AI 使用制限の超過',
+        },
+    },
+});
+
+const commitImportRoute = createRoute({
+    method: 'post',
+    path: '/imports/commit',
+    tags: ['Import'],
+    summary: '選択済み候補の一括登録',
+    description: '確認画面で選択・編集された候補を明細として一括登録する。登録後は通常の明細として編集・削除できる。',
+    security: [{ bearerAuth: [] }],
+    request: {
+        body: {
+            required: true,
+            content: { 'application/json': { schema: ImportCommitBodySchema } },
+        },
+    },
+    responses: {
+        200: {
+            content: { 'application/json': { schema: ImportCommitResponseSchema } },
+            description: '登録完了（登録件数）',
+        },
+        400: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'バリデーションエラー',
+        },
+        401: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: '未認証',
+        },
+        404: {
+            content: { 'application/json': { schema: ErrorResponseSchema } },
+            description: 'ユーザーが見つからない',
+        },
+    },
+});
+
+export function createImportRoutes({
+    tokenService,
+    analyzeImportUseCase,
+    commitImportUseCase,
+}: RouteServices) {
+    const auth = createAuthMiddleware(tokenService);
+    const app = createOpenAPIApp();
+
+    app.use('/imports/*', auth);
+
+    app.openapi(analyzeImportRoute, async (c) => {
+        const userId = c.get('userId');
+        const { image, mimeType } = c.req.valid('json');
+
+        const result = await analyzeImportUseCase.execute({
+            userId,
+            imageBase64: image,
+            mimeType,
+        });
+
+        return c.json(result, 200);
+    });
+
+    app.openapi(commitImportRoute, async (c) => {
+        const userId = c.get('userId');
+        const { rows } = c.req.valid('json');
+
+        const result = await commitImportUseCase.execute({ userId, rows });
+        if (!result.ok) {
+            return c.json(
+                { result: 'error' as const, message: result.error.message },
+                result.error.statusCode as 400 | 404
+            );
+        }
+        return c.json({ registered: result.value.registered }, 200);
+    });
+
+    return app;
+}

--- a/packages/api-client/src/schema.d.ts
+++ b/packages/api-client/src/schema.d.ts
@@ -1631,6 +1631,146 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/imports/analyze": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 明細一覧スクショの解析（取り込み候補の抽出）
+         * @description マネーツリー等の明細一覧スクショから取り込み候補を抽出し、既存明細との重複疑いを付けて返す。画像は解析後に破棄され保存されない。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ImportAnalyzeBody"];
+                };
+            };
+            responses: {
+                /** @description 取り込み候補列（skippedRows で部分成功を明示） */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ImportAnalyzeResponse"];
+                    };
+                };
+                /** @description バリデーションエラー・全手段で解析失敗 */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description AI 使用制限の超過 */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/imports/commit": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * 選択済み候補の一括登録
+         * @description 確認画面で選択・編集された候補を明細として一括登録する。登録後は通常の明細として編集・削除できる。
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ImportCommitBody"];
+                };
+            };
+            responses: {
+                /** @description 登録完了（登録件数） */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ImportCommitResponse"];
+                    };
+                };
+                /** @description バリデーションエラー */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description 未認証 */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+                /** @description ユーザーが見つからない */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ErrorResponse"];
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2360,6 +2500,77 @@ export interface components {
              * @enum {string}
              */
             mimeType: "image/jpeg" | "image/png";
+        };
+        ImportCandidate: {
+            /**
+             * @description YYYY-MM-DD
+             * @example 2026-06-29
+             */
+            date: string;
+            /**
+             * @description 金額（正の整数・円）
+             * @example 17504
+             */
+            amount: number;
+            /**
+             * @description 0=支出, 1=収入
+             * @example 0
+             */
+            balanceType: 0 | 1;
+            /** @description 摘要（店名・振込元など） */
+            content: string;
+            /** @description 推定カテゴリ ID（0=その他） */
+            categoryId: number;
+            /**
+             * @description 解析の確からしさ。low は要確認
+             * @enum {string}
+             */
+            confidence: "high" | "low";
+            /** @description 読み取った元の行テキスト（監査用） */
+            raw: string;
+            /** @description 既存明細と同日・同額・同収支のとき true（登録済みの可能性） */
+            duplicateSuspect: boolean;
+        };
+        ImportAnalyzeResponse: {
+            candidates: components["schemas"]["ImportCandidate"][];
+            /** @description 解析器が出力したが検証で弾かれた行数（部分成功の明示） */
+            skippedRows: number;
+            /**
+             * @description 使用された解析手段
+             * @enum {string}
+             */
+            source: "claude-cli" | "claude-api";
+        };
+        ImportAnalyzeBody: {
+            /** @description base64 エンコード済み画像（data: プレフィックスなし・最大約7MB） */
+            image: string;
+            /**
+             * @description 画像の MIME タイプ
+             * @enum {string}
+             */
+            mimeType: "image/jpeg" | "image/png";
+        };
+        ImportCommitResponse: {
+            /**
+             * @description 登録した明細数
+             * @example 6
+             */
+            registered: number;
+        };
+        ImportCommitBody: {
+            /** @description 確認画面で選択・編集済みの登録対象行 */
+            rows: {
+                /** @description YYYY-MM-DD */
+                date: string;
+                /** @description 金額（円） */
+                amount: number;
+                /** @description 0=支出, 1=収入 */
+                balanceType: 0 | 1;
+                /** @description カテゴリ ID */
+                categoryId: number;
+                /** @description 摘要 */
+                content: string;
+            }[];
         };
     };
     responses: never;

--- a/packages/api-spec/openapi.yaml
+++ b/packages/api-spec/openapi.yaml
@@ -1016,6 +1016,148 @@ components:
       required:
         - image
         - mimeType
+    ImportCandidate:
+      type: object
+      properties:
+        date:
+          type: string
+          description: YYYY-MM-DD
+          example: 2026-06-29
+        amount:
+          type: integer
+          minimum: 1
+          description: 金額（正の整数・円）
+          example: 17504
+        balanceType:
+          anyOf:
+            - type: number
+              enum:
+                - 0
+            - type: number
+              enum:
+                - 1
+          description: 0=支出, 1=収入
+          example: 0
+        content:
+          type: string
+          description: 摘要（店名・振込元など）
+        categoryId:
+          type: integer
+          minimum: 0
+          description: 推定カテゴリ ID（0=その他）
+        confidence:
+          type: string
+          enum:
+            - high
+            - low
+          description: 解析の確からしさ。low は要確認
+        raw:
+          type: string
+          description: 読み取った元の行テキスト（監査用）
+        duplicateSuspect:
+          type: boolean
+          description: 既存明細と同日・同額・同収支のとき true（登録済みの可能性）
+      required:
+        - date
+        - amount
+        - balanceType
+        - content
+        - categoryId
+        - confidence
+        - raw
+        - duplicateSuspect
+    ImportAnalyzeResponse:
+      type: object
+      properties:
+        candidates:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportCandidate"
+        skippedRows:
+          type: integer
+          minimum: 0
+          description: 解析器が出力したが検証で弾かれた行数（部分成功の明示）
+        source:
+          type: string
+          enum:
+            - claude-cli
+            - claude-api
+          description: 使用された解析手段
+      required:
+        - candidates
+        - skippedRows
+        - source
+    ImportAnalyzeBody:
+      type: object
+      properties:
+        image:
+          type: string
+          minLength: 1
+          maxLength: 10000000
+          description: "base64 エンコード済み画像（data: プレフィックスなし・最大約7MB）"
+        mimeType:
+          type: string
+          enum:
+            - image/jpeg
+            - image/png
+          description: 画像の MIME タイプ
+      required:
+        - image
+        - mimeType
+    ImportCommitResponse:
+      type: object
+      properties:
+        registered:
+          type: integer
+          minimum: 0
+          description: 登録した明細数
+          example: 6
+      required:
+        - registered
+    ImportCommitBody:
+      type: object
+      properties:
+        rows:
+          type: array
+          items:
+            type: object
+            properties:
+              date:
+                type: string
+                pattern: ^\d{4}-\d{2}-\d{2}$
+                description: YYYY-MM-DD
+              amount:
+                type: integer
+                minimum: 1
+                description: 金額（円）
+              balanceType:
+                anyOf:
+                  - type: number
+                    enum:
+                      - 0
+                  - type: number
+                    enum:
+                      - 1
+                description: 0=支出, 1=収入
+              categoryId:
+                type: integer
+                minimum: 0
+                description: カテゴリ ID
+              content:
+                type: string
+                maxLength: 255
+                description: 摘要
+            required:
+              - date
+              - amount
+              - balanceType
+              - categoryId
+              - content
+          minItems: 1
+          maxItems: 100
+          description: 確認画面で選択・編集済みの登録対象行
+      required:
+        - rows
   parameters: {}
 paths:
   /api/login:
@@ -2050,6 +2192,84 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: 全手段で解析に失敗
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/imports/analyze:
+    post:
+      tags:
+        - Import
+      summary: 明細一覧スクショの解析（取り込み候補の抽出）
+      description: マネーツリー等の明細一覧スクショから取り込み候補を抽出し、既存明細との重複疑いを付けて返す。画像は解析後に破棄され保存されない。
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportAnalyzeBody"
+      responses:
+        "200":
+          description: 取り込み候補列（skippedRows で部分成功を明示）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportAnalyzeResponse"
+        "400":
+          description: バリデーションエラー・全手段で解析失敗
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: 未認証
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "429":
+          description: AI 使用制限の超過
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /api/imports/commit:
+    post:
+      tags:
+        - Import
+      summary: 選択済み候補の一括登録
+      description: 確認画面で選択・編集された候補を明細として一括登録する。登録後は通常の明細として編集・削除できる。
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportCommitBody"
+      responses:
+        "200":
+          description: 登録完了（登録件数）
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportCommitResponse"
+        "400":
+          description: バリデーションエラー
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "401":
+          description: 未認証
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: ユーザーが見つからない
           content:
             application/json:
               schema:


### PR DESCRIPTION
## 概要

スクショ一括取り込み（#559）の API 層（PBI ②・Sprint #47）。解析エンジン（#568）を HTTP から使えるようにし、確認画面（#569 プロトタイプ → #566 本番）からの一括登録を受ける。

## 変更内容

- **POST /imports/analyze**: 画像（base64・最大約7MB）→ 取り込み候補列 + `skippedRows`（部分成功の明示）+ `source`
  - 既存明細（未削除・固定費自動登録含む）と同日・同額・同収支の候補に `duplicateSuspect: true` を付与（#559 シナリオ3。除外ではなくマークに留め、判断はユーザーに委ねる）
  - 画像は解析後に破棄（永続保存しない）。LlmUsageGuard 超過は 429
- **POST /imports/commit**: 選択・編集済みの行（1〜100件）→ 明細へ一括登録
  - 全行を `Expense.create`（ドメイン規則）で検証してから保存し、1行でも不正なら登録前に全体を失敗させる（部分登録の混乱防止）
- openapi スキーマ追加 + `pnpm codegen` で api-client 型を再生成
- container / RouteServices への配線（StatementScanService は cli → api フォールバック）

## 影響範囲

新規エンドポイントのみ。既存の明細登録・レシート読み取りへの変更なし。

## 規約・設計チェック

- [x] ユビキタス言語遵守 / [x] 境界依存なし（route → use-case → service/repository） / [x] ulid は Expense.create 内で生成 / [x] マジックナンバー定数化（MAX_ROWS_PER_COMMIT） / [x] UI 変更なし / [x] SSOT マップ該当なし

## スクリーンショット

該当なし（API のみ）

## Test plan

- `AnalyzeImportUseCase` 3 件（重複疑い付与 / 不一致は付与しない / 削除済みは対象外）
- `CommitImportUseCase` 4 件（一括登録 / ユーザー不在 / 0件・上限超過 / 1行不正で全体失敗・保存なし）
- apps/api unit 全 119 件パス・type-check（全 7 パッケージ）・biome lint パス

## 関連 Issue

- Closes #564
- Sprint: 47