### PR TITLE
chore(web): トンネル越し実機確認のため dev アセットのクロスオリジン許可を追加する

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -4,6 +4,10 @@ const nextConfig: NextConfig = {
   // コンテナデプロイ用: standalone モードで最小ランタイムを出力
   output: "standalone",
 
+  // 開発時のみ: cloudflared 等のトンネル越し実機確認で dev アセットの
+  // クロスオリジン読み込みを許可する（本番ビルドには影響しない）
+  allowedDevOrigins: ["*.trycloudflare.com"],
+
   experimental: {
     serverActions: {
       // レシート画像（最大約7MB）を Server Action で受けるため既定の 1MB から拡大（#521）


### PR DESCRIPTION
## 概要

cloudflared 等のトンネル経由で Web dev サーバーを実機確認する際、Next.js が dev アセットのクロスオリジン読み込みをブロックして画面が真っ白になる問題への対応。

## 変更内容

- `next.config.ts` の `allowedDevOrigins` に `*.trycloudflare.com` を追加（1行 + コメント）

## 影響範囲

開発サーバーのみ（`allowedDevOrigins` は next dev にのみ作用）。本番ビルド・セキュリティヘッダーへの影響なし。実地（出先からのトンネル実機確認）で効果確認済み。

## 規約・設計チェック

- [x] ユビキタス言語 / [x] 境界依存なし / [x] ulid 該当なし / [x] マジックナンバー該当なし / [x] スクリーンショット（UI 変更なし） / [x] SSOT マップ該当なし

## Test plan

- トンネル経由で `/_next/static/*` の取得が 200 になることを実地確認済み（変更前はブロック警告 + 真っ白）

## 関連 Issue

- Closes #581
- Sprint: 49