### PR TITLE
feat(mobile,common,web): モバイルホームをスワイプビュー + 最近の記録に再構成する

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { AppHeader } from '@/components/layout/AppHeader';
 import { InvestmentCapacityCard } from '@/components/dashboard/InvestmentCapacityCard';
 import { LivingMarginCard } from '@/components/dashboard/LivingMarginCard';
 import { MonthlySummaryCard } from '@/components/dashboard/MonthlySummaryCard';
+import { SavingsForecastCard } from '@/components/dashboard/SavingsForecastCard';
 import { TodayStatusCard } from '@/components/dashboard/TodayStatusCard';
 import { WeeklyStreak } from '@/components/dashboard/WeeklyStreak';
 import { colors } from '@/theme/tokens';
@@ -67,6 +68,13 @@ function Dashboard({ data, today }: { data: DashboardData; today?: Date }) {
         weeklyRecord={data.weeklyRecord}
         dailyBudget={data.dailyBudget?.amount ?? null}
         streak={data.streak}
+      />
+      {/* 今月の貯蓄予測（#575 / Web #458 のパリティ） */}
+      <SavingsForecastCard
+        monthSummary={data.monthSummary}
+        todayExpense={data.todayExpense}
+        savingsGoal={data.savingsGoal}
+        today={today}
       />
       <MonthlySummaryCard
         monthSummary={data.monthSummary}

--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -8,9 +8,15 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  calculateInvestmentCapacity,
+  HOME_CAROUSEL_SLIDES,
+  type HomeCarouselSlideKey,
+} from '@budget/common';
 import { useDashboard, type DashboardData } from '@/lib/api/use-dashboard';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { InvestmentCapacityCard } from '@/components/dashboard/InvestmentCapacityCard';
+import { DashboardCarousel, type CarouselSlide } from '@/components/dashboard/DashboardCarousel';
 import { LivingMarginCard } from '@/components/dashboard/LivingMarginCard';
 import { MonthlySummaryCard } from '@/components/dashboard/MonthlySummaryCard';
 import { SavingsForecastCard } from '@/components/dashboard/SavingsForecastCard';
@@ -52,6 +58,46 @@ export default function HomeScreen() {
   );
 }
 
+/**
+ * スワイプビューのスライド構成（#576）。
+ * 順序・キー・ラベルは common の HOME_CAROUSEL_SLIDES（SSOT）に従い、Web SP と一致させる。
+ * 投資余力は算出不能のときスライドごと出さない（Web と同一ルール）。
+ */
+function buildCarouselSlides(data: DashboardData, today?: Date): CarouselSlide[] {
+  const nodes: Record<HomeCarouselSlideKey, React.ReactNode> = {
+    'margin-streak': (
+      <View style={styles.slideStack}>
+        <LivingMarginCard livingMargin={data.livingMargin} />
+        <WeeklyStreak
+          weeklyRecord={data.weeklyRecord}
+          dailyBudget={data.dailyBudget?.amount ?? null}
+          streak={data.streak}
+        />
+      </View>
+    ),
+    'savings-forecast': (
+      <SavingsForecastCard
+        monthSummary={data.monthSummary}
+        todayExpense={data.todayExpense}
+        savingsGoal={data.savingsGoal}
+        today={today}
+      />
+    ),
+    'monthly-summary': (
+      <MonthlySummaryCard
+        monthSummary={data.monthSummary}
+        lastMonthExpense={data.lastMonthExpense}
+        today={today}
+      />
+    ),
+    'investment-capacity': <InvestmentCapacityCard livingMargin={data.livingMargin} />,
+  };
+  const investable = calculateInvestmentCapacity(data.livingMargin).status === 'ok';
+  return HOME_CAROUSEL_SLIDES.filter(
+    (slide) => slide.key !== 'investment-capacity' || investable
+  ).map((slide) => ({ key: slide.key, label: slide.label, node: nodes[slide.key] }));
+}
+
 /** today はテスト・VRT で決定論的にレンダリングするための注入口（Web の DailyBudgetHero と同パターン） */
 function Dashboard({ data, today }: { data: DashboardData; today?: Date }) {
   return (
@@ -63,26 +109,8 @@ function Dashboard({ data, today }: { data: DashboardData; today?: Date }) {
         savingsGoal={data.savingsGoal}
         today={today}
       />
-      <LivingMarginCard livingMargin={data.livingMargin} />
-      <WeeklyStreak
-        weeklyRecord={data.weeklyRecord}
-        dailyBudget={data.dailyBudget?.amount ?? null}
-        streak={data.streak}
-      />
-      {/* 今月の貯蓄予測（#575 / Web #458 のパリティ） */}
-      <SavingsForecastCard
-        monthSummary={data.monthSummary}
-        todayExpense={data.todayExpense}
-        savingsGoal={data.savingsGoal}
-        today={today}
-      />
-      <MonthlySummaryCard
-        monthSummary={data.monthSummary}
-        lastMonthExpense={data.lastMonthExpense}
-        today={today}
-      />
-      {/* 投資余力（#543 / #545）。Web と同じく MonthlySummary の後・算出不能時は非表示 */}
-      <InvestmentCapacityCard livingMargin={data.livingMargin} />
+      {/* スワイプビュー（#576 / Web SP と同構成・SSOT: HOME_CAROUSEL_SLIDES） */}
+      <DashboardCarousel slides={buildCarouselSlides(data, today)} />
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>最近の記録</Text>
@@ -147,6 +175,9 @@ const styles = StyleSheet.create({
     color: colors.surface,
   },
   dashboard: {
+    gap: 12,
+  },
+  slideStack: {
     gap: 12,
   },
   card: {

--- a/apps/mobile/src/components/dashboard/DashboardCarousel.tsx
+++ b/apps/mobile/src/components/dashboard/DashboardCarousel.tsx
@@ -1,0 +1,101 @@
+import { useRef, useState } from 'react';
+import {
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { colors } from '@/theme/tokens';
+
+/** ホーム画面の左右パディング（(tabs)/index.tsx の container と一致させる） */
+const SCREEN_PADDING = 20;
+
+export type CarouselSlide = {
+  key: string;
+  /** ドットの accessibilityLabel に使う名称（common HOME_CAROUSEL_SLIDES 由来） */
+  label: string;
+  node: React.ReactNode;
+};
+
+/**
+ * SP ホームのスワイプビュー（#576 / Web DashboardCarousel と同構成）。
+ * 依存追加なしの ScrollView paging で実装し、ドットで現在位置と直接移動を提供する。
+ */
+export function DashboardCarousel({ slides }: { slides: CarouselSlide[] }) {
+  const { width } = useWindowDimensions();
+  const slideWidth = width - SCREEN_PADDING * 2;
+  const [index, setIndex] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+
+  if (slides.length === 0) return null;
+
+  const handleMomentumEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const next = Math.round(event.nativeEvent.contentOffset.x / slideWidth);
+    setIndex(Math.min(Math.max(next, 0), slides.length - 1));
+  };
+
+  const goTo = (next: number) => {
+    scrollRef.current?.scrollTo({ x: next * slideWidth, animated: true });
+    setIndex(next);
+  };
+
+  return (
+    <View testID="dashboard-carousel">
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={handleMomentumEnd}
+        // paging の 1 ページ幅 = スライド幅（コンテナがパディング済みのため width 指定で揃う）
+        style={{ width: slideWidth }}
+      >
+        {slides.map((slide) => (
+          <View key={slide.key} style={{ width: slideWidth }}>
+            {slide.node}
+          </View>
+        ))}
+      </ScrollView>
+
+      {/* ドットインジケーター（タップで直接移動） */}
+      <View style={styles.dotsRow}>
+        {slides.map((slide, i) => (
+          <Pressable
+            key={slide.key}
+            onPress={() => goTo(i)}
+            accessibilityRole="button"
+            accessibilityLabel={slide.label}
+            accessibilityState={{ selected: i === index }}
+            hitSlop={8}
+          >
+            <View
+              style={[
+                styles.dot,
+                i === index && { width: 20, backgroundColor: colors.brandPrimary },
+              ]}
+            />
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dotsRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingTop: 10,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 9999,
+    backgroundColor: 'rgba(28,20,16,0.18)',
+  },
+});

--- a/apps/mobile/src/components/dashboard/SavingsForecastCard.tsx
+++ b/apps/mobile/src/components/dashboard/SavingsForecastCard.tsx
@@ -1,0 +1,238 @@
+import {
+  calcSavingsForecast,
+  formatYen,
+  savingsForecastBadgeLabel,
+} from '@budget/common';
+import { StyleSheet, Text, View } from 'react-native';
+import { colors, savingsForecastUi } from '@/theme/tokens';
+
+type Props = {
+  monthSummary: { expense: number; income: number };
+  todayExpense: number;
+  /** 月間貯蓄目標（円）。未設定は 0 */
+  savingsGoal: number;
+  /** 基準日。テストで決定論的にレンダリングするための注入口（既定: 現在日時） */
+  today?: Date;
+};
+
+/**
+ * 今月の貯蓄予測カード（Web SavingsForecastCard と同一ロジック・同一文言 #575）
+ * 計算は common の calcSavingsForecast、バッジ文言は savingsForecastBadgeLabel が SSOT。
+ */
+export function SavingsForecastCard({ monthSummary, todayExpense, savingsGoal, today }: Props) {
+  const now = today ?? new Date();
+  const dayOfMonth = now.getDate();
+  const daysInMonth = new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
+
+  const forecast = calcSavingsForecast({
+    monthIncome: monthSummary.income,
+    monthExpense: monthSummary.expense,
+    todayExpense,
+    savingsGoal,
+    dayOfMonth,
+    daysInMonth,
+  });
+  const ui = savingsForecastUi[forecast.state];
+  const label = savingsForecastBadgeLabel(forecast, savingsGoal);
+
+  const income = Math.max(1, monthSummary.income);
+  const actualPct = Math.min(99, (monthSummary.expense / income) * 100);
+  const projectedPct = Math.min(
+    100 - actualPct,
+    Math.max(0, (forecast.projectedMonthEndExpense / income) * 100 - actualPct)
+  );
+  const targetLinePct = Math.min(99, ((income - savingsGoal) / income) * 100);
+
+  const stats = [
+    {
+      label: '残り予算',
+      value: formatYen(forecast.remainingBudget),
+      color: forecast.remainingBudget >= 0 ? colors.foreground : savingsForecastUi.danger.color,
+    },
+    { label: '残り日数', value: `あと${forecast.remainingDays}日`, color: colors.foreground },
+    {
+      label: '1日の目安',
+      value: formatYen(Math.max(0, forecast.dailyRemainingBudget)),
+      color:
+        forecast.dailyRemainingBudget >= 0 ? colors.foreground : savingsForecastUi.danger.color,
+    },
+  ];
+
+  return (
+    <View style={styles.card} testID="savings-forecast-card">
+      <View style={styles.headerRow}>
+        <Text style={styles.title}>今月の貯蓄予測</Text>
+        <View style={[styles.badge, { backgroundColor: ui.badgeBg }]}>
+          <Text style={[styles.badgeLabel, { color: ui.color }]}>{label}</Text>
+        </View>
+      </View>
+
+      <Text style={styles.subLabel}>月末予測残高</Text>
+      <View style={styles.heroRow}>
+        <Text
+          style={[
+            styles.heroValue,
+            {
+              color:
+                forecast.projectedSavings >= 0 ? colors.income : savingsForecastUi.danger.color,
+            },
+          ]}
+        >
+          {forecast.projectedSavings >= 0 ? '+' : '−'}
+          {formatYen(Math.abs(forecast.projectedSavings))}
+        </Text>
+        <Text style={styles.heroNote}>
+          {forecast.projectedSavings >= 0 ? '貯まる見込み' : '不足見込み'}
+        </Text>
+      </View>
+
+      <View style={styles.barLabelRow}>
+        <Text style={styles.barLabel}>{formatYen(monthSummary.expense)} 使用</Text>
+        <Text style={styles.barLabel}>目標貯蓄 {formatYen(savingsGoal)}</Text>
+      </View>
+      <View style={styles.barTrack}>
+        <View style={[styles.barActual, { width: `${actualPct}%`, backgroundColor: ui.bar }]} />
+        <View
+          style={[
+            styles.barProjected,
+            { left: `${actualPct}%`, width: `${projectedPct}%`, backgroundColor: ui.barLight },
+          ]}
+        />
+        {savingsGoal > 0 && <View style={[styles.targetLine, { left: `${targetLinePct}%` }]} />}
+      </View>
+      <Text style={styles.elapsed}>
+        {dayOfMonth}日経過 / {daysInMonth}日
+      </Text>
+
+      <View style={styles.statsRow}>
+        {stats.map((stat) => (
+          <View key={stat.label} style={styles.statItem}>
+            <Text style={styles.statLabel}>{stat.label}</Text>
+            <Text style={[styles.statValue, { color: stat.color }]}>{stat.value}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 16,
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.borderDefault,
+    padding: 16,
+  },
+  headerRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    marginBottom: 12,
+    gap: 8,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: colors.foreground,
+  },
+  badge: {
+    borderRadius: 9999,
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    flexShrink: 1,
+  },
+  badgeLabel: {
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  subLabel: {
+    fontSize: 10,
+    fontWeight: '600',
+    color: colors.foreground,
+    opacity: 0.42,
+    marginBottom: 2,
+  },
+  heroRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    gap: 6,
+    marginBottom: 12,
+  },
+  heroValue: {
+    fontSize: 28,
+    fontWeight: '800',
+    letterSpacing: -0.5,
+    fontVariant: ['tabular-nums'],
+  },
+  heroNote: {
+    fontSize: 11,
+    fontWeight: '600',
+    color: colors.foreground,
+    opacity: 0.42,
+    marginBottom: 4,
+  },
+  barLabelRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: 4,
+  },
+  barLabel: {
+    fontSize: 10,
+    color: colors.foreground,
+    opacity: 0.42,
+  },
+  barTrack: {
+    height: 8,
+    borderRadius: 9999,
+    backgroundColor: 'rgba(28,20,16,0.06)',
+    overflow: 'hidden',
+  },
+  barActual: {
+    position: 'absolute',
+    height: '100%',
+    borderTopLeftRadius: 9999,
+    borderBottomLeftRadius: 9999,
+  },
+  barProjected: {
+    position: 'absolute',
+    height: '100%',
+  },
+  targetLine: {
+    position: 'absolute',
+    top: 0,
+    height: '100%',
+    width: 2,
+    backgroundColor: 'rgba(28,20,16,0.28)',
+  },
+  elapsed: {
+    marginTop: 4,
+    textAlign: 'right',
+    fontSize: 10,
+    color: colors.foreground,
+    opacity: 0.42,
+  },
+  statsRow: {
+    flexDirection: 'row',
+    marginTop: 12,
+    paddingTop: 12,
+    borderTopWidth: 1,
+    borderTopColor: colors.borderDefault,
+  },
+  statItem: {
+    flex: 1,
+    alignItems: 'center',
+    gap: 2,
+  },
+  statLabel: {
+    fontSize: 9,
+    fontWeight: '600',
+    color: colors.foreground,
+    opacity: 0.42,
+  },
+  statValue: {
+    fontSize: 12,
+    fontWeight: '800',
+    fontVariant: ['tabular-nums'],
+  },
+});

--- a/apps/mobile/src/theme/tokens.ts
+++ b/apps/mobile/src/theme/tokens.ts
@@ -4,7 +4,7 @@
  * CssVarName の keyof 型により、Web 側で変数が消えるとここが型エラーになり乖離を検知できる。
  * RN は CSS 変数・linear-gradient を使えないため、bar はグラデーションの主色を用いる。
  */
-import type { BudgetTone, SavingsInsightKind, SpendStatus } from '@budget/common';
+import type { BudgetTone, SavingsForecastState, SavingsInsightKind, SpendStatus } from '@budget/common';
 import { cssVars, type CssVarName } from './tokens.generated';
 
 function v(name: CssVarName): string {
@@ -80,6 +80,38 @@ export const spendStatusUi: Record<
   steady: forecast.safe,
   caution: forecast.caution,
   over: forecast.danger,
+};
+
+/** 貯蓄予測カードの4状態配色（Web SavingsForecastCard の STATE_TOKENS と同マッピング。#575）
+ *  RN はグラデーション不可のため bar は主色を使う */
+export const savingsForecastUi: Record<
+  SavingsForecastState,
+  { color: string; badgeBg: string; bar: string; barLight: string }
+> = {
+  excellent: {
+    color: v('--color-forecast-excellent'),
+    badgeBg: v('--color-forecast-excellent-badge-bg'),
+    bar: v('--color-forecast-excellent'),
+    barLight: v('--color-forecast-excellent-bar-light'),
+  },
+  safe: {
+    color: v('--color-forecast-safe'),
+    badgeBg: v('--color-forecast-safe-badge-bg'),
+    bar: v('--color-forecast-safe'),
+    barLight: v('--color-forecast-safe-bar-light'),
+  },
+  caution: {
+    color: v('--color-forecast-caution'),
+    badgeBg: v('--color-forecast-caution-badge-bg'),
+    bar: v('--color-forecast-caution'),
+    barLight: v('--color-forecast-caution-bar-light'),
+  },
+  danger: {
+    color: v('--color-forecast-danger'),
+    badgeBg: v('--color-forecast-danger-badge-bg'),
+    bar: v('--color-forecast-danger'),
+    barLight: v('--color-forecast-danger-bar-light'),
+  },
 };
 
 /** インサイト種別ごとの配色（Web DailyBudgetHero の INSIGHT_UI と同マッピング） */

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
-import { calculateInvestmentCapacity, calculateLivingMargin } from "@budget/common";
+import {
+  calculateInvestmentCapacity,
+  calculateLivingMargin,
+  HOME_CAROUSEL_SLIDES,
+  type HomeCarouselSlideKey,
+} from "@budget/common";
 import { PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
 import type { DashboardResponse, CategoryItem } from "@/lib/api/types";
 import { DailyBudgetHero } from "./DailyBudgetHero";
@@ -25,55 +30,40 @@ type Props = {
 };
 
 /**
- * SP カルーセルのスライド構成（sandbox HomePrototype 準拠）。
- * ① 生活余力 + 今週の記録 ② 今月の貯蓄予測 ③ 今月のサマリー ④ 投資余力。
+ * SP カルーセルのスライド構成。順序・キー・ラベルは common の
+ * HOME_CAROUSEL_SLIDES（SSOT）に従い、モバイルアプリと機械的に一致させる（#576）。
  * 投資余力は算出不能（総資産未設定・記録不足）のときスライドごと出さない。
  */
 function buildCarouselSlides(dashboard: DashboardResponse): CarouselSlide[] {
-  const slides: CarouselSlide[] = [
-    {
-      key: "margin-streak",
-      label: "生活余力・今週の記録",
-      node: (
-        <div className="flex flex-col gap-3">
-          <LivingMarginCard livingMargin={dashboard.livingMargin} />
-          <WeeklyStreak
-            weeklyRecord={dashboard.weeklyRecord}
-            dailyBudget={dashboard.dailyBudget?.amount ?? null}
-          />
-        </div>
-      ),
-    },
-    {
-      key: "savings-forecast",
-      label: "今月の貯蓄予測",
-      node: (
-        <SavingsForecastCard
-          monthSummary={dashboard.monthSummary}
-          todayExpense={dashboard.todayExpense}
-          savingsGoal={dashboard.savingsGoal}
+  const nodes: Record<HomeCarouselSlideKey, React.ReactNode> = {
+    "margin-streak": (
+      <div className="flex flex-col gap-3">
+        <LivingMarginCard livingMargin={dashboard.livingMargin} />
+        <WeeklyStreak
+          weeklyRecord={dashboard.weeklyRecord}
+          dailyBudget={dashboard.dailyBudget?.amount ?? null}
         />
-      ),
-    },
-    {
-      key: "monthly-summary",
-      label: "今月のサマリー",
-      node: (
-        <MonthlySummaryCard
-          monthSummary={dashboard.monthSummary}
-          lastMonthExpense={dashboard.lastMonthExpense}
-        />
-      ),
-    },
-  ];
-  if (calculateInvestmentCapacity(dashboard.livingMargin).status === "ok") {
-    slides.push({
-      key: "investment-capacity",
-      label: "投資余力",
-      node: <InvestmentCapacityCard livingMargin={dashboard.livingMargin} />,
-    });
-  }
-  return slides;
+      </div>
+    ),
+    "savings-forecast": (
+      <SavingsForecastCard
+        monthSummary={dashboard.monthSummary}
+        todayExpense={dashboard.todayExpense}
+        savingsGoal={dashboard.savingsGoal}
+      />
+    ),
+    "monthly-summary": (
+      <MonthlySummaryCard
+        monthSummary={dashboard.monthSummary}
+        lastMonthExpense={dashboard.lastMonthExpense}
+      />
+    ),
+    "investment-capacity": <InvestmentCapacityCard livingMargin={dashboard.livingMargin} />,
+  };
+  const investable = calculateInvestmentCapacity(dashboard.livingMargin).status === "ok";
+  return HOME_CAROUSEL_SLIDES.filter(
+    (slide) => slide.key !== "investment-capacity" || investable,
+  ).map((slide) => ({ key: slide.key, label: slide.label, node: nodes[slide.key] }));
 }
 
 export function HomeClient({

--- a/apps/web/src/components/dashboard/SavingsForecastCard.tsx
+++ b/apps/web/src/components/dashboard/SavingsForecastCard.tsx
@@ -2,7 +2,11 @@
 
 import { motion } from "framer-motion";
 import { formatYen } from "@budget/common";
-import { calcSavingsForecast, type SavingsForecastState } from "@budget/common";
+import {
+  calcSavingsForecast,
+  savingsForecastBadgeLabel,
+  type SavingsForecastState,
+} from "@budget/common";
 import { SPRING } from "@/lib/motion";
 
 type Props = {
@@ -47,27 +51,7 @@ const STATE_TOKENS: Record<
   },
 };
 
-/** 状態バッジの文言（SavingsForecastPalettePrototype 準拠） */
-function badgeLabel(params: {
-  state: SavingsForecastState;
-  achievementRate: number | null;
-  projectedSavings: number;
-  savingsGoal: number;
-}): string {
-  const { state, achievementRate, projectedSavings, savingsGoal } = params;
-  if (savingsGoal <= 0) return "目標未設定";
-  if (projectedSavings < 0) return "赤字見込み";
-  switch (state) {
-    case "excellent":
-      return `目標 +${Math.round(((achievementRate ?? 0) - 1) * 100)}% 達成見込み！`;
-    case "safe":
-      return "達成見込み ✓";
-    case "caution":
-      return `目標まであと${formatYen(savingsGoal - projectedSavings)}`;
-    default:
-      return "達成困難";
-  }
-}
+// バッジ文言は @budget/common の savingsForecastBadgeLabel に共通化（モバイルとのパリティ #575）
 
 /**
  * 今月の貯蓄予測カード（サンドボックス HomePrototype Block 3 準拠 / #458）
@@ -93,12 +77,7 @@ export function SavingsForecastCard({
     daysInMonth,
   });
   const tokens = STATE_TOKENS[forecast.state];
-  const label = badgeLabel({
-    state: forecast.state,
-    achievementRate: forecast.achievementRate,
-    projectedSavings: forecast.projectedSavings,
-    savingsGoal,
-  });
+  const label = savingsForecastBadgeLabel(forecast, savingsGoal);
 
   const stats = [
     {

--- a/packages/common/src/__tests__/constants/appDefinitions.test.ts
+++ b/packages/common/src/__tests__/constants/appDefinitions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { HOME_CAROUSEL_SLIDES } from '../../constants/appDefinitions'
+
+describe('HOME_CAROUSEL_SLIDES', () => {
+    it('キーは一意で、投資余力は末尾（条件付き表示スライド）にある', () => {
+        const keys = HOME_CAROUSEL_SLIDES.map((s) => s.key)
+        expect(new Set(keys).size).toBe(keys.length)
+        expect(keys[keys.length - 1]).toBe('investment-capacity')
+    })
+
+    it('Web/モバイルが参照する 4 スライド構成である', () => {
+        expect(HOME_CAROUSEL_SLIDES.map((s) => s.key)).toEqual([
+            'margin-streak',
+            'savings-forecast',
+            'monthly-summary',
+            'investment-capacity',
+        ])
+    })
+})

--- a/packages/common/src/__tests__/utils/savingsForecast.test.ts
+++ b/packages/common/src/__tests__/utils/savingsForecast.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { calcSavingsForecast } from '../../utils/savingsForecast'
+import { calcSavingsForecast, savingsForecastBadgeLabel } from '../../utils/savingsForecast'
 
 /**
  * サンドボックス HomePrototype Block 3 のモック値に基づく検証。
@@ -98,5 +98,27 @@ describe('calcSavingsForecast', () => {
             todayExpense: 0,
         })
         expect(r.actualExpensePct).toBe(99)
+    })
+})
+
+describe('savingsForecastBadgeLabel', () => {
+    const base = { state: 'safe' as const, achievementRate: 1.2, projectedSavings: 36000 }
+
+    it('目標未設定・赤字見込みを最優先で表示する', () => {
+        expect(savingsForecastBadgeLabel(base, 0)).toBe('目標未設定')
+        expect(savingsForecastBadgeLabel({ ...base, projectedSavings: -5000 }, 30000)).toBe('赤字見込み')
+    })
+
+    it('4状態の文言を返す（Web SavingsForecastCard と同一）', () => {
+        expect(
+            savingsForecastBadgeLabel({ state: 'excellent', achievementRate: 2.49, projectedSavings: 74700 }, 30000)
+        ).toBe('目標 +149% 達成見込み！')
+        expect(savingsForecastBadgeLabel(base, 30000)).toBe('達成見込み ✓')
+        expect(
+            savingsForecastBadgeLabel({ state: 'caution', achievementRate: 0.7, projectedSavings: 21000 }, 30000)
+        ).toBe('目標まであと¥9,000')
+        expect(
+            savingsForecastBadgeLabel({ state: 'danger', achievementRate: 0.2, projectedSavings: 6000 }, 30000)
+        ).toBe('達成困難')
     })
 })

--- a/packages/common/src/constants/appDefinitions.ts
+++ b/packages/common/src/constants/appDefinitions.ts
@@ -33,3 +33,16 @@ export type PeriodValue = keyof typeof PERIOD_LABELS;
 /** レポート画面で選択できる期間（表示順） */
 export const REPORT_PERIODS = ['week', 'month', 'lastMonth'] as const;
 export type ReportPeriodValue = (typeof REPORT_PERIODS)[number];
+
+/**
+ * SP ホームのスワイプビュー構成（#576）。
+ * Web（SP）とモバイルアプリの両方がこの定義を参照して描画し、構成のズレを防ぐ。
+ * investment-capacity スライドは投資余力が算出不能のとき両プラットフォームとも非表示にする。
+ */
+export const HOME_CAROUSEL_SLIDES = [
+    { key: 'margin-streak', label: '生活余力・今週の記録' },
+    { key: 'savings-forecast', label: '今月の貯蓄予測' },
+    { key: 'monthly-summary', label: '今月のサマリー' },
+    { key: 'investment-capacity', label: '投資余力' },
+] as const;
+export type HomeCarouselSlideKey = (typeof HOME_CAROUSEL_SLIDES)[number]['key'];

--- a/packages/common/src/utils/savingsForecast.ts
+++ b/packages/common/src/utils/savingsForecast.ts
@@ -1,3 +1,4 @@
+import { formatYen } from './format';
 /**
  * 今月の貯蓄予測（spec: サンドボックス HomePrototype Block 3 / #458）
  *
@@ -103,4 +104,26 @@ export function calcSavingsForecast(inputs: SavingsForecastInputs): SavingsForec
         projectedExpensePct: toPct(projectedMonthEndExpense, monthIncome),
         targetLinePct: hasGoal ? toPct(monthIncome - savingsGoal, monthIncome) : null,
     };
+}
+
+/**
+ * 状態バッジの文言（Web / モバイル共通 SSOT）。
+ * 事実のみのトーン（煽らない・断定しない）を保つ。
+ */
+export function savingsForecastBadgeLabel(
+    forecast: Pick<SavingsForecastResult, 'state' | 'achievementRate' | 'projectedSavings'>,
+    savingsGoal: number
+): string {
+    if (savingsGoal <= 0) return '目標未設定';
+    if (forecast.projectedSavings < 0) return '赤字見込み';
+    switch (forecast.state) {
+        case 'excellent':
+            return `目標 +${Math.round(((forecast.achievementRate ?? 0) - 1) * 100)}% 達成見込み！`;
+        case 'safe':
+            return '達成見込み ✓';
+        case 'caution':
+            return `目標まであと${formatYen(savingsGoal - forecast.projectedSavings)}`;
+        default:
+            return '達成困難';
+    }
 }


### PR DESCRIPTION
## 概要

モバイルアプリのホームを Web SP（Sprint #46）と同じ「ヒーロー → スワイプビュー → 最近の記録」構成へ統一する（Sprint #49・ユーザー指示）。#577（貯蓄予測カード）の上に積んだ PR（#577 マージ後に update-branch で差分が確定します）。

## 変更内容

- **common**: スライド構成 `HOME_CAROUSEL_SLIDES`（①生活余力+今週の記録 ②今月の貯蓄予測 ③今月のサマリー ④投資余力）を appDefinitions に SSOT 化 + 構成テスト 2 件
- **mobile**: `DashboardCarousel` を RN 標準（ScrollView paging・依存追加なし）で実装。ドットはタップ移動・accessibilityState 対応。ホームは TodayStatusCard（ヒーロー）→ スワイプビュー → 最近の記録
- **web**: HomeClient のスライド定義を SSOT 参照へリファクタ（表示不変・両プラットフォームが同一定義を .map するためパリティは構造的に保証）
- 投資余力は算出不能時にスライドごと非表示（ドット数連動・Web と同一ルール）

## 規約・設計チェック

- [x] ユビキタス言語遵守 / [x] 境界依存なし / [x] ulid 該当なし / [x] マジックナンバー定数化（画面パディングを定数化） / [x] スクリーンショット（Web SP 承認済み構成の移植。実機は Expo Go で確認予定） / [x] SSOT マップ該当なし

## Test plan

- common: HOME_CAROUSEL_SLIDES 構成テスト 2 件 → 全 178 件パス
- web: 全 157 件パス（カルーセルテスト含む）・mobile: jest 14 件・全体 type-check パス

## 関連 Issue

- Closes #576
- Sprint: 49