### PR TITLE
feat(mobile,common,web): モバイルホームをスワイプビュー + 最近の記録に再構成する

### DIFF
--- a/apps/mobile/src/app/(tabs)/index.tsx
+++ b/apps/mobile/src/app/(tabs)/index.tsx
@@ -8,9 +8,15 @@ import {
   View,
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import {
+  calculateInvestmentCapacity,
+  HOME_CAROUSEL_SLIDES,
+  type HomeCarouselSlideKey,
+} from '@budget/common';
 import { useDashboard, type DashboardData } from '@/lib/api/use-dashboard';
 import { AppHeader } from '@/components/layout/AppHeader';
 import { InvestmentCapacityCard } from '@/components/dashboard/InvestmentCapacityCard';
+import { DashboardCarousel, type CarouselSlide } from '@/components/dashboard/DashboardCarousel';
 import { LivingMarginCard } from '@/components/dashboard/LivingMarginCard';
 import { MonthlySummaryCard } from '@/components/dashboard/MonthlySummaryCard';
 import { SavingsForecastCard } from '@/components/dashboard/SavingsForecastCard';
@@ -52,6 +58,46 @@ export default function HomeScreen() {
   );
 }
 
+/**
+ * スワイプビューのスライド構成（#576）。
+ * 順序・キー・ラベルは common の HOME_CAROUSEL_SLIDES（SSOT）に従い、Web SP と一致させる。
+ * 投資余力は算出不能のときスライドごと出さない（Web と同一ルール）。
+ */
+function buildCarouselSlides(data: DashboardData, today?: Date): CarouselSlide[] {
+  const nodes: Record<HomeCarouselSlideKey, React.ReactNode> = {
+    'margin-streak': (
+      <View style={styles.slideStack}>
+        <LivingMarginCard livingMargin={data.livingMargin} />
+        <WeeklyStreak
+          weeklyRecord={data.weeklyRecord}
+          dailyBudget={data.dailyBudget?.amount ?? null}
+          streak={data.streak}
+        />
+      </View>
+    ),
+    'savings-forecast': (
+      <SavingsForecastCard
+        monthSummary={data.monthSummary}
+        todayExpense={data.todayExpense}
+        savingsGoal={data.savingsGoal}
+        today={today}
+      />
+    ),
+    'monthly-summary': (
+      <MonthlySummaryCard
+        monthSummary={data.monthSummary}
+        lastMonthExpense={data.lastMonthExpense}
+        today={today}
+      />
+    ),
+    'investment-capacity': <InvestmentCapacityCard livingMargin={data.livingMargin} />,
+  };
+  const investable = calculateInvestmentCapacity(data.livingMargin).status === 'ok';
+  return HOME_CAROUSEL_SLIDES.filter(
+    (slide) => slide.key !== 'investment-capacity' || investable
+  ).map((slide) => ({ key: slide.key, label: slide.label, node: nodes[slide.key] }));
+}
+
 /** today はテスト・VRT で決定論的にレンダリングするための注入口（Web の DailyBudgetHero と同パターン） */
 function Dashboard({ data, today }: { data: DashboardData; today?: Date }) {
   return (
@@ -63,26 +109,8 @@ function Dashboard({ data, today }: { data: DashboardData; today?: Date }) {
         savingsGoal={data.savingsGoal}
         today={today}
       />
-      <LivingMarginCard livingMargin={data.livingMargin} />
-      <WeeklyStreak
-        weeklyRecord={data.weeklyRecord}
-        dailyBudget={data.dailyBudget?.amount ?? null}
-        streak={data.streak}
-      />
-      {/* 今月の貯蓄予測（#575 / Web #458 のパリティ） */}
-      <SavingsForecastCard
-        monthSummary={data.monthSummary}
-        todayExpense={data.todayExpense}
-        savingsGoal={data.savingsGoal}
-        today={today}
-      />
-      <MonthlySummaryCard
-        monthSummary={data.monthSummary}
-        lastMonthExpense={data.lastMonthExpense}
-        today={today}
-      />
-      {/* 投資余力（#543 / #545）。Web と同じく MonthlySummary の後・算出不能時は非表示 */}
-      <InvestmentCapacityCard livingMargin={data.livingMargin} />
+      {/* スワイプビュー（#576 / Web SP と同構成・SSOT: HOME_CAROUSEL_SLIDES） */}
+      <DashboardCarousel slides={buildCarouselSlides(data, today)} />
 
       <View style={styles.card}>
         <Text style={styles.cardTitle}>最近の記録</Text>
@@ -147,6 +175,9 @@ const styles = StyleSheet.create({
     color: colors.surface,
   },
   dashboard: {
+    gap: 12,
+  },
+  slideStack: {
     gap: 12,
   },
   card: {

--- a/apps/mobile/src/components/dashboard/DashboardCarousel.tsx
+++ b/apps/mobile/src/components/dashboard/DashboardCarousel.tsx
@@ -1,0 +1,101 @@
+import { useRef, useState } from 'react';
+import {
+  type NativeScrollEvent,
+  type NativeSyntheticEvent,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import { colors } from '@/theme/tokens';
+
+/** ホーム画面の左右パディング（(tabs)/index.tsx の container と一致させる） */
+const SCREEN_PADDING = 20;
+
+export type CarouselSlide = {
+  key: string;
+  /** ドットの accessibilityLabel に使う名称（common HOME_CAROUSEL_SLIDES 由来） */
+  label: string;
+  node: React.ReactNode;
+};
+
+/**
+ * SP ホームのスワイプビュー（#576 / Web DashboardCarousel と同構成）。
+ * 依存追加なしの ScrollView paging で実装し、ドットで現在位置と直接移動を提供する。
+ */
+export function DashboardCarousel({ slides }: { slides: CarouselSlide[] }) {
+  const { width } = useWindowDimensions();
+  const slideWidth = width - SCREEN_PADDING * 2;
+  const [index, setIndex] = useState(0);
+  const scrollRef = useRef<ScrollView>(null);
+
+  if (slides.length === 0) return null;
+
+  const handleMomentumEnd = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+    const next = Math.round(event.nativeEvent.contentOffset.x / slideWidth);
+    setIndex(Math.min(Math.max(next, 0), slides.length - 1));
+  };
+
+  const goTo = (next: number) => {
+    scrollRef.current?.scrollTo({ x: next * slideWidth, animated: true });
+    setIndex(next);
+  };
+
+  return (
+    <View testID="dashboard-carousel">
+      <ScrollView
+        ref={scrollRef}
+        horizontal
+        pagingEnabled
+        showsHorizontalScrollIndicator={false}
+        onMomentumScrollEnd={handleMomentumEnd}
+        // paging の 1 ページ幅 = スライド幅（コンテナがパディング済みのため width 指定で揃う）
+        style={{ width: slideWidth }}
+      >
+        {slides.map((slide) => (
+          <View key={slide.key} style={{ width: slideWidth }}>
+            {slide.node}
+          </View>
+        ))}
+      </ScrollView>
+
+      {/* ドットインジケーター（タップで直接移動） */}
+      <View style={styles.dotsRow}>
+        {slides.map((slide, i) => (
+          <Pressable
+            key={slide.key}
+            onPress={() => goTo(i)}
+            accessibilityRole="button"
+            accessibilityLabel={slide.label}
+            accessibilityState={{ selected: i === index }}
+            hitSlop={8}
+          >
+            <View
+              style={[
+                styles.dot,
+                i === index && { width: 20, backgroundColor: colors.brandPrimary },
+              ]}
+            />
+          </Pressable>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  dotsRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingTop: 10,
+  },
+  dot: {
+    width: 6,
+    height: 6,
+    borderRadius: 9999,
+    backgroundColor: 'rgba(28,20,16,0.18)',
+  },
+});

--- a/apps/web/src/components/dashboard/HomeClient.tsx
+++ b/apps/web/src/components/dashboard/HomeClient.tsx
@@ -2,7 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
-import { calculateInvestmentCapacity, calculateLivingMargin } from "@budget/common";
+import {
+  calculateInvestmentCapacity,
+  calculateLivingMargin,
+  HOME_CAROUSEL_SLIDES,
+  type HomeCarouselSlideKey,
+} from "@budget/common";
 import { PAGE_VARIANTS, PAGE_ITEM_VARIANTS } from "@/lib/motion";
 import type { DashboardResponse, CategoryItem } from "@/lib/api/types";
 import { DailyBudgetHero } from "./DailyBudgetHero";
@@ -25,55 +30,40 @@ type Props = {
 };
 
 /**
- * SP カルーセルのスライド構成（sandbox HomePrototype 準拠）。
- * ① 生活余力 + 今週の記録 ② 今月の貯蓄予測 ③ 今月のサマリー ④ 投資余力。
+ * SP カルーセルのスライド構成。順序・キー・ラベルは common の
+ * HOME_CAROUSEL_SLIDES（SSOT）に従い、モバイルアプリと機械的に一致させる（#576）。
  * 投資余力は算出不能（総資産未設定・記録不足）のときスライドごと出さない。
  */
 function buildCarouselSlides(dashboard: DashboardResponse): CarouselSlide[] {
-  const slides: CarouselSlide[] = [
-    {
-      key: "margin-streak",
-      label: "生活余力・今週の記録",
-      node: (
-        <div className="flex flex-col gap-3">
-          <LivingMarginCard livingMargin={dashboard.livingMargin} />
-          <WeeklyStreak
-            weeklyRecord={dashboard.weeklyRecord}
-            dailyBudget={dashboard.dailyBudget?.amount ?? null}
-          />
-        </div>
-      ),
-    },
-    {
-      key: "savings-forecast",
-      label: "今月の貯蓄予測",
-      node: (
-        <SavingsForecastCard
-          monthSummary={dashboard.monthSummary}
-          todayExpense={dashboard.todayExpense}
-          savingsGoal={dashboard.savingsGoal}
+  const nodes: Record<HomeCarouselSlideKey, React.ReactNode> = {
+    "margin-streak": (
+      <div className="flex flex-col gap-3">
+        <LivingMarginCard livingMargin={dashboard.livingMargin} />
+        <WeeklyStreak
+          weeklyRecord={dashboard.weeklyRecord}
+          dailyBudget={dashboard.dailyBudget?.amount ?? null}
         />
-      ),
-    },
-    {
-      key: "monthly-summary",
-      label: "今月のサマリー",
-      node: (
-        <MonthlySummaryCard
-          monthSummary={dashboard.monthSummary}
-          lastMonthExpense={dashboard.lastMonthExpense}
-        />
-      ),
-    },
-  ];
-  if (calculateInvestmentCapacity(dashboard.livingMargin).status === "ok") {
-    slides.push({
-      key: "investment-capacity",
-      label: "投資余力",
-      node: <InvestmentCapacityCard livingMargin={dashboard.livingMargin} />,
-    });
-  }
-  return slides;
+      </div>
+    ),
+    "savings-forecast": (
+      <SavingsForecastCard
+        monthSummary={dashboard.monthSummary}
+        todayExpense={dashboard.todayExpense}
+        savingsGoal={dashboard.savingsGoal}
+      />
+    ),
+    "monthly-summary": (
+      <MonthlySummaryCard
+        monthSummary={dashboard.monthSummary}
+        lastMonthExpense={dashboard.lastMonthExpense}
+      />
+    ),
+    "investment-capacity": <InvestmentCapacityCard livingMargin={dashboard.livingMargin} />,
+  };
+  const investable = calculateInvestmentCapacity(dashboard.livingMargin).status === "ok";
+  return HOME_CAROUSEL_SLIDES.filter(
+    (slide) => slide.key !== "investment-capacity" || investable,
+  ).map((slide) => ({ key: slide.key, label: slide.label, node: nodes[slide.key] }));
 }
 
 export function HomeClient({

--- a/packages/common/src/__tests__/constants/appDefinitions.test.ts
+++ b/packages/common/src/__tests__/constants/appDefinitions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { HOME_CAROUSEL_SLIDES } from '../../constants/appDefinitions'
+
+describe('HOME_CAROUSEL_SLIDES', () => {
+    it('キーは一意で、投資余力は末尾（条件付き表示スライド）にある', () => {
+        const keys = HOME_CAROUSEL_SLIDES.map((s) => s.key)
+        expect(new Set(keys).size).toBe(keys.length)
+        expect(keys[keys.length - 1]).toBe('investment-capacity')
+    })
+
+    it('Web/モバイルが参照する 4 スライド構成である', () => {
+        expect(HOME_CAROUSEL_SLIDES.map((s) => s.key)).toEqual([
+            'margin-streak',
+            'savings-forecast',
+            'monthly-summary',
+            'investment-capacity',
+        ])
+    })
+})

--- a/packages/common/src/constants/appDefinitions.ts
+++ b/packages/common/src/constants/appDefinitions.ts
@@ -33,3 +33,16 @@ export type PeriodValue = keyof typeof PERIOD_LABELS;
 /** レポート画面で選択できる期間（表示順） */
 export const REPORT_PERIODS = ['week', 'month', 'lastMonth'] as const;
 export type ReportPeriodValue = (typeof REPORT_PERIODS)[number];
+
+/**
+ * SP ホームのスワイプビュー構成（#576）。
+ * Web（SP）とモバイルアプリの両方がこの定義を参照して描画し、構成のズレを防ぐ。
+ * investment-capacity スライドは投資余力が算出不能のとき両プラットフォームとも非表示にする。
+ */
+export const HOME_CAROUSEL_SLIDES = [
+    { key: 'margin-streak', label: '生活余力・今週の記録' },
+    { key: 'savings-forecast', label: '今月の貯蓄予測' },
+    { key: 'monthly-summary', label: '今月のサマリー' },
+    { key: 'investment-capacity', label: '投資余力' },
+] as const;
+export type HomeCarouselSlideKey = (typeof HOME_CAROUSEL_SLIDES)[number]['key'];


### PR DESCRIPTION
## 概要

#578 の置き換え（スタック元 #577 の squash マージ起因のコンフリクトにより、main 起点で cherry-pick し直したもの。**内容は #578 でレビュー済みのカルーセル実装コミットと同一**）。

## 変更内容

- common: スライド構成 `HOME_CAROUSEL_SLIDES` の SSOT 化 + 構成テスト 2 件
- mobile: `DashboardCarousel`（RN 標準 ScrollView paging・依存追加なし）とホーム再構成（TodayStatus → スワイプビュー → 最近の記録）
- web: HomeClient のスライド定義を SSOT 参照へリファクタ（表示不変）
- 投資余力は算出不能時にスライドごと非表示（Web と同一ルール）

## Test plan

- common 178 / web 157 / mobile 14 全件パス・全体 type-check パス（cherry-pick 後に再検証済み）

## 規約・設計チェック

- [x] ユビキタス言語 / [x] 境界依存なし / [x] ulid 該当なし / [x] マジックナンバー定数化 / [x] スクリーンショット（Web SP 承認済み構成の移植） / [x] SSOT マップ該当なし

## 関連 Issue

- Closes #576
- Sprint: 49